### PR TITLE
Api: 攻撃が当たったときのサウンドの実装＆GroupIdを用いたチームキル防止

### DIFF
--- a/Character.h
+++ b/Character.h
@@ -33,11 +33,11 @@ public:
 	CharacterInfo(const char* characterName);
 
 	// ゲッタのみを持つ
-	inline std::string name() { return m_name; }
-	inline int maxHp() { return m_maxHp; }
-	inline double handleEx() { return m_handleEx; }
-	inline int moveSpeed() { return m_moveSpeed; }
-	inline int jumpHeight() { return m_jumpHeight; }
+	inline std::string name() const { return m_name; }
+	inline int maxHp() const { return m_maxHp; }
+	inline double handleEx() const { return m_handleEx; }
+	inline int moveSpeed() const { return m_moveSpeed; }
+	inline int jumpHeight() const { return m_jumpHeight; }
 };
 
 
@@ -79,27 +79,45 @@ private:
 	// 斬撃の吹っ飛び(Y方向の初速)
 	int m_slashImpactY;
 
+	// 射撃攻撃のエフェクト
+	GraphHandles* m_bulletEffectHandles;
+
+	// 斬撃攻撃のエフェクト
+	GraphHandles* m_slashEffectHandles;
+
+	// 射撃攻撃が当たったときのサウンド
+	int m_bulletSoundHandle;
+
+	// 斬撃攻撃が当たったときのサウンド
+	int m_slashSoundHandle;
+
 public:
 	// デフォルト値で初期化
 	AttackInfo();
 	// csvファイルを読み込み、キャラ名で検索しパラメータ取得
-	AttackInfo(const char* characterName);
+	AttackInfo(const char* characterName, double drawEx);
+
+	~AttackInfo();
 	
 	// ゲッタのみを持つ
-	int bulletDamage() { return m_bulletDamage; }
-	int bulletRx() { return m_bulletRx; }
-	int bulletRy() { return m_bulletRy; }
-	int bulletSpeed() { return m_bulletSpeed; }
+	int bulletDamage() const { return m_bulletDamage; }
+	int bulletRx() const { return m_bulletRx; }
+	int bulletRy() const { return m_bulletRy; }
+	int bulletSpeed() const { return m_bulletSpeed; }
 	int bulletRapid() { return m_bulletRapid; }
-	int bulletDistance() { return m_bulletDistance; }
-	int bulletImpactX() { return m_bulletImpactX; }
-	int bulletImpactY() { return m_bulletImpactY; }
-	int slashDamage() { return m_slashDamage; }
-	int slashLenX() { return m_slashLenX; }
-	int slashLenY() { return m_slashLenY; }
-	int slashCountSum() { return m_slashCountSum; }
-	int slashImpactX() { return m_slashImpactX; }
-	int slashImpactY() { return m_slashImpactY; }
+	int bulletDistance() const { return m_bulletDistance; }
+	int bulletImpactX() const { return m_bulletImpactX; }
+	int bulletImpactY() const { return m_bulletImpactY; }
+	int slashDamage() const { return m_slashDamage; }
+	int slashLenX() const { return m_slashLenX; }
+	int slashLenY() const { return m_slashLenY; }
+	int slashCountSum() const { return m_slashCountSum; }
+	int slashImpactX() const { return m_slashImpactX; }
+	int slashImpactY() const { return m_slashImpactY; }
+	GraphHandles* bulletEffectHandle() const { return m_bulletEffectHandles; }
+	GraphHandles* slashEffectHandle() const { return m_slashEffectHandles; }
+	int bulletSoundeHandle() const { return m_bulletSoundHandle; }
+	int slashSoundHandle() const { return m_slashSoundHandle; }
 };
 
 
@@ -143,7 +161,7 @@ protected:
 public:
 	// コンストラクタ
 	Character();
-	Character(int maxHp, int hp, int x, int y);
+	Character(int maxHp, int hp, int x, int y, int groupId);
 	~Character();
 
 	// デバッグ
