### PR TITLE
Ui: マウスカーソルの位置にターゲットの画像を描画

### DIFF
--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -11,7 +11,7 @@ private:
 	const CharacterAction* m_characterAction;
 
 	const int HP_BAR_WIDE = 200;
-	const int HP_BAR_HEIGHT = 50;
+	const int HP_BAR_HEIGHT = 20;
 	static int HP_COLOR;
 	static int DAMAGE_COLOR;
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -5,7 +5,10 @@
 #include "DxLib.h"
 
 
+// フルスクリーンならFALSE
 static int WINDOW = TRUE;
+// マウスを表示するならFALSE
+static int MOUSE_DISP = FALSE;
 
 ///////fpsの調整///////////////
 static int mStartTime;
@@ -50,7 +53,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	//SetAlwaysRunFlag(TRUE);//画面を常にアクティブ
 	SetMainWindowText("複製のHeart");
 	////マウス関連////
-	SetMouseDispFlag(TRUE);//マウス表示
+	SetMouseDispFlag(MOUSE_DISP);//マウス表示
 	//SetMousePoint(320, 240);//マウスカーソルの初期位置
 	//SetDrawMode(DX_DRAWMODE_BILINEAR);
 	SetDrawMode(DX_DRAWMODE_NEAREST);

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -5,9 +5,41 @@
 #include "CharacterAction.h"
 #include "ObjectDrawer.h"
 #include "AnimationDrawer.h"
+#include "DxLib.h"
 #include <queue>
 
 using namespace std;
+
+
+TargetDrawer::TargetDrawer() {
+	m_ex = TARGET_EX;
+	m_targetHandle1 = LoadGraph("picture/battleMaterial/mouseTarget1.png");
+	m_targetAngle1 = 0.0;
+	m_targetHandle2 = LoadGraph("picture/battleMaterial/mouseTarget2.png");
+	m_targetAngle2 = 0.0;
+	m_targetHandle3 = LoadGraph("picture/battleMaterial/mouseTarget3.png");
+	m_targetAngle3 = 0.0;
+}
+
+TargetDrawer::~TargetDrawer() {
+	DeleteGraph(m_targetHandle1);
+	DeleteGraph(m_targetHandle2);
+	DeleteGraph(m_targetHandle3);
+}
+
+void TargetDrawer::draw() {
+	int mouseX, mouseY;
+	GetMousePoint(&mouseX, &mouseY);
+	DrawRotaGraph(mouseX, mouseY, m_ex, m_targetAngle1, m_targetHandle1, TRUE);
+	DrawRotaGraph(mouseX, mouseY, m_ex, m_targetAngle2, m_targetHandle2, TRUE);
+	DrawRotaGraph(mouseX, mouseY, m_ex, m_targetAngle3, m_targetHandle3, TRUE);
+	anime();
+}
+
+void TargetDrawer::anime() {
+	m_targetAngle2 += PI / 90;
+	m_targetAngle3 -= PI / 180;
+}
 
 
 WorldDrawer::WorldDrawer(const World* world) {
@@ -60,4 +92,7 @@ void WorldDrawer::draw() {
 		// ƒJƒƒ‰‚ðŽg‚Á‚ÄƒLƒƒƒ‰‚ð•`‰æ
 		m_animationDrawer->drawAnimation(camera);
 	}
+
+	m_targetDrawer.setEx(camera->getEx());
+	m_targetDrawer.draw();
 }

--- a/WorldDrawer.h
+++ b/WorldDrawer.h
@@ -6,6 +6,31 @@ class CharacterDrawer;
 class ObjectDrawer;
 class AnimationDrawer;
 
+
+class TargetDrawer {
+private:
+	const double TARGET_EX = 0.3;
+	double m_ex;
+	int m_targetHandle1;
+	int m_targetHandle2;
+	int m_targetHandle3;
+	const double PI = 3.14;
+	double m_targetAngle1;
+	double m_targetAngle2;
+	double m_targetAngle3;
+public:
+	TargetDrawer();
+	~TargetDrawer();
+
+	void setEx(double ex) { m_ex = ex * TARGET_EX; }
+
+	void draw();
+
+private:
+	void anime();
+};
+
+
 // 世界を描画する
 class WorldDrawer {
 private:
@@ -21,6 +46,9 @@ private:
 
 	// アニメーション描画用
 	AnimationDrawer* m_animationDrawer;
+
+	// マウスカーソル代わり
+	TargetDrawer m_targetDrawer;
 
 public:
 	WorldDrawer(const World* world);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
マウスの位置にターゲットの画像を描画し、狙いが見やすくなる。

# やったこと
TargetDrawerクラスを作成し、WorldDrawerクラスに持たせた。
ターゲットの画像は３枚の画像で構成され、時間経過で変化するアニメーションとして描画する。
カメラの拡大率に合わせてターゲットの画像の大きさも変わる。
マウスを非表示にした。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
ターゲットの画像のおかげで、狙いを定めやすくなる。

# できなくなること(ユーザ目線)
マウスが見えなくなる。

# 動作確認
視覚的に確認。

# 懸念点
HPバーの赤色と被ると見えにくい？
