### PR TITLE
Api: オブジェクト関係のバグの修正

### DIFF
--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -13,6 +13,8 @@ CharacterAction::CharacterAction(Character* character) {
 	//初期状態
 	m_state = CHARACTER_STATE::STAND;
 	m_grand = false;
+	m_grandRightSlope = false;
+	m_grandRightSlope = false;
 	m_runCnt = -1;
 	m_squat = false;
 	m_preJumpCnt = -1;
@@ -90,6 +92,8 @@ void StickAction::init() {
 
 	// いったん宙に浮かせる
 	m_grand = false;
+	m_grandRightSlope = false;
+	m_grandRightSlope = false;
 }
 
 void CharacterAction::setSquat(bool squat) {
@@ -222,7 +226,18 @@ void CharacterAction::afterChangeGraph(int beforeWide, int beforeHeight, int aft
 	// 上下どっちにでも行ける
 	else {
 		// 両方に広げる
-		m_character->moveUp((afterHeight - beforeHeight) / 2);
+		int d = afterHeight - beforeHeight;
+		if (d % 2 == 1) {
+			if (d < 0) {
+				m_character->moveUp((d - 1) / 2);
+			}
+			else {
+				m_character->moveUp((d + 1) / 2);
+			}
+		}
+		else {
+			m_character->moveUp(d / 2);
+		}
 	}
 
 	// 右へ行けないなら
@@ -237,7 +252,18 @@ void CharacterAction::afterChangeGraph(int beforeWide, int beforeHeight, int aft
 	// 左右どっちにでも行ける、もしくはいけない
 	else {
 		// 両方に広げる
-		m_character->moveLeft((afterWide - beforeWide) / 2);
+		int d = afterWide - beforeWide;
+		if (d % 2 == 1) {
+			if (d < 0) {
+				m_character->moveLeft((d - 1) / 2);
+			}
+			else {
+				m_character->moveLeft((d + 1) / 2);
+			}
+		}
+		else {
+			m_character->moveLeft(d / 2);
+		}
 	}
 }
 

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -30,6 +30,12 @@ protected:
 	// キャラが地面にいる
 	bool m_grand;
 
+	// 右肩下がりの坂にいる
+	bool m_grandRightSlope;
+	
+	// 左肩下がりの坂にいる
+	bool m_grandLeftSlope;
+
 	// キャラが走っていないなら-1 そうでないなら走ったフレーム数
 	int m_runCnt;
 
@@ -93,6 +99,10 @@ public:
 		}
 		m_grand = grand;
 	}
+	inline bool getGrandRightSlope() const { return m_grandRightSlope; }
+	inline void setGrandRightSlope(bool grand) { m_grandRightSlope = grand; }
+	inline bool getGrandLeftSlope() const { return m_grandLeftSlope; }
+	inline void setGrandLeftSlope(bool grand) { m_grandLeftSlope = grand; }
 	inline int getVx() const { return m_vx; }
 	inline int getVy() const { return m_vy; }
 	inline int getSlashCnt() { return m_slashCnt; }

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -235,6 +235,12 @@ CharacterController::~CharacterController() {
 void CharacterController::setCharacterGrand(bool grand) {
 	m_characterAction->setGrand(grand);
 }
+void CharacterController::setCharacterGrandRightSlope(bool grand) {
+	m_characterAction->setGrandRightSlope(grand);
+}
+void CharacterController::setCharacterGrandLeftSlope(bool grand) {
+	m_characterAction->setGrandLeftSlope(grand);
+}
 void CharacterController::setActionRightLock(bool lock) {
 	m_characterAction->setRightLock(lock);
 }

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -148,6 +148,8 @@ public:
 
 	// アクションのセッタ
 	void setCharacterGrand(bool grand);
+	void setCharacterGrandRightSlope(bool grand);
+	void setCharacterGrandLeftSlope(bool grand);
 	void setActionRightLock(bool lock);
 	void setActionLeftLock(bool lock);
 	void setActionUpLock(bool lock);

--- a/Object.cpp
+++ b/Object.cpp
@@ -222,8 +222,8 @@ void TriangleObject::atari(CharacterController* characterController) {
 	int characterHeight = characterController->getAction()->getCharacter()->getHeight();
 	int characterX2 = characterX1 + characterWide;
 	int characterY2 = characterY1 + characterHeight;
-	int characterX1_5 = characterX1 + (characterWide / 2);
-	int characterY1_5 = characterY1 + (characterHeight / 2);
+	int characterX1_5 = characterController->getAction()->getCharacter()->getCenterX();
+	int characterY1_5 = characterController->getAction()->getCharacter()->getCenterY();
 	int characterVx = characterController->getAction()->getVx();
 	int characterVy = characterController->getAction()->getVy();
 
@@ -233,6 +233,12 @@ void TriangleObject::atari(CharacterController* characterController) {
 		if (characterY2 == getY(characterX1_5 - characterVx)) {
 			// 前のフレームでは着地していたので、引き続き着地
 			characterController->setCharacterGrand(true);
+			if (m_leftDown) {
+				characterController->setCharacterGrandRightSlope(true);
+			}
+			else {
+				characterController->setCharacterGrandLeftSlope(true);
+			}
 			// キャラは下へ移動できない
 			characterController->setActionDownLock(true);
 			// 密着状態までは移動させる
@@ -242,6 +248,12 @@ void TriangleObject::atari(CharacterController* characterController) {
 		else if (characterY2 <= getY(characterX1_5) && characterY2 + characterVy >= getY(characterX1_5)) {
 			// 着地
 			characterController->setCharacterGrand(true);
+			if (m_leftDown) {
+				characterController->setCharacterGrandRightSlope(true);
+			}
+			else {
+				characterController->setCharacterGrandLeftSlope(true);
+			}
 			// キャラは下へ移動できない
 			characterController->setActionDownLock(true);
 			// 密着状態までは移動させる


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
オブジェクトに関係する、以下のバグを修正する。
- 左下りの坂に着地すると一瞬宙に浮くバグ
- 床や壁を抜けるバグ
  - 画像が変わることでオブジェクトにキャラが入り込み、意図しない方向へワープして壁や床を貫通していると思われる。。
  - 画像が変わることによってキャラがオブジェクトに入り込むのは許容する。入り込んだ時の処理を修正する方向で。

# やったこと
- [x] 左下りの坂に着地すると一瞬宙に浮くバグ
- [ ] 床や壁を抜けるバグ

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