@@ -152,6 +170,8 @@ public:
 
 	// ゲッタとセッタ
 	inline int getId() const { return m_id; }
+
+	inline int getGroupId() const { return m_groupId; }
 
 	inline int getMaxHp() const { return m_maxHp; }
 
@@ -296,16 +316,10 @@ private:
 
 	// 空中斬撃画像
 	GraphHandle* m_airSlashHandle;
-
-	// 射撃攻撃のエフェクト
-	GraphHandles* m_bulletEffectHandles;
-
-	// 斬撃攻撃のエフェクト
-	GraphHandles* m_slashEffectHandles;
 	
 public:
 	// コンストラクタ
-	Heart(int maxHp, int hp, int x, int y);
+	Heart(int maxHp, int hp, int x, int y, int groupId);
 
 	// デストラクタ
 	~Heart();

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -221,7 +221,13 @@ void StickAction::switchHandle() {
 	else { // ’ˆ‚É‚¢‚é‚Æ‚«
 		switch (m_state) {
 		case CHARACTER_STATE::STAND: //—§‚¿ó‘Ô(‚È‚É‚à‚È‚µ‚Ìó‘Ô)
-			if (m_boostCnt > 0) {
+			if (m_slashCnt > 0) {
+				m_character->switchAirSlash();
+			}
+			else if (m_bulletCnt > 0) {
+				m_character->switchAirBullet();
+			}
+			else if (m_boostCnt > 0) {
 				m_character->switchBoost();
 			}
 			else if (m_vy < 0) {

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -110,12 +110,16 @@ void NormalAI::moveOrder(int& right, int& left, int& up, int& down) {
 
 	// 目標地点設定
 	if (m_gx > x - GX_ERROR && m_gx < x + GX_ERROR && GetRand(99) == 0) {
-		// targetについていく
-		m_gx = m_target->getCenterX() + GetRand(2000) - 1000;
-		// ランダムに設定
-		//m_gx = GetRand(200) + 100;
-		//if (GetRand(99) < GX_ERROR) { m_gx *= -1; }
-		//m_gx += x;
+		if (m_target != NULL) {
+			// targetについていく
+			m_gx = m_target->getCenterX() + GetRand(2000) - 1000;
+		}
+		else {
+			// ランダムに設定
+			m_gx = GetRand(200) + 100;
+			if (GetRand(99) < GX_ERROR) { m_gx *= -1; }
+			m_gx += x;
+		}
 	}
 
 	// 目標に向かって走る

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -5,6 +5,7 @@
 #include "Control.h"
 #include "Define.h"
 #include "DxLib.h"
+#include <algorithm>
 
 
 // Brainクラス
@@ -172,7 +173,10 @@ int NormalAI::squatOrder() {
 }
 
 int NormalAI::slashOrder() {
-	// ランダムで射撃
+	if (m_target != NULL && abs(m_target->getCenterX() - m_characterAction->getCharacter()->getCenterX()) > 500) {
+		return 0;
+	}
+	// ランダムで斬撃
 	if (GetRand(50) == 0) {
 		return 1;
 	}
@@ -191,7 +195,7 @@ int NormalAI::bulletOrder() {
 void NormalAI::searchTarget(const Character* character) {
 	if (m_target == NULL || m_target->getHp() == 0) {
 		// 自分自身や味方じゃなければ
-		if (character->getId() != m_characterAction->getCharacter()->getId()) {
+		if (character->getId() != m_characterAction->getCharacter()->getId() && character->getGroupId() != m_characterAction->getCharacter()->getGroupId()) {
 			m_target = character;
 		}
 	}

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -32,13 +32,14 @@ void debugObjects(int x, int y, int color, std::vector<Object*> objects) {
 void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, anime=%d", m_characters.size(), m_characterControllers.size(), m_animations.size());
-	m_characterControllers.front()->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+	m_characterControllers[0]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+	m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE + 600, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	// オブジェクト
-	debugObjects(x, y, color, m_stageObjects);
+	// debugObjects(x, y, color, m_stageObjects);
 	debugObjects(x + 500, y, RED, m_attackObjects);
-	for (unsigned int i = 0; i < m_animations.size(); i++) {
-		m_animations[i]->getHandle()->draw(GAME_WIDE - 200, 200, m_animations[i]->getHandle()->getEx());
-	}
+	//for (unsigned int i = 0; i < m_animations.size(); i++) {
+	//	m_animations[i]->getHandle()->draw(GAME_WIDE - 200, 200, m_animations[i]->getHandle()->getEx());
+	//}
 }
 
 
@@ -83,7 +84,7 @@ void StickAction::debug(int x, int y, int color) const {
 // Characterクラスのデバッグ
 void Character::debugCharacter(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**Character**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "HP=%d/%d, (x,y)=(%d,%d), left=%d", m_hp, m_maxHp, m_x, m_y, m_leftDirection);
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "HP=%d/%d, (x,y)=(%d,%d), left=%d, id=%d, groupId=%d", m_hp, m_maxHp, m_x, m_y, m_leftDirection, m_id, m_groupId);
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "(wide, height)=(%d,%d), handle=%d", m_wide, m_height, m_graphHandle->getHandle());
 	// 画像
 	// m_graphHandle->draw(GAME_WIDE - (m_wide / 2), (m_height / 2), m_graphHandle->getEx());
@@ -139,7 +140,7 @@ void TriangleObject::debug(int x, int y, int color) const {
 */
 void BulletObject::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**BulletObject**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "(gx,gy)=(%d,%d)", m_gx, m_gy);
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "(gx,gy)=(%d,%d), groupId=%d", m_gx, m_gy, m_groupId);
 	debugObject(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	// DrawOval(m_x1 + m_rx, m_y1 + m_ry, m_rx, m_ry, m_color, TRUE);
 }

--- a/Game.cpp
+++ b/Game.cpp
@@ -1,18 +1,29 @@
 #include "Game.h"
 #include "World.h"
 #include "Define.h"
+#include "Sound.h"
 #include "DxLib.h"
 
 
 Game::Game() {
+	// サウンドプレイヤー
+	m_soundPlayer = new SoundPlayer();
+	m_soundPlayer->setVolume(50);
+
+	// 世界
 	int startAreaNum = 0;
-	m_world = new World(startAreaNum);
+	m_world = new World(startAreaNum, m_soundPlayer);
 }
 
 Game::~Game() {
+	delete m_soundPlayer;
 	delete m_world;
 }
 
 void Game::play() {
+	// 戦わせる
 	m_world->battle();
+
+	// 音
+	m_soundPlayer->play();
 }

--- a/Game.h
+++ b/Game.h
@@ -2,11 +2,15 @@
 #define GAME_H_INCLUDED
 
 
+class SoundPlayer;
 class World;
 
 
 class Game {
 private:
+	// サウンドプレイヤー
+	SoundPlayer* m_soundPlayer;
+
 	World* m_world;
 
 public:

--- a/Main.cpp
+++ b/Main.cpp
@@ -30,7 +30,7 @@ bool Update() {
 }
 
 void Draw(int x, int y, int color) {
-	DrawFormatString(0, 0, WHITE, "%.1f", mFps);
+	DrawFormatString(0, 0, WHITE, "デバッグモード：%.1f FPS", mFps);
 }
 
 void Wait() {

--- a/Object.cpp
+++ b/Object.cpp
@@ -29,6 +29,7 @@ Object::Object(int x1, int y1, int x2, int y2) {
 	m_ableDelete = false;
 
 	m_effectHandles = NULL;
+	m_soundHandle = -1;
 }
 
 // アニメーション作成
@@ -436,7 +437,7 @@ void TriangleObject::action() {
 }
 
 
-BulletObject::BulletObject(int x, int y, int color, int gx, int gy, AttackInfo* attackInfo, GraphHandles* effectHandles) :
+BulletObject::BulletObject(int x, int y, int color, int gx, int gy, AttackInfo* attackInfo) :
 	Object(x - attackInfo->bulletRx(), y - attackInfo->bulletRx(), x + attackInfo->bulletRx(), y + attackInfo->bulletRy())
 {
 	// 必要なら後からセッタで設定
@@ -462,7 +463,10 @@ BulletObject::BulletObject(int x, int y, int color, int gx, int gy, AttackInfo* 
 	m_vy = (int)(m_v * std::sin(r));
 
 	// エフェクトの画像
-	m_effectHandles = effectHandles;
+	m_effectHandles = attackInfo->bulletEffectHandle();
+
+	// サウンド
+	m_soundHandle = attackInfo->bulletSoundeHandle();
 }
 
 // キャラとの当たり判定
@@ -470,6 +474,10 @@ BulletObject::BulletObject(int x, int y, int color, int gx, int gy, AttackInfo* 
 bool BulletObject::atari(CharacterController* characterController) {
 	// 自滅防止
 	if (m_characterId == characterController->getAction()->getCharacter()->getId()) {
+		return false;
+	}
+	// チームキル防止
+	if (m_groupId == characterController->getAction()->getCharacter()->getGroupId()) {
 		return false;
 	}
 
@@ -507,11 +515,12 @@ void BulletObject::action() {
 }
 
 
-SlashObject::SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo, GraphHandles* effectHandles) :
+SlashObject::SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo) :
 	Object(x1, y1, x2, y2)
 {
 	// 必要なら後からセッタで設定
 	m_characterId = -1;
+	m_groupId = -1;
 
 	// 画像
 	m_handle = handle;
@@ -533,17 +542,20 @@ SlashObject::SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, in
 
 
 	// エフェクトの画像
-	m_effectHandles = effectHandles;
+	m_effectHandles = attackInfo->slashEffectHandle();
+
+	// サウンド
+	m_soundHandle = attackInfo->slashSoundHandle();
 }
 
 // 大きさを指定しない場合。画像からサイズ取得。生存時間、AttackInfo
-SlashObject::SlashObject(int x, int y, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo, GraphHandles* effectHandles) {
+SlashObject::SlashObject(int x, int y, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo) {
 	int x2 = 0;
 	int y2 = 0;
 	GetGraphSize(handle->getHandle(), &x2, &y2);
 	x2 += x;
 	y2 = y;
-	SlashObject(x, y, x2, y2, handle, slashCountSum, attackInfo, effectHandles);
+	SlashObject(x, y, x2, y2, handle, slashCountSum, attackInfo);
 }
 
 // キャラとの当たり判定
@@ -551,6 +563,10 @@ SlashObject::SlashObject(int x, int y, GraphHandle* handle, int slashCountSum, A
 bool SlashObject::atari(CharacterController* characterController) {
 	// 自滅防止
 	if (m_characterId == characterController->getAction()->getCharacter()->getId()) {
+		return false;
+	}
+	// チームキル防止
+	if (m_groupId == characterController->getAction()->getCharacter()->getGroupId()) {
 		return false;
 	}
 

--- a/Object.h
+++ b/Object.h
@@ -29,6 +29,9 @@ protected:
 	// エフェクト
 	GraphHandles* m_effectHandles;
 
+	// サウンド
+	int m_soundHandle;
+
 public:
 	Object();
 	Object(int x1, int y1, int x2, int y2);
@@ -43,6 +46,7 @@ public:
 	inline int getX2() const { return m_x2; }
 	inline int getY1() const { return m_y1; }
 	inline int getY2() const { return m_y2; }
+	inline int getSoundHandle() const { return m_soundHandle; }
 
 	// 画像を返す　ないならNULL
 	virtual GraphHandle* getHandle() const = 0;
@@ -192,7 +196,7 @@ private:
 
 public:
 	// x, y, gx, gyは弾の中心座標
-	BulletObject(int x, int y, int color, int gx, int gy, AttackInfo* attackInfo, GraphHandles* effectHandles);
+	BulletObject(int x, int y, int color, int gx, int gy, AttackInfo* attackInfo);
 
 	void debug(int x, int y, int color) const;
 
@@ -203,8 +207,9 @@ public:
 	void drawObject(int x1, int y1, int x2, int y2) const;
 
 	// セッタ
-	// キャラクターIDを取得
+	// キャラクターIDをセット
 	inline void setCharacterId(int id) { m_characterId = id; }
+	inline void setGroupId(int id) { m_groupId = id; }
 
 	// キャラとの当たり判定
 	// 当たっているならキャラを操作する。
@@ -235,6 +240,9 @@ private:
 	// この攻撃を出したキャラのＩＤ 自滅やチームキル防止用
 	int m_characterId;
 
+	// この攻撃が当たらないグループのID チームキル防止用
+	int m_groupId;
+
 	// オブジェクトの画像
 	GraphHandle* m_handle;
 
@@ -255,10 +263,10 @@ private:
 
 public:
 	// 座標、画像、生存時間、AttackInfo
-	SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo, GraphHandles* effectHandles);
+	SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo);
 
 	// 大きさを指定しない場合。画像からサイズ取得。生存時間、AttackInfo
-	SlashObject(int x, int y, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo, GraphHandles* effectHandles);
+	SlashObject(int x, int y, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo);
 
 	void debug(int x, int y, int color) const;
 
@@ -270,6 +278,7 @@ public:
 
 	// セッタ
 	inline void setCharacterId(int id) { m_characterId = id; }
+	inline void setGroupId(int id) { m_groupId = id; }
 
 	// キャラとの当たり判定
 	// 当たっているならキャラを操作する。

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -1,10 +1,64 @@
 #include "Sound.h"
+#include "DxLib.h"
+#include <algorithm>
+
+using namespace std;
+
+
+// 音量調節
+void changeSoundVolume(int soundHandle, int volume) {
+	ChangeVolumeSoundMem(255 * (volume) / 100, soundHandle);
+}
 
 
 SoundPlayer::SoundPlayer() {
+	m_volume = 50;
+	m_bgmName = "";
+	m_bgmHandle = -1;
 
 }
 
 SoundPlayer::~SoundPlayer() {
+	DeleteSoundMem(m_bgmHandle);
+}
 
+void SoundPlayer::setVolume(int volume) {
+	if (volume < 0) { m_volume = 0; }
+	else {
+		m_volume = min(m_volume, 100);
+	}
+	changeSoundVolume(m_bgmHandle, m_volume);
+}
+
+// BGMをセット（変更）
+void SoundPlayer::setBGM(std::string bgmName) {
+	m_bgmName = bgmName;
+	m_bgmHandle = LoadSoundMem(bgmName.c_str());
+	// 音量調整
+	changeSoundVolume(m_bgmHandle, m_volume);
+}
+
+// BGMを再生
+void SoundPlayer::playBGM() {
+	PlaySoundMem(m_bgmHandle, DX_PLAYTYPE_LOOP);
+}
+
+// BGMをストップ
+void SoundPlayer::stopBGM() {
+	StopSoundMem(m_bgmHandle);
+}
+
+// 効果音の再生待機列へプッシュ
+void SoundPlayer::pushSoundQueue(int soundHandle) {
+	m_soundQueue.push(soundHandle);
+}
+
+// 効果音を鳴らす
+void SoundPlayer::play() {
+	while (!m_soundQueue.empty()) {
+		int handle = m_soundQueue.front();
+		m_soundQueue.pop();
+		changeSoundVolume(handle, m_volume);
+		PlaySoundMem(handle, DX_PLAYTYPE_BACK);
+	}
 }

--- a/Sound.h
+++ b/Sound.h
@@ -1,14 +1,47 @@
 #ifndef SOUND_H_INCLUDED
 #define SOUND_H_INCLUDED
 
+#include <queue>
+#include <string>
+
 class SoundPlayer {
 private:
 	// 音量
 	int m_volume;
 
+	// BGMの名前
+	std::string m_bgmName;
+
+	// BGM
+	int m_bgmHandle;
+
+	// 再生予定の効果音
+	std::queue<int> m_soundQueue;
+
 public:
 	SoundPlayer();
 	~SoundPlayer();
+
+	void setVolume(int volume);
+	inline int getVolume() const { return m_volume; }
+
+	// BGMをセット（変更）
+	void setBGM(std::string bgmName);
+
+	// 今流している音楽をチェックする
+	inline bool sameBGM(std::string bgmName) const { return m_bgmName == bgmName; }
+
+	// BGMを再生
+	void playBGM();
+
+	// BGMをストップ
+	void stopBGM();
+
+	// 効果音の再生待機列へプッシュ
+	void pushSoundQueue(int soundHandle);
+
+	// 効果音を鳴らす
+	void play();
 };
 
 #endif

--- a/World.cpp
+++ b/World.cpp
@@ -5,6 +5,7 @@
 #include "CharacterController.h"
 #include "Camera.h"
 #include "Animation.h"
+#include "Sound.h"
 #include "Define.h"
 #include "DxLib.h"
 
@@ -64,7 +65,10 @@ void penetrationCharacterAndObject(CharacterController* controller, vector<Objec
 /*
 * オブジェクトのロードなど
 */
-World::World(int areaNum) {
+World::World(int areaNum, SoundPlayer* soundPlayer) {
+	// サウンドプレイヤー
+	m_soundPlayer = soundPlayer;
+
 	// 主人公のスタート地点
 	m_areaNum = areaNum;
 
@@ -87,7 +91,7 @@ World::World(int areaNum) {
 	m_stageObjects.push_back(object8);
 
 	// 主人公をロード キャラの削除はWorldがやる予定
-	Heart* heart = new Heart(100, 100, 0, 0);
+	Heart* heart = new Heart(100, 100, 0, 0, 0);
 	m_characters.push_back(heart);
 
 	// カメラを主人公注目、倍率1.0で作成
@@ -102,11 +106,23 @@ World::World(int areaNum) {
 	m_characterControllers.push_back(heartController);
 
 	// CPUをロード
-	Heart* cp = new Heart(100, 100, 500, 0);
-	m_characters.push_back(cp);
+	Heart* cp1 = new Heart(100, 100, 2000, 0, 1);
+	m_characters.push_back(cp1);
 	//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
-	NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp));
-	m_characterControllers.push_back(cpController);
+	NormalController* cpController1 = new NormalController(new NormalAI(), new StickAction(cp1));
+	m_characterControllers.push_back(cpController1);
+	// CPUをロード
+	Heart* cp2 = new Heart(100, 100, 2200, 0, 1);
+	m_characters.push_back(cp2);
+	//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
+	NormalController* cpController2 = new NormalController(new NormalAI(), new StickAction(cp2));
+	m_characterControllers.push_back(cpController2);
+	// CPUをロード
+	Heart* cp3 = new Heart(100, 100, 200, 0, 0);
+	m_characters.push_back(cp3);
+	//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
+	NormalController* cpController3 = new NormalController(new NormalAI(), new StickAction(cp3));
+	m_characterControllers.push_back(cpController3);
 }
 
 World::~World() {
@@ -241,6 +257,7 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 		if (objects[i]->atari(controller)) {
 			// 当たった場合 エフェクト作成
 			m_animations.push_back(objects[i]->createAnimation(controller->getAction()->getCharacter()));
+			m_soundPlayer->pushSoundQueue(objects[i]->getSoundHandle());
 		}
 		// deleteFlagがtrueなら削除する
 		if (objects[i]->getDeleteFlag()) {

--- a/World.cpp
+++ b/World.cpp
@@ -21,7 +21,7 @@ void deleteAllObject(vector<Object*>& objects) {
 	}
 }
 
-// vectorに入ったdeleteFlagがtrueのオブジェクトを削除する
+// vectorに入ったdeleteFlagがtarueのオブジェクトを削除する
 void deleteObject(vector<Object*>& objects) {
 	for (unsigned int i = 0; i < objects.size(); i++) {
 		// deleteFlagがtrueなら削除する
@@ -106,23 +106,23 @@ World::World(int areaNum, SoundPlayer* soundPlayer) {
 	m_characterControllers.push_back(heartController);
 
 	// CPUをロード
-	Heart* cp1 = new Heart(100, 100, 2000, 0, 1);
-	m_characters.push_back(cp1);
-	//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
-	NormalController* cpController1 = new NormalController(new NormalAI(), new StickAction(cp1));
-	m_characterControllers.push_back(cpController1);
-	// CPUをロード
-	Heart* cp2 = new Heart(100, 100, 2200, 0, 1);
-	m_characters.push_back(cp2);
-	//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
-	NormalController* cpController2 = new NormalController(new NormalAI(), new StickAction(cp2));
-	m_characterControllers.push_back(cpController2);
-	// CPUをロード
-	Heart* cp3 = new Heart(100, 100, 200, 0, 0);
-	m_characters.push_back(cp3);
-	//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
-	NormalController* cpController3 = new NormalController(new NormalAI(), new StickAction(cp3));
-	m_characterControllers.push_back(cpController3);
+	for (int i = 0; i < 1; i++) {
+		// CPUをロード
+		Heart* cp = new Heart(100, 100, 2000 + 100*i, 0, 1);
+		m_characters.push_back(cp);
+		//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
+		NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp));
+		m_characterControllers.push_back(cpController);
+	}
+	for (int i = 0; i < 0; i++) {
+		// CPUをロード
+		Heart* cp = new Heart(100, 100, 2000 + 100 * i, 0, 0);
+		m_characters.push_back(cp);
+		//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
+		NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp));
+		m_characterControllers.push_back(cpController);
+	}
+	
 }
 
 World::~World() {

--- a/World.h
+++ b/World.h
@@ -9,9 +9,13 @@ class Character;
 class Object;
 class Camera;
 class Animation;
+class SoundPlayer;
 
 class World {
 private:
+	// サウンドプレイヤー
+	SoundPlayer* m_soundPlayer;
+
 	// 描画用のカメラ
 	Camera* m_camera;
 
@@ -43,7 +47,7 @@ private:
 	int m_areaNum;
 
 public:
-	World(int areaNum);
+	World(int areaNum, SoundPlayer* soundPlayer);
 	~World();
 
 	// ゲッタとセッタ


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
攻撃が当たったときに音が鳴る機能を実装する。
味方に攻撃が当たらない機能を実装する。

# やったこと
SoundPlayerクラスを実装した。
このクラスはBGMや効果音等すべてのサウンドを再生する。
再生したい効果音はQueueに入れて再生してもらう。
GameクラスがSoundPlayerを持つ。ゲーム全体の音のボリュームを管理するため。
Worldクラスはそのインスタンスへのポインタを持ち、効果音をQueueに入れる。
Gameクラスが毎フレーム、SoundPlayerのQueueに入った効果音を１回ずつ再生する。

groupIdをCharacterに持たせる。攻撃Objectは作成したキャラのGroupIdと攻撃対象のGroupIdを照合し、
一致するなら当たったことにならない。

たまに落ちるバグを修正。
原因はAIのtargetがNULLのときに、AIが移動目標地点を設定するためにtargetを使おうとすること。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
攻撃が当たった音を聞ける。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。

# 懸念点
なんか移動できない時がある。買い換えたキーボードの問題？
