### PR TITLE
Ui: 斬撃エフェクトの描画、HPバーの描画

### DIFF
--- a/Camera.h
+++ b/Camera.h
@@ -35,7 +35,7 @@ public:
 	inline void setGx(int x) { m_gx = x; }
 	inline void setGy(int y) { m_gy = y; }
 	inline void setSpeed(int speed) { m_speed = speed; }
-	inline double getEx() { return m_ex; }
+	inline double getEx() const { return m_ex; }
 	inline void setEx(double ex) { m_ex = ex; }
 
 	// ƒJƒƒ‰‚Ì“®‚«

--- a/Character.cpp
+++ b/Character.cpp
@@ -153,7 +153,7 @@ Heart::Heart(int maxHp, int hp, int x, int y) :
 	// Še‰æ‘œ‚Ìƒ[ƒh
 	double ex = m_characterInfo->handleEx();
 	m_standHandle = new GraphHandle("picture/stick/stand.png", ex);
-	m_slashHandles = new GraphHandles("picture/stick/zangeki", 3, ex);
+	m_slashHandles = new GraphHandles("picture/stick/slashEffect", 3, ex);
 	m_squatHandle = new GraphHandle("picture/stick/squat.png", ex);
 	m_standBulletHandle = new GraphHandle("picture/stick/bullet.png", ex);
 	m_standSlashHandle = new GraphHandle("picture/stick/slash.png", ex);

--- a/Character.h
+++ b/Character.h
@@ -153,7 +153,7 @@ public:
 	// ゲッタとセッタ
 	inline int getId() const { return m_id; }
 
-	inline int getMaxHp() { return m_maxHp; }
+	inline int getMaxHp() const { return m_maxHp; }
 
 	inline void setMaxHp(int maxHp) { m_maxHp = maxHp; }
 

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -3,7 +3,19 @@
 #include "Character.h"
 #include "CharacterAction.h"
 #include "GraphHandle.h"
+#include "DxLib.h"
 
+
+// 体力バーを表示
+void drawHpBar(int x1, int y1, int x2, int y2, int hp, int maxHp, int damageColor, int hpColor) {
+	int wide = x2 - x1;
+	int damage = wide * (maxHp - hp) / maxHp;
+	DrawBox(x1, y1, x1 + damage, y2, damageColor, TRUE);
+	DrawBox(x1 + damage, y1, x2, y2, hpColor, TRUE);
+}
+
+int CharacterDrawer::HP_COLOR = GetColor(0, 255, 0);
+int CharacterDrawer::DAMAGE_COLOR = GetColor(255, 0, 0);
 
 CharacterDrawer::CharacterDrawer(const CharacterAction* const characterAction) {
 	m_characterAction = characterAction;
@@ -31,4 +43,15 @@ void CharacterDrawer::drawCharacter(const Camera* const camera) {
 
 	// 描画
 	graphHandle->draw(x, y, ex);
+
+	// 体力バーの座標をカメラで調整
+	x = character->getX() + (character->getWide() / 2);
+	y = character->getY();
+	ex = graphHandle->getEx();
+	camera->setCamera(&x, &y, &ex);
+	int wide = (int)(HP_BAR_WIDE / 2 * camera->getEx());
+	int height = (int)(HP_BAR_HEIGHT * camera->getEx());
+	y -= (int)(10 * camera->getEx());
+	// 体力の描画
+	drawHpBar(x - wide, y - height, x + wide, y, character->getHp(), character->getMaxHp(), DAMAGE_COLOR, HP_COLOR);
 }

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -10,6 +10,11 @@ private:
 	// ƒLƒƒƒ‰‚Ì“®‚«‚Ìî•ñ constŠÖ”‚µ‚©ŒÄ‚Î‚È‚¢
 	const CharacterAction* m_characterAction;
 
+	const int HP_BAR_WIDE = 200;
+	const int HP_BAR_HEIGHT = 50;
+	static int HP_COLOR;
+	static int DAMAGE_COLOR;
+
 public:
 	CharacterDrawer(const CharacterAction* const characterAction);
 

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -2,6 +2,7 @@
 #include "DxLib.h"
 #include <string>
 #include <sstream>
+#include <algorithm>
 
 using namespace std;
 
@@ -23,6 +24,17 @@ GraphHandle::~GraphHandle() {
 // •`‰æ‚·‚é
 void GraphHandle::draw(int x, int y, double ex = 1.0) const {
 	DrawRotaGraph(x, y, ex, m_angle, m_handle, m_trans, m_reverseX, m_reverseY);
+}
+
+// ”ÍˆÍ‚ðŽw’è‚µ‚Ä•`‰æ‚·‚é
+void GraphHandle::extendDraw(int x1, int y1, int x2, int y2) const {
+	if (m_reverseX) {
+		swap(x1, x2);
+	}
+	if (m_reverseY) {
+		swap(y1, y2);
+	}
+	DrawExtendGraph(x1, y1, x2, y2, m_handle, m_trans);
 }
 
 

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -39,6 +39,8 @@ public:
 
 	// •`‰æ‚·‚é
 	void draw(int x, int y, double ex) const;
+
+	void extendDraw(int x1, int y1, int x2, int y2) const ;
 };
 
 

--- a/ObjectDrawer.cpp
+++ b/ObjectDrawer.cpp
@@ -2,6 +2,7 @@
 #include "Camera.h"
 #include "Object.h"
 #include "GraphHandle.h"
+#include "DxLib.h"
 
 
 ObjectDrawer::ObjectDrawer(const Object* object) {
@@ -27,14 +28,16 @@ void ObjectDrawer::drawObject(const Camera* const camera) {
 		m_object->drawObject(x1, y1, x2, y2);
 	}
 	else {
-		// 画像の中心を座標とする
-		x1 = (x1 + x2) / 2;
-		y1 = (y1 + y2) / 2;
+		//// 画像の中心を座標とする
+		//x1 = (x1 + x2) / 2;
+		//y1 = (y1 + y2) / 2;
 		// 画像固有の拡大率取得
-		ex = graphHandle->getEx();
+		// ex = graphHandle->getEx();
 		// カメラで調整
 		camera->setCamera(&x1, &y1, &ex);
+		camera->setCamera(&x2, &y2, &ex);
 		// 描画
-		graphHandle->draw(x1, y1, ex);
+		graphHandle->extendDraw(x1, y1, x2, y2);
+		DrawBox(x1, y1, x2, y2, GetColor(255, 0, 0), FALSE);
 	}	
 }


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
斬撃エフェクトを描画する処理を追加する。具体的には、攻撃範囲に合わせて画像を変形して描画する。
HPバーを描画する処理を追加する。具体的には、各キャラの上部に表示する。カメラの拡大率に合わせてHPバーの大きさも変化する。

# やったこと
指定範囲に合わせて画像を変形して描画する関数をGraphHandleクラスに追加した。
HPバーを描画する処理をCharacterDrawerクラスに追加した。

# やらないこと
斬撃の処理自体はAPI側で実装する。
主人公のHPバーだけ画面の端に描画するべきかと思ったが、いったん保留。全キャラ共通の処理でＨＰバーを描画する。

# できるようになること(ユーザ目線)
攻撃範囲が斬撃エフェクトの見た目で分かる。
各キャラのHPがどのくらい残っているか、バーを見ると分かる。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。試しにHP、MAX_HPを設定してHPバーを確認すると、正しく描画されていた。

# 懸念点
記入欄
