### PR TITLE
Api: しゃがみ機能の実装

### DIFF
--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -12,7 +12,6 @@ enum class CHARACTER_STATE {
 	BULLET,	// 射撃中
 	SLASH,	// 斬撃中
 	PREJUMP,	// ジャンプ前
-	SQUAT		// しゃがみ中
 };
 
 
@@ -102,7 +101,9 @@ public:
 	void setDownLock(bool lock);
 	inline void setBoost() { m_boostCnt = BOOST_TIME; }
 	inline const Character* getCharacter() const { return m_character; }
-	virtual void setState(CHARACTER_STATE state) = 0;
+
+	// squat==trueならしゃがむ、falseなら立つ
+	void setSquat(bool squat);
 
 	// キャラクターのセッタ
 	void setCharacterX(int x);
@@ -157,8 +158,6 @@ public:
 	StickAction(Character* character);
 
 	void debug(int x, int y, int color);
-
-	void setState(CHARACTER_STATE state);
 
 	//行動前の処理 毎フレーム行う
 	void init();

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -124,6 +124,10 @@ void CharacterKeyboardController::control() {
 	// ƒWƒƒƒ“ƒv
 	m_keyboard.controlJump(m_jumpKey);
 	m_characterAction->jump(m_jumpKey);
+
+	int sKey;
+	m_keyboard.controlSquat(sKey);
+	m_characterAction->setSquat(sKey);
 }
 
 Object* CharacterKeyboardController::bulletAttack() {


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
キャラがしゃがめるようになる。

# やったこと
CharacterControllerでCharacterActionにしゃがませることを命令する処理を追加。
CharacterActionでは、地上にいることやstateがDAMAGEなどでないことを条件にしゃがみ状態をtrueにする処理を追加。しゃがみ中はrunができなくなる(キャラが走れなくなる)ように変更。

# やらないこと
しゃがみ中に右クリックなどでスライディングができるようになると面白そうと思ったが保留。
しゃがみ中はジャンプできなくするか迷ったが、ジャンプできるままにした。なぜなら人の動きに照らしたとき、しゃがみ状態からジャンプは自然にできそうなため。

# できるようになること(ユーザ目線)
Sキーを押すと操作しているキャラがしゃがむ。当たり判定が小さくなる。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
Ｓキーを押すとキャラがしゃがむことを目視で確認した。（画像が変化すること、歩けなくなること）

# 懸念点
CharacterControllerとKeyboardの実装が汚いと思う。
