### PR TITLE
Api: キャラクターのアニメーション追加

### DIFF
--- a/Camera.cpp
+++ b/Camera.cpp
@@ -3,17 +3,37 @@
 
 
 Camera::Camera() :
-	Camera(0, 0, 1.0)
+	Camera(0, 0, 1.0, 1)
 {
 
 }
 
-Camera::Camera(int x, int y, double ex) {
+Camera::Camera(int x, int y, double ex, int speed) {
 	m_x = x;
 	m_y = y;
+	m_gx = x;
+	m_gy = y;
 	m_ex = ex;
+	m_speed = 1;
+	m_maxSpeed = speed;
 	m_centerX = GAME_WIDE / 2;
 	m_centerY = GAME_HEIGHT / 2;
+}
+
+// カメラの移動 目標地点が近いほど鈍感になる
+void Camera::move() {
+	if (m_x < m_gx) {
+		m_x += (m_gx - m_x) / 2 + 1;
+	}
+	if (m_x > m_gx) {
+		m_x -= (m_x - m_gx) / 2 + 1;
+	}
+	if (m_y < m_gy) {
+		m_y += (m_gy - m_y) / 2 + 1;
+	}
+	if (m_y > m_gy) {
+		m_y -= (m_y - m_gy) / 2 + 1;
+	}
 }
 
 // カメラで座標と拡大率を調整する

--- a/Camera.h
+++ b/Camera.h
@@ -7,6 +7,13 @@ private:
 	// カメラの座標(画面の中心)
 	int m_x, m_y;
 
+	// 今カメラが向かっている座標
+	int m_gx, m_gy;
+
+	// カメラが動くスピード
+	int m_speed;
+	int m_maxSpeed;
+
 	// カメラの倍率
 	double m_ex;
 
@@ -15,17 +22,24 @@ private:
 
 public:
 	Camera();
-	Camera(int x, int y, double ex);
+	Camera(int x, int y, double ex, int speed);
 
 	// ゲッタとセッタ
 	inline void getPoint(int* x, int* y) { *x = m_x; *y = m_y; }
 	inline int getX() { return m_x; }
 	inline int getY() { return m_y; }
 	inline void setPoint(int x, int y) { m_x = x; m_y = y; }
+	inline void setGPoint(int x, int y) { m_gx = x; m_gy = y; }
 	inline void setX(int x) { m_x = x; }
 	inline void setY(int y) { m_y = y; }
+	inline void setGx(int x) { m_gx = x; }
+	inline void setGy(int y) { m_gy = y; }
+	inline void setSpeed(int speed) { m_speed = speed; }
 	inline double getEx() { return m_ex; }
 	inline void setEx(double ex) { m_ex = ex; }
+
+	// カメラの動き
+	void move();
 
 	// カメラの座標を考慮した描画位置の補正
 	void setCamera(int* x, int* y, double* ex) const;

--- a/Character.cpp
+++ b/Character.cpp
@@ -114,6 +114,12 @@ void Character::setHandle(GraphHandle* handle) {
 	m_height = (int)(m_height * m_characterInfo->handleEx());
 }
 
+void Character::getHandleSize(int& wide, int& height) {
+	// 今セットしている画像の縦幅と横幅を取得する。
+	wide = m_wide;
+	height = m_height;
+}
+
 void Character::setLeftDirection(bool leftDirection) { 
 	m_leftDirection = leftDirection;
 	m_graphHandle->setReverseX(m_leftDirection);

--- a/Character.cpp
+++ b/Character.cpp
@@ -198,7 +198,7 @@ void Heart::switchRun(int cnt) {
 // ジャンプ前画像をセット
 void Heart::switchPreJump(int cnt) { 
 	int index = (cnt / RUN_PREJUMP_SPEED) % (m_preJumpHandles->getSize());
-	setHandle(m_preJumpHandles->getGraphHandle(cnt));
+	setHandle(m_preJumpHandles->getGraphHandle(index));
 }
 
 // 射撃攻撃をする(キャラごとに違う)

--- a/Character.cpp
+++ b/Character.cpp
@@ -147,8 +147,19 @@ Heart::Heart(int maxHp, int hp, int x, int y) :
 	// 各画像のロード
 	double ex = m_characterInfo->handleEx();
 	m_standHandle = new GraphHandle("picture/stick/stand.png", ex);
-
 	m_slashHandles = new GraphHandles("picture/stick/zangeki", 3, ex);
+	m_squatHandle = new GraphHandle("picture/stick/squat.png", ex);
+	m_standBulletHandle = new GraphHandle("picture/stick/bullet.png", ex);
+	m_standSlashHandle = new GraphHandle("picture/stick/slash.png", ex);
+	m_runHandles = new GraphHandles("picture/stick/run", 6, ex);
+	m_landHandle = new GraphHandle("picture/stick/land.png", ex);
+	m_jumpHandle = new GraphHandle("picture/stick/jump.png", ex);
+	m_downHandle = new GraphHandle("picture/stick/down.png", ex);
+	m_preJumpHandles = new GraphHandles("picture/stick/preJump", 2, ex);
+	m_damageHandle = new GraphHandle("picture/stick/damage.png", ex);
+	m_boostHandle = new GraphHandle("picture/stick/boost.png", ex);
+	m_airBulletHandle = new GraphHandle("picture/stick/airBullet.png", ex);
+	m_airSlashHandle = new GraphHandle("picture/stick/airSlash.png", ex);
 
 	// とりあえず立ち画像でスタート
 	switchStand();
@@ -159,11 +170,34 @@ Heart::~Heart() {
 	// 画像を削除
 	delete m_standHandle;
 	delete m_slashHandles;
+	delete m_squatHandle;
+	delete m_standBulletHandle;
+	delete m_standSlashHandle;
+	delete m_runHandles;
+	delete m_landHandle;
+	delete m_jumpHandle;
+	delete m_downHandle;
+	delete m_preJumpHandles;
+	delete m_damageHandle;
+	delete m_boostHandle;
+	delete m_airBulletHandle;
+	delete m_airSlashHandle;
+}
+
+// 走り画像をセット
+void Heart::switchRun(int cnt) { 
+	int index = (cnt / RUN_ANIME_SPEED) % (m_runHandles->getSize());
+	setHandle(m_runHandles->getGraphHandle(index));
+}
+// ジャンプ前画像をセット
+void Heart::switchPreJump(int cnt) { 
+	int index = (cnt / RUN_PREJUMP_SPEED) % (m_preJumpHandles->getSize());
+	setHandle(m_preJumpHandles->getGraphHandle(cnt));
 }
 
 // 射撃攻撃をする(キャラごとに違う)
 Object* Heart::bulletAttack(int gx, int gy) {
-	BulletObject* attackObject = new BulletObject(m_x, m_y, WHITE, gx, gy, m_attackInfo);
+	BulletObject* attackObject = new BulletObject(m_x + m_wide / 2, m_y + m_height / 2, WHITE, gx, gy, m_attackInfo);
 	attackObject->setCharacterId(m_id);
 	return attackObject;
 }

--- a/Character.h
+++ b/Character.h
@@ -193,6 +193,7 @@ public:
 
 	// 画像のセッタ。画像の横幅(wide)と縦幅(height)もセットする。
 	void setHandle(GraphHandle* handle);
+	void getHandleSize(int& wide, int& height);
 
 	// 立ち画像をセット
 	virtual void switchStand(int cnt = 0) = 0;

--- a/Character.h
+++ b/Character.h
@@ -167,6 +167,9 @@ public:
 
 	inline void setX(int x) { m_x = x; }
 
+	inline int getCenterX() const{ return m_x + (m_wide / 2); }
+	inline int getCenterY() const { return m_y + (m_height / 2); }
+
 	inline int getY() const { return m_y; }
 
 	inline void setY(int y) { m_y = y; }

--- a/Character.h
+++ b/Character.h
@@ -263,7 +263,7 @@ private:
 	GraphHandle* m_standSlashHandle;
 
 	// 走り
-	const int RUN_ANIME_SPEED = 3;
+	const int RUN_ANIME_SPEED = 6;
 	GraphHandles* m_runHandles;
 
 	// 着地
@@ -276,7 +276,7 @@ private:
 	GraphHandle* m_downHandle;
 
 	// ジャンプ前
-	const int RUN_PREJUMP_SPEED = 3;
+	const int RUN_PREJUMP_SPEED = 6;
 	GraphHandles* m_preJumpHandles;
 
 	// ダメージ

--- a/Character.h
+++ b/Character.h
@@ -195,7 +195,32 @@ public:
 	void setHandle(GraphHandle* handle);
 
 	// 立ち画像をセット
-	virtual void switchStand() = 0;
+	virtual void switchStand(int cnt = 0) = 0;
+	// 立ち射撃画像をセット
+	virtual void switchBullet(int cnt = 0) = 0;
+	// 立ち斬撃画像をセット
+	virtual void switchSlash(int cnt = 0) = 0;
+	// しゃがみ画像をセット
+	virtual void switchSquat(int cnt = 0) = 0;
+	// 走り画像をセット
+	virtual void switchRun(int cnt = 0) = 0;
+	// 着地画像をセット
+	virtual void switchLand(int cnt = 0) = 0;
+	// 上昇画像をセット
+	virtual void switchJump(int cnt = 0) = 0;
+	// 降下画像をセット
+	virtual void switchDown(int cnt = 0) = 0;
+	// ジャンプ前画像をセット
+	virtual void switchPreJump(int cnt = 0) = 0;
+	// ダメージ画像をセット
+	virtual void switchDamage(int cnt = 0) = 0;
+	// ブースト画像をセット
+	virtual void switchBoost(int cnt = 0) = 0;
+	// 空中射撃画像をセット
+	virtual void switchAirBullet(int cnt = 0) = 0;
+	// 空中斬撃画像をセット
+	virtual void switchAirSlash(int cnt = 0) = 0;
+
 
 	// 移動する（座標を動かす）
 	void moveRight(int d);
@@ -221,11 +246,49 @@ private:
 	// キャラの名前
 	const char* const NAME = "ハート";
 
-	//立ち画像
+	// 立ち画像
 	GraphHandle* m_standHandle;
 
 	// 斬撃攻撃画像
 	GraphHandles* m_slashHandles;
+
+	// しゃがみ
+	GraphHandle* m_squatHandle;
+
+	// 立ち射撃
+	GraphHandle* m_standBulletHandle;
+
+	// 立ち斬撃
+	GraphHandle* m_standSlashHandle;
+
+	// 走り
+	const int RUN_ANIME_SPEED = 3;
+	GraphHandles* m_runHandles;
+
+	// 着地
+	GraphHandle* m_landHandle;
+
+	// 上昇
+	GraphHandle* m_jumpHandle;
+
+	// 下降
+	GraphHandle* m_downHandle;
+
+	// ジャンプ前
+	const int RUN_PREJUMP_SPEED = 3;
+	GraphHandles* m_preJumpHandles;
+
+	// ダメージ
+	GraphHandle* m_damageHandle;
+
+	// ブースト
+	GraphHandle* m_boostHandle;
+
+	// 空中射撃
+	GraphHandle* m_airBulletHandle;
+
+	// 空中斬撃
+	GraphHandle* m_airSlashHandle;
 	
 public:
 	// コンストラクタ
@@ -238,7 +301,31 @@ public:
 	void debug(int x, int y, int color);
 
 	// 立ち画像をセット
-	inline void switchStand() { setHandle(m_standHandle); }
+	inline void switchStand(int cnt = 0) { setHandle(m_standHandle); }
+	// 立ち射撃画像をセット
+	inline void switchBullet(int cnt = 0) { setHandle(m_standBulletHandle); }
+	// 立ち斬撃画像をセット
+	inline void switchSlash(int cnt = 0) { setHandle(m_standSlashHandle); }
+	// しゃがみ画像をセット
+	inline void switchSquat(int cnt = 0) { setHandle(m_squatHandle); }
+	// 走り画像をセット
+	void switchRun(int cnt = 0);
+	// 着地画像をセット
+	inline void switchLand(int cnt = 0) { setHandle(m_landHandle); }
+	// 上昇画像をセット
+	inline void switchJump(int cnt = 0) { setHandle(m_jumpHandle); }
+	// 降下画像をセット
+	inline void switchDown(int cnt = 0) { setHandle(m_downHandle); }
+	// ジャンプ前画像をセット
+	void switchPreJump(int cnt = 0);
+	// ダメージ画像をセット
+	inline void switchDamage(int cnt = 0) { setHandle(m_damageHandle); }
+	// ブースト画像をセット
+	inline void switchBoost(int cnt = 0) { setHandle(m_boostHandle); }
+	// 空中射撃画像をセット
+	inline void switchAirBullet(int cnt = 0) { setHandle(m_airBulletHandle); }
+	// 空中斬撃画像をセット
+	inline void switchAirSlash(int cnt = 0) { setHandle(m_airSlashHandle); }
 
 	// 射撃攻撃をする(キャラごとに違う)
 	Object* bulletAttack(int gx, int gy);

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -13,6 +13,9 @@ CharacterAction::CharacterAction(Character* character) {
 	//初期状態
 	m_state = CHARACTER_STATE::STAND;
 	m_grand = false;
+	m_runCnt = -1;
+	m_squat = false;
+	m_preJumpCnt = -1;
 	m_moveRight = false;
 	m_moveLeft = false;
 	m_moveUp = false;
@@ -188,11 +191,22 @@ void StickAction::move(bool right, bool left, bool up, bool down) {
 }
 
 // ジャンプ
-void StickAction::jump(int rate) {
-	if (m_grand) {// 地上にいるなら
-		int power = (m_character->getJumpHeight() * rate) / 100;
-		m_vy -= power;
-		m_grand = false;
+void StickAction::jump(int cnt) {
+	// ジャンプ前の状態なら
+	if (m_grand && m_preJumpCnt == -1) {
+		m_preJumpCnt = 0;
+	}
+	if (m_grand && m_preJumpCnt >= 0) {
+		if (cnt == 0 || m_preJumpCnt == 10) {
+			int rate = (100 * m_preJumpCnt) / 10;
+			int power = (m_character->getJumpHeight() * rate) / 100;
+			m_vy -= power;
+			m_grand = false;
+			m_preJumpCnt = -1;
+		}
+		else {
+			m_preJumpCnt++;
+		}
 	}
 }
 

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -148,6 +148,9 @@ void StickAction::action() {
 
 // 状態に応じて画像セット
 void StickAction::switchHandle() {
+	// セット前の画像のサイズ
+	int wide, height;
+	m_character->getHandleSize(wide, height);
 	if (m_grand) { // 地面にいるとき
 		switch (m_state) {
 		case CHARACTER_STATE::STAND: //立ち状態
@@ -157,10 +160,46 @@ void StickAction::switchHandle() {
 	}
 	else { // 宙にいるとき
 		switch (m_state) {
-		case CHARACTER_STATE::STAND: //立ち状態
-			m_character->switchStand();
+		case CHARACTER_STATE::STAND: //立ち状態(なにもなしの状態)
+			if (m_vy < 0) {
+				m_character->switchJump();
+			}
+			else {
+				m_character->switchDown();
+			}
 			break;
 		}
+	}
+	// セット後の画像のサイズ
+	int afterWide, afterHeight;
+	m_character->getHandleSize(afterWide, afterHeight);
+
+	// サイズ変更による位置調整
+	afterChangeGraph(wide, height, afterWide, afterHeight);
+}
+
+// 画像のサイズ変更による位置調整
+void CharacterAction::afterChangeGraph(int beforeWide, int beforeHeight, int afterWide, int afterHeight) {
+	// 下へ行けないなら
+	if (m_downLock) {
+		// 上へ動かす
+		m_character->moveUp((afterHeight - beforeHeight));
+	}
+	// 上へ行けないなら
+	if (m_upLock) {
+		// 下へ動かす
+		m_character->moveDown((afterHeight - beforeHeight));
+	}
+
+	// 右へ行けないなら
+	if (m_rightLock) {
+		// 左へ動かす
+		m_character->moveLeft((afterWide - beforeWide));
+	}
+	// 左へ行けないなら
+	if (m_leftLock) {
+		// 右へ動かす
+		m_character->moveRight((afterWide - beforeWide));
 	}
 }
 
@@ -193,7 +232,7 @@ void StickAction::move(bool right, bool left, bool up, bool down) {
 // ジャンプ
 void StickAction::jump(int cnt) {
 	// ジャンプ前の状態なら
-	if (m_grand && m_preJumpCnt == -1) {
+	if (cnt > 0 && m_grand && m_preJumpCnt == -1) {
 		m_preJumpCnt = 0;
 	}
 	if (m_grand && m_preJumpCnt >= 0) {

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -39,6 +39,9 @@ protected:
 	// ジャンプ前の動作
 	int m_preJumpCnt;
 
+	// ジャンプのため時間の最大
+	const int PRE_JUMP_MAX = 10;
+
 	// 移動中
 	bool m_moveRight;
 	bool m_moveLeft;

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -109,6 +109,10 @@ public:
 
 	// 斬撃攻撃
 	virtual Object* slashAttack() = 0;
+
+protected:
+	// 画像のサイズ変更による位置調整
+	void afterChangeGraph(int beforeWide, int beforeHeight, int afterWide, int afterHeight);
 };
 
 

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -7,12 +7,11 @@ class Object;
 
 // キャラクターの状態
 enum class CHARACTER_STATE {
-	STAND,
-	WALK,
-	JUMP_UP,
-	JUMP_DOWN,
-	ATTACK,
-	DAMAGE
+	STAND,	// 何もしていない
+	DAMAGE,	// ダメージ受け中 着地で解除
+	BULLET,	// 射撃中
+	SLASH,	// 斬撃中
+	PREJUMP	// ジャンプ前
 };
 
 
@@ -30,6 +29,15 @@ protected:
 
 	// キャラが地面にいる
 	bool m_grand;
+
+	// キャラが走っていないなら-1 そうでないなら走ったフレーム数
+	int m_runCnt;
+
+	// しゃがみ中
+	bool m_squat;
+
+	// ジャンプ前の動作
+	int m_preJumpCnt;
 
 	// 移動中
 	bool m_moveRight;
@@ -135,8 +143,8 @@ public:
 	// 移動 引数は４方向分
 	void move(bool right, bool left, bool up, bool down);
 
-	// ジャンプ rate%の力で飛び上がる。
-	void jump(int rate);
+	// ジャンプ cntフレーム目
+	void jump(int cnt);
 
 	// 射撃攻撃
 	Object* bulletAttack(int gx, int gy);

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -11,7 +11,8 @@ enum class CHARACTER_STATE {
 	DAMAGE,	// ダメージ受け中 着地で解除
 	BULLET,	// 射撃中
 	SLASH,	// 斬撃中
-	PREJUMP	// ジャンプ前
+	PREJUMP,	// ジャンプ前
+	SQUAT		// しゃがみ中
 };
 
 
@@ -41,6 +42,15 @@ protected:
 
 	// ジャンプのため時間の最大
 	const int PRE_JUMP_MAX = 10;
+
+	// 着地モーションの残り時間
+	int m_landCnt;
+
+	// 着地モーションの総時間
+	const int LAND_TIME = 10;
+
+	int m_boostCnt;
+	const int BOOST_TIME = 10;
 
 	// 移動中
 	bool m_moveRight;
@@ -76,8 +86,13 @@ public:
 	virtual void debug(int x, int y, int color) = 0;
 
 	// ゲッタとセッタ
-	inline bool getGrand() { return m_grand; }
-	inline void setGrand(bool grand) { m_grand = grand; }
+	inline bool getGrand() const { return m_grand; }
+	inline void setGrand(bool grand) { 
+		if (m_vy > 0) { // 着地モーションになる
+			m_landCnt = LAND_TIME;
+		}
+		m_grand = grand;
+	}
 	inline int getVx() const { return m_vx; }
 	inline int getVy() const { return m_vy; }
 	inline int getSlashCnt() { return m_slashCnt; }
@@ -85,7 +100,9 @@ public:
 	void setLeftLock(bool lock);
 	void setUpLock(bool lock);
 	void setDownLock(bool lock);
+	inline void setBoost() { m_boostCnt = BOOST_TIME; }
 	inline const Character* getCharacter() const { return m_character; }
+	virtual void setState(CHARACTER_STATE state) = 0;
 
 	// キャラクターのセッタ
 	void setCharacterX(int x);
@@ -140,6 +157,8 @@ public:
 	StickAction(Character* character);
 
 	void debug(int x, int y, int color);
+
+	void setState(CHARACTER_STATE state);
 
 	//行動前の処理 毎フレーム行う
 	void init();

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -68,8 +68,7 @@ void CharacterController::action() {
 * キーボード
 */
 CharacterKeyboard::CharacterKeyboard() {
-	m_nowSpaceKey = 0;
-	m_preSpaceKey = 0;
+
 }
 // 上下左右のキー
 void CharacterKeyboard::controlStick(int& right, int& left, int& up, int& down) {
@@ -80,12 +79,8 @@ void CharacterKeyboard::controlStick(int& right, int& left, int& up, int& down) 
 }
 
 // スペースキー
-void CharacterKeyboard::controlJump(int& nowSpaceKey, int& preSpaceKey) {
-	m_preSpaceKey = m_nowSpaceKey;
-	m_nowSpaceKey = controlSpace();
-
-	preSpaceKey = m_preSpaceKey;
-	nowSpaceKey = m_nowSpaceKey;
+void CharacterKeyboard::controlJump(int& spaceKey) {
+	spaceKey = controlSpace();
 }
 
 
@@ -119,14 +114,8 @@ void CharacterKeyboardController::control() {
 	m_characterAction->move(m_rightStick, m_leftStick, m_upStick, m_downStick);
 
 	// ジャンプ
-	int nowSpaceKey = 0;
-	// 1フレーム前のスペースキーを取得
-	m_keyboard.controlJump(nowSpaceKey, m_jumpKey);
-
-	// ジャンプする
-	if ((nowSpaceKey == 0 && m_jumpKey > 0 && m_jumpKey < JUMP_KEY_LONG) || m_jumpKey == JUMP_KEY_LONG) {
-		m_characterAction->jump((100 * m_jumpKey) / JUMP_KEY_LONG);
-	}
+	m_keyboard.controlJump(m_jumpKey);
+	m_characterAction->jump(m_jumpKey);
 }
 
 Object* CharacterKeyboardController::bulletAttack() {

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -43,6 +43,9 @@ void CharacterController::setActionUpLock(bool lock) {
 void CharacterController::setActionDownLock(bool lock) {
 	m_characterAction->setDownLock(lock);
 }
+void CharacterController::setActionBoost() {
+	m_characterAction->setBoost();
+}
 
 // キャラクターのセッタ
 void CharacterController::setCharacterX(int x) {
@@ -81,6 +84,11 @@ void CharacterKeyboard::controlStick(int& right, int& left, int& up, int& down) 
 // スペースキー
 void CharacterKeyboard::controlJump(int& spaceKey) {
 	spaceKey = controlSpace();
+}
+
+// Sキー
+void CharacterKeyboard::controlSquat(int& sKey) {
+	sKey = controlS();
 }
 
 

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -56,12 +56,11 @@ public:
 */
 class CharacterKeyboard {
 private:
-	int m_nowSpaceKey;
-	int m_preSpaceKey;
+
 public:
 	CharacterKeyboard();
 	void controlStick(int& right, int& left, int& up, int& down);
-	void controlJump(int& nowSpaceKey, int& preSpaceKey);
+	void controlJump(int& spaceKey);
 };
 
 /*
@@ -85,7 +84,7 @@ public:
 
 	void debug(int x, int y, int color);
 
-	// キャラの操作 毎フレーム行う
+	// キャラの移動やしゃがみ(;攻撃以外の)操作 毎フレーム行う
 	void control();
 
 	// 射撃攻撃

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -29,6 +29,7 @@ public:
 	void setActionLeftLock(bool lock);
 	void setActionUpLock(bool lock);
 	void setActionDownLock(bool lock);
+	void setActionBoost();
 
 	// キャラクターのセッタ
 	void setCharacterX(int x);
@@ -61,6 +62,7 @@ public:
 	CharacterKeyboard();
 	void controlStick(int& right, int& left, int& up, int& down);
 	void controlJump(int& spaceKey);
+	void controlSquat(int& sKey);
 };
 
 /*

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -68,7 +68,7 @@ void CharacterKeyboardController::debug(int x, int y, int color) {
 // Actionクラスのデバッグ
 void CharacterAction::debugAction(int x, int y, int color) {
 	DrawFormatString(x, y, color, "**CharacterAction**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "state=%d, grand=%d, (vx,vy)=(%d,%d)", (int)m_state, m_grand, m_vx, m_vy);
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "state=%d, grand=%d, (vx,vy)=(%d,%d), runCnt=%d", (int)m_state, m_grand, m_vx, m_vy, m_runCnt);
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "制限中：(←, →, ↑, ↓)=(%d,%d,%d,%d)", m_leftLock, m_rightLock, m_upLock, m_downLock);
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "移動中：(←, →, ↑, ↓)=(%d,%d,%d,%d)", m_moveLeft, m_moveRight, m_moveUp, m_moveDown);
 	m_character->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 4, color);

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -34,7 +34,7 @@ GraphHandles::GraphHandles(const char* filePath, int handleSum, double ex, doubl
 	m_handles = new GraphHandle* [m_handleSum];
 	for (int i = 0; i < m_handleSum; i++) {
 		ostringstream oss;
-		oss << filePath << i << ".png";
+		oss << filePath << i + 1 << ".png";
 		m_handles[i] = new GraphHandle(oss.str().c_str(), ex, angle, trans, reverseX, reverseY);
 	}
 }

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -58,6 +58,7 @@ public:
 	// ゲッタ
 	inline GraphHandle* getGraphHandle(int i) { return m_handles[i]; }
 	inline int getHandle(int i) { return m_handles[i]->getHandle(); }
+	inline int getSize() { return m_handleSum; }
 
 	// セッタ
 	void setEx(double ex);

--- a/Object.cpp
+++ b/Object.cpp
@@ -114,12 +114,25 @@ void BoxObject::atari(CharacterController* characterController) {
 
 	// 万が一オブジェクトの中に入り込んでしまったら
 	if (characterVy != 0 && characterY2 > m_y1 && characterY1 < m_y2 && characterX2 > m_x1 && characterX1 < m_x2) {
-		// 真上へ
-		characterController->setCharacterY(m_y1 - characterHeight);
-		// 着地
-		characterController->setCharacterGrand(true);
-		// キャラは下へ移動できない
-		characterController->setActionDownLock(true);
+		// キャラが横にはみ出しているなら
+		if (!(characterX1 >= m_x1 && characterX2 <= m_x2)) {
+			if ((characterX1 + characterX2) < (m_x1 + m_x2)) {
+				// 密着状態まで移動させる
+				characterController->setCharacterX(m_x1 - characterWide);
+			}
+			else {
+				// 密着状態まで移動させる
+				characterController->setCharacterX(m_x2);
+			}
+		}
+		else {
+			// 真上へ
+			characterController->setCharacterY(m_y1 - characterHeight);
+			// 着地
+			characterController->setCharacterGrand(true);
+			// キャラは下へ移動できない
+			characterController->setActionDownLock(true);
+		}
 	}
 }
 

--- a/Object.cpp
+++ b/Object.cpp
@@ -81,6 +81,7 @@ void BoxObject::atari(CharacterController* characterController) {
 				characterController->setCharacterY(m_y1 - characterHeight);
 				// 着地
 				characterController->setCharacterGrand(true);
+				characterController->setActionBoost();
 				// キャラは下へ移動できない
 				characterController->setActionDownLock(true);
 			}
@@ -100,6 +101,7 @@ void BoxObject::atari(CharacterController* characterController) {
 				characterController->setCharacterY(m_y1 - characterHeight);
 				// 着地
 				characterController->setCharacterGrand(true);
+				characterController->setActionBoost();
 				// キャラは下へ移動できない
 				characterController->setActionDownLock(true);
 			}
@@ -113,19 +115,23 @@ void BoxObject::atari(CharacterController* characterController) {
 	}
 
 	// 万が一オブジェクトの中に入り込んでしまったら
-	if (characterVy != 0 && characterY2 > m_y1 && characterY1 < m_y2 && characterX2 > m_x1 && characterX1 < m_x2) {
+	if (characterY2 > m_y1 && characterY1 < m_y2 && characterX2 > m_x1 && characterX1 < m_x2) {
 		// キャラが横にはみ出しているなら
-		if (!(characterX1 >= m_x1 && characterX2 <= m_x2)) {
+		if (characterY2 == m_y2 && !(characterX1 >= m_x1 && characterX2 <= m_x2)) {
 			if ((characterX1 + characterX2) < (m_x1 + m_x2)) {
 				// 密着状態まで移動させる
 				characterController->setCharacterX(m_x1 - characterWide);
+				// キャラは右へ移動できない
+				characterController->setActionRightLock(true);
 			}
 			else {
 				// 密着状態まで移動させる
 				characterController->setCharacterX(m_x2);
+				// キャラは左へ移動できない
+				characterController->setActionLeftLock(true);
 			}
 		}
-		else {
+		else if(characterVy != 0) {
 			// 真上へ
 			characterController->setCharacterY(m_y1 - characterHeight);
 			// 着地

--- a/World.cpp
+++ b/World.cpp
@@ -92,7 +92,8 @@ World::World(int areaNum) {
 	// カメラを主人公注目、倍率1.0で作成
 	m_playerId = heart->getId();
 	m_focusId = m_playerId;
-	m_camera = new Camera(0, 0, 1.0);
+	m_camera = new Camera(0, 0, 1.0, CAMERA_SPEED_DEFAULT);
+	m_camera->setPoint(heart->getX(), heart->getY());
 	updateCamera();
 
 	// 主人公の動きを作成
@@ -177,14 +178,17 @@ void World::updateCamera() {
 	while (characterSum > 0) {
 		Character* character = m_characters.front();
 		m_characters.pop();
+		// 今フォーカスしているキャラの座標に合わせる
 		if(m_focusId == character->getId()){
 			x = character->getX();
 			y = character->getY();
-			m_camera->setPoint(x, y);
+			m_camera->setGPoint(x, y);
 		}
 		m_characters.push(character);
 		characterSum--;
 	}
+	// カメラはゆっくり動く
+	m_camera->move();
 }
 
 // キャラクターの動き

--- a/World.cpp
+++ b/World.cpp
@@ -93,7 +93,7 @@ World::World(int areaNum) {
 	m_playerId = heart->getId();
 	m_focusId = m_playerId;
 	m_camera = new Camera(0, 0, 1.0, CAMERA_SPEED_DEFAULT);
-	m_camera->setPoint(heart->getX(), heart->getY());
+	m_camera->setPoint(heart->getCenterX(), heart->getCenterY());
 	updateCamera();
 
 	// 主人公の動きを作成
@@ -180,8 +180,8 @@ void World::updateCamera() {
 		m_characters.pop();
 		// 今フォーカスしているキャラの座標に合わせる
 		if(m_focusId == character->getId()){
-			x = character->getX();
-			y = character->getY();
+			x = character->getCenterX();
+			y = character->getCenterY();
 			m_camera->setGPoint(x, y);
 		}
 		m_characters.push(character);

--- a/World.h
+++ b/World.h
@@ -14,6 +14,9 @@ private:
 	// 描画用のカメラ
 	Camera* m_camera;
 
+	// カメラの移動速度の初期値
+	const int CAMERA_SPEED_DEFAULT = 5;
+
 	// カメラで見ているキャラのID
 	int m_focusId;
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
画面に描画されているキャラの画像が状態に応じて変化する。
例えば、移動中は走っているアニメーションになる。

# やったこと
- Characterクラスにメンバ変数（画像ハンドル）を追加

- ジャンプの処理を変更（ユーザ目線では変化なし）
  - 今まではControllerのkeyboardでジャンプの強さを処理していたが、ジャンプ前のアニメーションはActionクラスで動かすため、ジャンプの強さもActionで処理するように変更。アニメーションの処理も同時にやるだけなのでこのほうが楽。

- カメラがワープするのではなく移動するように変更
  - カメラの移動は目標地点が近い(わずかな移動)ほど鈍感になる（移動スピードが落ちる）。

- 画像が変わるとキャラのサイズも変わるため、座標が調整される処理を追加。

- 着地のアニメーション追加
- 走るアニメーション追加
- ブーストのアニメーション追加
- ジャンプ前のアニメーション追加
- ジャンプのアニメーション追加

# やらないこと
しゃがみ機能はこのPRに含めず、後々やった方がよさそう。

# できるようになること(ユーザ目線)
キャラを操作すると画像が変化し、キャラが動いて見える。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認

# 懸念点
- BoxObjectの端っこに着地すると降下と着地を繰り返す。
  - 降下中画像が大きくて着地→着地すると小さくなって宙に浮く→・・・　この繰り返しで起きる。
  - 降下中画像が大きくて着地→着地すると小さくなって宙に浮く→降下中になって画像が拡大→オブジェクトの中にキャラがめりこむ→オブジェクトの上にワープして着地→着地すると小さくなって宙に浮く→・・・

# 修正済みのバグ
- 左下りの坂に着地すると降下と着地を繰り返す。
- 坂の近くに着地すると坂の中に入り込めてしまう。
- 空中で方向転換すると、その次のジャンプでジャンプ前アニメがおかしくなる。
- 画像が変わって座標が調整されるとカメラも移動して見えにくい。
  - カメラをワープではなくゆっくり移動するよう変更する。
  - カメラの移動は目標地点が近い(わずかな移動)ほど鈍感になる（移動スピードが落ちる）。
