### PR TITLE
Api: 斬撃機能の実装

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -125,6 +125,11 @@ void Character::setLeftDirection(bool leftDirection) {
 	m_graphHandle->setReverseX(m_leftDirection);
 }
 
+// HPŒ¸­
+void Character::damageHp(int value) {
+	m_hp = max(0, m_hp - value);
+}
+
 // ˆÚ“®‚·‚éiÀ•W‚ð“®‚©‚·j
 void Character::moveRight(int d) {
 	m_x += d;
@@ -204,6 +209,7 @@ void Heart::switchPreJump(int cnt) {
 // ŽËŒ‚UŒ‚‚ð‚·‚é(ƒLƒƒƒ‰‚²‚Æ‚Éˆá‚¤)
 Object* Heart::bulletAttack(int gx, int gy) {
 	BulletObject* attackObject = new BulletObject(m_x + m_wide / 2, m_y + m_height / 2, WHITE, gx, gy, m_attackInfo);
+	// Ž©–Å–hŽ~
 	attackObject->setCharacterId(m_id);
 	return attackObject;
 }
@@ -237,6 +243,10 @@ Object* Heart::slashAttack(bool leftDirection, int cnt) {
 	else if (cnt == m_attackInfo->slashCountSum() / 3) {
 		attackObject = new SlashObject(m_x, m_y, x2, y2,
 			m_slashHandles->getGraphHandle(index), slashCountSum, m_attackInfo);
+	}
+	// Ž©–Å–hŽ~
+	if (attackObject != NULL) {
+		attackObject->setCharacterId(m_id);
 	}
 	return attackObject;
 }

--- a/Character.cpp
+++ b/Character.cpp
@@ -153,7 +153,7 @@ Heart::Heart(int maxHp, int hp, int x, int y) :
 	// 各画像のロード
 	double ex = m_characterInfo->handleEx();
 	m_standHandle = new GraphHandle("picture/stick/stand.png", ex);
-	m_slashHandles = new GraphHandles("picture/stick/zangeki", 3, ex);
+	m_slashHandles = new GraphHandles("picture/stick/slashEffect", 3, ex);
 	m_squatHandle = new GraphHandle("picture/stick/squat.png", ex);
 	m_standBulletHandle = new GraphHandle("picture/stick/bullet.png", ex);
 	m_standSlashHandle = new GraphHandle("picture/stick/slash.png", ex);
@@ -224,6 +224,7 @@ Object* Heart::slashAttack(bool leftDirection, int cnt) {
 	int index = 0;
 	int slashCountSum = 5;
 	SlashObject* attackObject = NULL;
+	m_slashHandles->setReverseX(m_leftDirection);
 	// cntが攻撃のタイミングならオブジェクト生成
 	if (cnt == m_attackInfo->slashCountSum()) {
 		attackObject = new SlashObject(m_x, m_y, x2, y2,

--- a/Character.h
+++ b/Character.h
@@ -225,6 +225,9 @@ public:
 	// 空中斬撃画像をセット
 	virtual void switchAirSlash(int cnt = 0) = 0;
 
+	// HP減少
+	void damageHp(int value);
+
 
 	// 移動する（座標を動かす）
 	void moveRight(int d);

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -101,6 +101,7 @@ void StickAction::init() {
 void CharacterAction::setGrand(bool grand) {
 	if (m_vy > 0) { // 着地モーションになる
 		m_landCnt = LAND_TIME;
+		m_slashCnt = 0;
 	}
 	m_grand = grand;
 	if (m_state == CHARACTER_STATE::DAMAGE && m_damageCnt == 0) { 
@@ -120,6 +121,9 @@ void CharacterAction::setSquat(bool squat) {
 }
 
 void StickAction::action() {
+	// 状態(state)に応じて画像をセット
+	switchHandle();
+
 	// 射撃のインターバル処理
 	if (m_bulletCnt > 0) { m_bulletCnt--; }
 
@@ -173,9 +177,6 @@ void StickAction::action() {
 			m_character->moveDown(m_vy);
 		}
 	}
-
-	// 状態(state)に応じて画像をセット
-	switchHandle();
 }
 
 // 状態に応じて画像セット
@@ -188,6 +189,12 @@ void StickAction::switchHandle() {
 		case CHARACTER_STATE::STAND: //立ち状態
 			if (m_landCnt > 0) {
 				m_character->switchLand();
+			}
+			else if (m_slashCnt > 0) {
+				m_character->switchSlash();
+			}
+			else if (m_bulletCnt > 0) {
+				m_character->switchBullet();
 			}
 			else if (m_squat) {
 				m_character->switchSquat();
@@ -320,7 +327,7 @@ void StickAction::walk(bool right, bool left) {
 
 // 移動
 void StickAction::move(bool right, bool left, bool up, bool down) {
-	if (m_state == CHARACTER_STATE::STAND && m_grand && m_slashCnt == 0) {
+	if (m_state == CHARACTER_STATE::STAND && m_grand && m_slashCnt == 0 && m_bulletCnt == 0) {
 		// 移動方向へ向く
 		if(left){
 			m_character->setLeftDirection(true);
@@ -369,7 +376,7 @@ Object* StickAction::bulletAttack(int gx, int gy) {
 		return NULL;
 	}
 	// 射撃可能状態なら
-	if (m_bulletCnt == 0) {
+	if (m_bulletCnt == 0 && m_slashCnt == 0) {
 		// 射撃不可能状態にして
 		m_bulletCnt = m_character->getBulletRapid();
 		// 撃つ方向へ向く

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -407,6 +407,8 @@ Object* StickAction::slashAttack(int gx, int gy) {
 }
 
 void StickAction::damage(int vx, int vy, int damageValue, int soundHandle) {
+	if (m_state == CHARACTER_STATE::DAMAGE) { return; }
+
 	m_state = CHARACTER_STATE::DAMAGE;
 	m_vx += vx;
 	m_vy += vy;
@@ -418,4 +420,6 @@ void StickAction::damage(int vx, int vy, int damageValue, int soundHandle) {
 	m_grand = false;
 	m_grandRightSlope = false;
 	m_grandLeftSlope = false;
+	// HPŒ»Û
+	m_character->damageHp(damageValue);
 }

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -172,6 +172,10 @@ int NormalAI::squatOrder() {
 }
 
 int NormalAI::slashOrder() {
+	// ƒ‰ƒ“ƒ_ƒ€‚ÅŽËŒ‚
+	if (GetRand(50) == 0) {
+		return 1;
+	}
 	return 0;
 }
 

--- a/Object.cpp
+++ b/Object.cpp
@@ -440,6 +440,7 @@ BulletObject::BulletObject(int x, int y, int color, int gx, int gy, AttackInfo* 
 // キャラとの当たり判定
 // 当たっているならキャラを操作する。
 void BulletObject::atari(CharacterController* characterController) {
+	// 自滅防止
 	if (m_characterId == characterController->getAction()->getCharacter()->getId()) {
 		return;
 	}
@@ -506,6 +507,11 @@ SlashObject::SlashObject(int x, int y, GraphHandle* handle, int slashCountSum, A
 // キャラとの当たり判定
 // 当たっているならキャラを操作する。
 void SlashObject::atari(CharacterController* characterController) {
+	// 自滅防止
+	if (m_characterId == characterController->getAction()->getCharacter()->getId()) {
+		return;
+	}
+
 	// キャラの情報　座標と移動スピード
 	int characterX1 = characterController->getAction()->getCharacter()->getX();
 	int characterY1 = characterController->getAction()->getCharacter()->getY();
@@ -515,7 +521,13 @@ void SlashObject::atari(CharacterController* characterController) {
 	// 当たり判定
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2) {
 		// 貫通弾じゃないなら消滅
-		// m_deleteFlag = true;
+		 // m_deleteFlag = true;
+		if (characterX1 + characterX2 < m_x1 + m_x2) {
+			characterController->damage(-m_damage * 3, -m_damage * 3, m_damage, -1);
+		}
+		else {
+			characterController->damage(m_damage * 3, -m_damage * 3, m_damage, -1);
+		}
 	}
 }
 

--- a/World.cpp
+++ b/World.cpp
@@ -148,10 +148,11 @@ vector<const Object*> World::getObjects() const {
 // 戦わせる
 void World::battle() {
 
-	// HP0のキャラ削除
-	cleanCharacter();
+	// HP0のキャラコントローラ削除
+	cleanCharacterController();
 
 	// キャラの更新（攻撃対象の変更）
+	// 上でキャラを削除したから更新したから必要
 	updateCharacter();
 
 	// キャラクターの動き
@@ -165,13 +166,13 @@ void World::battle() {
 
 }
 
-// ＨＰ０のキャラ削除
-void World::cleanCharacter() {
-	for (unsigned int i = 0; i < m_characters.size(); i++) {
-		if (m_characters[i]->getHp() == 0) {
-			delete m_characters[i];
-			m_characters[i] = m_characters.back();
-			m_characters.pop_back();
+// ＨＰ０のキャラコントローラ削除
+void World::cleanCharacterController() {
+	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
+		if (m_characterControllers[i]->getAction()->getCharacter()->getHp() == 0) {
+			delete m_characterControllers[i];
+			m_characterControllers[i] = m_characterControllers.back();
+			m_characterControllers.pop_back();
 			i--;
 		}
 	}

--- a/World.h
+++ b/World.h
@@ -59,7 +59,7 @@ public:
 private:
 
 	// ＨＰ０のキャラ削除
-	void cleanCharacter();
+	void cleanCharacterController();
 
 	// キャラの更新（攻撃対象の変更）
 	void updateCharacter();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
斬撃機能を実装する。
斬撃に当たると吹っ飛ぶ。
また、HPが減少する機能も追加。

# やったこと
AIが斬撃攻撃をするようになった。（敵との距離を考慮してはいないため、今後改善予定）
ダメージモーション中は無敵時間とするように変更。
HP減少関数をCharacterに追加、０未満になると０に設定する。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
斬撃攻撃を敵に当てられるようになった。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。デバッグモードでHPが減少していることも確認。

# 懸念点
- 斬撃攻撃がやりにくい？攻撃の向きがマウスの位置で決まる。
- ＨＰが０になったキャラの処理方法がまだ決まっていない。現状、Controllerを削除するだけ。削除すると、削除されたインスタンスへのポインタが使えなくなり、あらゆる場所で実行時エラーが起きそう。
- AIは現状、攻撃が完全ランダムで賢くないため改善が必要。
- 斬撃攻撃の吹っ飛ぶ強さにマジックナンバーを使っているため、今後修正するべき。
- 無敵時間中はキャラを点滅させたりしてみる？
