### PR TITLE
Api: 戦闘時にキャラの位置からカメラを拡大・縮小する機能

### DIFF
--- a/Debug.cpp
+++ b/Debug.cpp
@@ -33,7 +33,7 @@ void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, anime=%d", m_characters.size(), m_characterControllers.size(), m_animations.size());
 	m_characterControllers[0]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
-	m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE + 600, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+	//m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE + 600, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	// オブジェクト
 	// debugObjects(x, y, color, m_stageObjects);
 	debugObjects(x + 500, y, RED, m_attackObjects);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
戦闘時、キャラが画面外にいるとカメラを縮小して遠くを見れるようになる。
逆に、キャラがが広がってないならカメラを拡大してキャラを大きく見れる。

# やったこと
Worldがキャラの位置を考慮してカメラの拡大率を調節する処理を追加。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
必要に応じて遠くを見れるようになり、遊びやすくなる。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。

# 懸念点
時々画面が揺れるかも。
マジックナンバーを使っているため後々修正するかも？
