### PR TITLE
A,Dキーを同時に押したときのバグを修正&攻撃開始の条件変更+受け身機能

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -83,18 +83,18 @@ AttackInfo::~AttackInfo() {
 int Character::characterId;
 
 Character::Character() :
-	Character(100, 100, 0, 0, 0)
+	Character(100, 0, 0, 0)
 {
 
 }
 
-Character::Character(int maxHp, int hp, int x, int y, int groupId) {
+Character::Character(int hp, int x, int y, int groupId) {
 	// IDを振る
 	characterId++;
 	m_id = characterId;
 
 	m_groupId = groupId;
-	m_maxHp = maxHp;
+
 	m_hp = hp;
 	m_x = x;
 	m_y = y;
@@ -176,8 +176,12 @@ void Character::switchBullet(int cnt) { m_graphHandle->switchBullet(); }
 void Character::switchSlash(int cnt) { m_graphHandle->switchSlash(); }
 // しゃがみ画像をセット
 void Character::switchSquat(int cnt) { m_graphHandle->switchSquat(); }
+// しゃがみ画像をセット
+void Character::switchSquatBullet(int cnt) { m_graphHandle->switchSquatBullet(); }
 // 走り画像をセット
 void Character::switchRun(int cnt) { m_graphHandle->switchRun(); }
+// 走り射撃画像をセット
+void Character::switchRunBullet(int cnt) { m_graphHandle->switchRunBullet(); }
 // 着地画像をセット
 void Character::switchLand(int cnt) { m_graphHandle->switchLand(); }
 // 上昇画像をセット
@@ -199,12 +203,14 @@ void Character::switchAirSlash(int cnt) { m_graphHandle->switchAirSlash(); }
 /*
 * ハート
 */
-Heart::Heart(int maxHp, int hp, int x, int y, int groupId) :
-	Character(maxHp, hp, x, y, groupId)
+Heart::Heart(int hp, int x, int y, int groupId) :
+	Character(hp, x, y, groupId)
 {
 	// キャラ固有の情報設定
 	m_characterInfo = new CharacterInfo(NAME);
 	m_attackInfo = new AttackInfo(NAME, m_characterInfo->handleEx());
+
+	m_hp = m_characterInfo->maxHp();
 
 	// 各画像のロード
 	m_graphHandle = new CharacterGraphHandle(NAME, m_characterInfo->handleEx());
@@ -223,6 +229,13 @@ void Heart::switchRun(int cnt) {
 	int index = (cnt / RUN_ANIME_SPEED) % (m_graphHandle->getRunHandle()->getSize());
 	m_graphHandle->switchRun(index);
 }
+
+// 走り射撃画像をセット
+void Heart::switchRunBullet(int cnt) {
+	int index = (cnt / RUN_ANIME_SPEED) % (m_graphHandle->getRunBulletHandle()->getSize());
+	m_graphHandle->switchRunBullet(index);
+}
+
 // ジャンプ前画像をセット
 void Heart::switchPreJump(int cnt) { 
 	int index = (cnt / RUN_PREJUMP_SPEED) % (m_graphHandle->getPreJumpHandle()->getSize());

--- a/Character.h
+++ b/Character.h
@@ -135,9 +135,6 @@ protected:
 	// グループID 味方識別用
 	int m_groupId;
 
-	// 最大体力
-	int m_maxHp;
-
 	// 残り体力
 	int m_hp;
 
@@ -159,7 +156,7 @@ protected:
 public:
 	// コンストラクタ
 	Character();
-	Character(int maxHp, int hp, int x, int y, int groupId);
+	Character(int hp, int x, int y, int groupId);
 	~Character();
 
 	// デバッグ
@@ -169,15 +166,15 @@ public:
 	// ゲッタ
 	inline int getId() const { return m_id; }
 	inline int getGroupId() const { return m_groupId; }
-	inline int getMaxHp() const { return m_maxHp; }
+	inline int getMaxHp() const { return m_characterInfo->maxHp(); }
 	inline int getHp() const { return m_hp; }
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline bool getLeftDirection() const { return m_leftDirection; }
 
 	// セッタ
-	inline void setMaxHp(int maxHp) { m_maxHp = maxHp; }
-	inline void setHp(int hp) { m_hp = (hp > m_maxHp) ? m_maxHp : hp; }
+	//inline void setMaxHp(int maxHp) { m_maxHp = maxHp; }
+	inline void setHp(int hp) { m_hp = (hp > m_characterInfo->maxHp()) ? m_characterInfo->maxHp() : hp; }
 	inline void setX(int x) { m_x = x; }
 	inline void setY(int y) { m_y = y; }
 	// キャラの向き変更は、画像の反転も行う
@@ -209,8 +206,12 @@ public:
 	virtual void switchSlash(int cnt = 0);
 	// しゃがみ画像をセット
 	virtual void switchSquat(int cnt = 0);
+	// しゃがみ射撃画像をセット
+	virtual void switchSquatBullet(int cnt = 0);
 	// 走り画像をセット
 	virtual void switchRun(int cnt = 0);
+	// 走り射撃画像をセット
+	virtual void switchRunBullet(int cnt = 0);
 	// 着地画像をセット
 	virtual void switchLand(int cnt = 0);
 	// 上昇画像をセット
@@ -263,7 +264,7 @@ private:
 	
 public:
 	// コンストラクタ
-	Heart(int maxHp, int hp, int x, int y, int groupId);
+	Heart(int hp, int x, int y, int groupId);
 
 	// デストラクタ
 	~Heart();
@@ -274,6 +275,10 @@ public:
 	// 画像変更関数のオーバーライド
 	// 走り画像をセット
 	void switchRun(int cnt = 0);
+
+	// 走り射撃画像をセット
+	void switchRunBullet(int cnt = 0);
+
 	// ジャンプ前画像をセット
 	void switchPreJump(int cnt = 0);
 

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -329,11 +329,13 @@ void StickAction::walk(bool right, bool left) {
 	if (damageFlag()) {
 		return;
 	}
-	if (!m_rightLock && !m_moveRight && !m_moveLeft && right && !m_squat) { // 右へ歩く
+	// 右へ歩き始める
+	if (!m_rightLock && !m_moveRight && !m_moveLeft && right && (!left || !m_character_p->getLeftDirection()) && !m_squat) { // 右へ歩く
 		m_vx += m_character_p->getMoveSpeed();
 		m_moveRight = true;
 	}
-	if (!m_leftLock && !m_moveRight && !m_moveLeft && left && !m_squat) { // 左へ歩く
+	// 左へ歩き始める
+	if (!m_leftLock && !m_moveRight && !m_moveLeft && left && (!right || m_character_p->getLeftDirection()) && !m_squat) { // 左へ歩く
 		m_vx -= m_character_p->getMoveSpeed();
 		m_moveLeft = true;
 	}
@@ -347,10 +349,10 @@ void StickAction::walk(bool right, bool left) {
 void StickAction::move(bool right, bool left, bool up, bool down) {
 	if (getState() == CHARACTER_STATE::STAND && m_grand && m_slashCnt == 0 && m_bulletCnt == 0) {
 		// 移動方向へ向く
-		if(left){
+		if(left && !right){
 			m_character_p->setLeftDirection(true);
 		}
-		if (right) {
+		if (right && !left) {
 			m_character_p->setLeftDirection(false);
 		}
 	}
@@ -416,11 +418,9 @@ Object* StickAction::slashAttack(int gx, int gy) {
 		return NULL;
 	}
 	// 攻撃開始
-	if (m_slashCnt == 0) {
+	if (m_slashCnt == 0 && m_bulletCnt == 0) {
 		m_attackLeftDirection = m_character_p->getCenterX() > gx;
 		m_slashCnt = m_character_p->getSlashCountSum();
-	}
-	if (m_slashCnt > 0) {
 		// 攻撃の方向へ向く
 		m_character_p->setLeftDirection(m_attackLeftDirection);
 	}

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -85,6 +85,53 @@ bool CharacterAction::ableDamage() const {
 	return true;
 }
 
+bool CharacterAction::ableAttack() const {
+	if (m_bulletCnt > 0 || m_slashCnt > 0) {
+		return false;
+	}
+	return true;
+}
+
+// 着地
+void CharacterAction::setGrand(bool grand) {
+	if (m_vy > 0) { // 着地モーションになる
+		m_landCnt = LAND_TIME;
+		m_slashCnt = 0;
+	}
+	m_grand = grand;
+	if (m_state == CHARACTER_STATE::DAMAGE && m_damageCnt == 0) {
+		m_vx = 0;
+		m_vy = 0;
+		m_state = CHARACTER_STATE::STAND;
+	}
+}
+
+void CharacterAction::setSquat(bool squat) {
+	if (squat && m_grand && m_state != CHARACTER_STATE::DAMAGE && m_state != CHARACTER_STATE::SLASH && m_state != CHARACTER_STATE::PREJUMP) {
+		m_squat = true;
+	}
+	else {
+		m_squat = false;
+	}
+}
+
+// 歩くのをやめる
+void CharacterAction::stopMoveLeft() {
+	// 左へ歩くのをやめる
+	if (m_moveLeft) {
+		m_vx += m_character_p->getMoveSpeed();
+		m_moveLeft = false;
+		m_runCnt = -1;
+	}
+}
+void CharacterAction::stopMoveRight() {
+	// 右へ歩くのをやめる
+	if (m_moveRight) {
+		m_vx -= m_character_p->getMoveSpeed();
+		m_moveRight = false;
+		m_runCnt = -1;
+	}
+}
 
 /*
 * 空を飛ばない普通の棒人間
@@ -107,29 +154,6 @@ void StickAction::init() {
 	m_grand = false;
 	m_grandRightSlope = false;
 	m_grandLeftSlope = false;
-}
-
-// 着地
-void CharacterAction::setGrand(bool grand) {
-	if (m_vy > 0) { // 着地モーションになる
-		m_landCnt = LAND_TIME;
-		m_slashCnt = 0;
-	}
-	m_grand = grand;
-	if (m_state == CHARACTER_STATE::DAMAGE && m_damageCnt == 0) { 
-		m_vx = 0;
-		m_vy = 0;
-		m_state = CHARACTER_STATE::STAND;
-	}
-}
-
-void CharacterAction::setSquat(bool squat) {
-	if (squat && m_grand && m_state != CHARACTER_STATE::DAMAGE && m_state != CHARACTER_STATE::SLASH && m_state != CHARACTER_STATE::PREJUMP) {
-		m_squat = true;
-	}
-	else {
-		m_squat = false;
-	}
 }
 
 void StickAction::action() {
@@ -206,7 +230,15 @@ void StickAction::switchHandle() {
 				m_character_p->switchSlash();
 			}
 			else if (m_bulletCnt > 0) {
-				m_character_p->switchBullet();
+				if (m_runCnt != -1) {
+					m_character_p->switchRunBullet(m_runCnt);
+				}
+				else if (m_squat) {
+					m_character_p->switchSquatBullet();
+				}
+				else {
+					m_character_p->switchBullet();
+				}
 			}
 			else if (m_squat) {
 				m_character_p->switchSquat();
@@ -221,19 +253,43 @@ void StickAction::switchHandle() {
 		case CHARACTER_STATE::PREJUMP:
 			m_character_p->switchPreJump(m_preJumpCnt);
 			break;
+		case CHARACTER_STATE::DAMAGE:
+			if (m_boostCnt > 0) {
+				if (m_slashCnt > 0) {
+					m_character_p->switchSlash();
+				}
+				else if (m_bulletCnt > 0) {
+					if (m_runCnt != -1) {
+						m_character_p->switchRunBullet(m_runCnt);
+					}
+					else if (m_squat) {
+						m_character_p->switchSquatBullet();
+					}
+					else {
+						m_character_p->switchBullet();
+					}
+				}
+				else {
+					m_character_p->switchBoost();
+				}
+			}
+			else {
+				m_character_p->switchDamage();
+			}
+			break;
 		}
 	}
 	else { // 宙にいるとき
 		switch (getState()) {
 		case CHARACTER_STATE::STAND: //立ち状態(なにもなしの状態)
-			if (m_slashCnt > 0) {
+			if (m_boostCnt > 0) {
+				m_character_p->switchBoost();
+			}
+			else if (m_slashCnt > 0) {
 				m_character_p->switchAirSlash();
 			}
 			else if (m_bulletCnt > 0) {
 				m_character_p->switchAirBullet();
-			}
-			else if (m_boostCnt > 0) {
-				m_character_p->switchBoost();
 			}
 			else if (m_vy < 0) {
 				m_character_p->switchJump();
@@ -243,7 +299,20 @@ void StickAction::switchHandle() {
 			}
 			break;
 		case CHARACTER_STATE::DAMAGE:
-			m_character_p->switchDamage();
+			if (m_boostCnt > 0) {
+				if (m_slashCnt > 0) {
+					m_character_p->switchAirSlash();
+				}
+				else if (m_bulletCnt > 0) {
+					m_character_p->switchAirBullet();
+				}
+				else {
+					m_character_p->switchBoost();
+				}
+			}
+			else {
+				m_character_p->switchDamage();
+			}
 			break;
 		}
 	}
@@ -315,16 +384,12 @@ void CharacterAction::afterChangeGraph(int beforeWide, int beforeHeight, int aft
 // 歩く ダメージ中、しゃがみ中、壁ぶつかり中は不可
 void StickAction::walk(bool right, bool left) {
 	// 右へ歩くのをやめる
-	if (m_moveRight && (!right || m_rightLock || m_squat || damageFlag())) {
-		m_vx -= m_character_p->getMoveSpeed();
-		m_moveRight = false;
-		m_runCnt = -1;
+	if (!right || m_rightLock || m_squat || damageFlag()) {
+		stopMoveRight();
 	}
 	// 左へ歩くのをやめる
-	if (m_moveLeft && (!left || m_leftLock || m_squat || damageFlag())) {
-		m_vx += m_character_p->getMoveSpeed();
-		m_moveLeft = false;
-		m_runCnt = -1;
+	if (!left || m_leftLock || m_squat || damageFlag()) {
+		stopMoveLeft();
 	}
 	if (damageFlag()) {
 		return;
@@ -362,8 +427,21 @@ void StickAction::move(bool right, bool left, bool up, bool down) {
 
 // ジャンプ
 void StickAction::jump(int cnt) {
+	// ダメージ状態ならジャンプできないためreturn
 	if (damageFlag()) {
-		m_bulletCnt = 0;
+		// 受け身はできる
+		if (cnt == 1 || m_boostCnt > 0) {
+			if (m_boostCnt == 0) {
+				// 受け身をした瞬間
+				m_vy -= m_character_p->getJumpHeight() / 2;
+				m_grand = false;
+				m_preJumpCnt = -1;
+				stopMoveLeft();
+				stopMoveRight();
+			}
+			// ダメージ状態が解除されるまではずっとBoost
+			m_boostCnt = BOOST_TIME;
+		}
 		return;
 	}
 	// 宙に浮いたらジャンプ中止
@@ -373,13 +451,14 @@ void StickAction::jump(int cnt) {
 			setState(CHARACTER_STATE::STAND);
 		}
 	}
-	// ジャンプ前の状態なら
+	// ジャンプの準備開始
 	if (cnt > 0 && m_grand && m_preJumpCnt == -1) {
 		m_preJumpCnt = 0;
 		setState(CHARACTER_STATE::PREJUMP);
 	}
 	if (m_grand && m_preJumpCnt >= 0) {
 		if (cnt == 0 || m_preJumpCnt == PRE_JUMP_MAX) {
+			// ジャンプ
 			int rate = (100 * m_preJumpCnt) / PRE_JUMP_MAX;
 			int power = (m_character_p->getJumpHeight() * rate) / 100;
 			m_vy -= power;
@@ -388,6 +467,7 @@ void StickAction::jump(int cnt) {
 			setState(CHARACTER_STATE::STAND);
 		}
 		else {
+			// ジャンプ前の溜め中
 			m_preJumpCnt++;
 		}
 	}
@@ -395,12 +475,12 @@ void StickAction::jump(int cnt) {
 
 // 射撃攻撃
 Object* StickAction::bulletAttack(int gx, int gy) {
-	if (damageFlag()) {
+	if (damageFlag() && m_boostCnt == 0) {
 		m_bulletCnt = 0;
 		return NULL;
 	}
 	// 射撃可能状態なら
-	if (m_bulletCnt == 0 && m_slashCnt == 0) {
+	if (ableAttack()) {
 		// 射撃不可能状態にして
 		m_bulletCnt = m_character_p->getBulletRapid();
 		// 撃つ方向へ向く
@@ -413,12 +493,12 @@ Object* StickAction::bulletAttack(int gx, int gy) {
 
 // 斬撃攻撃
 Object* StickAction::slashAttack(int gx, int gy) {
-	if (damageFlag()) {
+	if (damageFlag() && m_boostCnt == 0) {
 		m_slashCnt = 0;
 		return NULL;
 	}
 	// 攻撃開始
-	if (m_slashCnt == 0 && m_bulletCnt == 0) {
+	if (ableAttack()) {
 		m_attackLeftDirection = m_character_p->getCenterX() > gx;
 		m_slashCnt = m_character_p->getSlashCountSum();
 		// 攻撃の方向へ向く
@@ -428,6 +508,7 @@ Object* StickAction::slashAttack(int gx, int gy) {
 	return m_character_p->slashAttack(m_attackLeftDirection, m_slashCnt);
 }
 
+// ダメージを受ける
 void StickAction::damage(int vx, int vy, int damageValue, int soundHandle) {
 	setState(CHARACTER_STATE::DAMAGE);
 	m_vx += vx;
@@ -442,4 +523,5 @@ void StickAction::damage(int vx, int vy, int damageValue, int soundHandle) {
 	m_grandLeftSlope = false;
 	// HP減少
 	m_character_p->damageHp(damageValue);
+	m_boostCnt = 0;
 }

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -20,10 +20,10 @@ enum class CHARACTER_STATE {
 * Controllerが使用する。それ以外のインスタンスから使われることはない。
 */
 class CharacterAction {
-private:
+protected:
 	// キャラの状態
 	CHARACTER_STATE m_state;
-protected:
+
 	// 動かすキャラクター
 	Character* m_character_p;
 
@@ -54,6 +54,7 @@ protected:
 	// 着地モーションの総時間
 	const int LAND_TIME = 10;
 
+	// ブーストアニメの残り時間 または受け身状態
 	int m_boostCnt;
 	const int BOOST_TIME = 10;
 
@@ -155,6 +156,13 @@ public:
 
 	// 今無敵時間じゃない
 	bool ableDamage() const;
+
+	// 今攻撃可能状態
+	bool ableAttack() const;
+
+	// 歩くのをやめる
+	void stopMoveLeft();
+	void stopMoveRight();
 
 protected:
 	// 画像のサイズ変更による位置調整

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -101,6 +101,7 @@ public:
 	inline int getVx() const { return m_vx; }
 	inline int getVy() const { return m_vy; }
 	inline int getSlashCnt() const { return m_slashCnt; }
+	inline int getBulletCnt() const { return m_bulletCnt; }
 	bool getRightLock() const { return m_rightLock; }
 	bool getLeftLock() const { return m_leftLock; }
 	bool getUpLock() const { return m_upLock; }

--- a/Control.cpp
+++ b/Control.cpp
@@ -38,7 +38,7 @@ static int right_cnt = 0;
 void mouseClick() {
 	if ((GetMouseInput() & MOUSE_INPUT_LEFT) != 0) { left_cnt++; }
 	else { left_cnt = 0; }
-	if (GetMouseInput() == MOUSE_INPUT_RIGHT) { right_cnt++; }
+	if ((GetMouseInput() & MOUSE_INPUT_RIGHT) != 0) { right_cnt++; }
 	else { right_cnt = 0; }
 }
 int leftClick() {

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -85,7 +85,7 @@ void StickAction::debug(int x, int y, int color) const {
 // Characterクラスのデバッグ
 void Character::debugCharacter(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**Character**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "HP=%d/%d, (x,y)=(%d,%d), left=%d, id=%d, groupId=%d", m_hp, m_maxHp, m_x, m_y, m_leftDirection, m_id, m_groupId);
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "(x,y)=(%d,%d), left=%d, id=%d, groupId=%d", m_x, m_y, m_leftDirection, m_id, m_groupId);
 	// DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "(wide, height)=(%d,%d), handle=%d", m_wide, m_height, m_graphHandle->getHandle());
 	// 画像
 	// m_graphHandle->draw(GAME_WIDE - (m_wide / 2), (m_height / 2), m_graphHandle->getEx());

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -49,7 +49,8 @@ void World::debug(int x, int y, int color) const {
 // CharacterControllerクラスのデバッグ
 void CharacterController::debugController(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**CharacterController**");
-	m_characterAction->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE, color);
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "slashOrder=%d, slashCnt=%d, bulletOrder=%d, bulletCnt=%d", m_brain->slashOrder(), m_characterAction->getSlashCnt(), m_brain->bulletOrder(), m_characterAction->getBulletCnt());
+	m_characterAction->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 }
 
 // CharacterKeyboardControllerクラスのデバッグ

--- a/Define.h
+++ b/Define.h
@@ -6,9 +6,8 @@
 //画面の大きさ
 #define GAME_WIDE 1920
 #define GAME_HEIGHT 1080
-
-//キャラクターやオブジェクトの描画倍率
-const double EXTEND = 0.35;
+//#define GAME_WIDE 1240
+//#define GAME_HEIGHT 1024
 
 // DrawFormatString関数で表示される文字の大きさは20くらい
 #define DRAW_FORMAT_STRING_SIZE 20

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -134,9 +134,11 @@ CharacterGraphHandle::CharacterGraphHandle(const char* characterName, double dra
 	loadCharacterGraph(characterName, m_standHandles, "stand", data, m_ex);
 	loadCharacterGraph(characterName, m_slashHandles, "slashEffect", data, m_ex);
 	loadCharacterGraph(characterName, m_squatHandles, "squat", data, m_ex);
+	loadCharacterGraph(characterName, m_squatBulletHandles, "squatBullet", data, m_ex);
 	loadCharacterGraph(characterName, m_standBulletHandles, "standBullet", data, m_ex);
 	loadCharacterGraph(characterName, m_standSlashHandles, "standSlash", data, m_ex);
 	loadCharacterGraph(characterName, m_runHandles, "run", data, m_ex);
+	loadCharacterGraph(characterName, m_runBulletHandles, "runBullet", data, m_ex);
 	loadCharacterGraph(characterName, m_landHandles, "land", data, m_ex);
 	loadCharacterGraph(characterName, m_jumpHandles, "jump", data, m_ex);
 	loadCharacterGraph(characterName, m_downHandles, "down", data, m_ex);
@@ -153,9 +155,11 @@ CharacterGraphHandle::~CharacterGraphHandle() {
 	delete m_standHandles;
 	delete m_slashHandles;
 	delete m_squatHandles;
+	delete m_squatBulletHandles;
 	delete m_standBulletHandles;
 	delete m_standSlashHandles;
 	delete m_runHandles;
+	delete m_runBulletHandles;
 	delete m_landHandles;
 	delete m_jumpHandles;
 	delete m_downHandles;
@@ -197,9 +201,17 @@ void CharacterGraphHandle::switchSlash(int index){
 void CharacterGraphHandle::switchSquat(int index){
 	setGraph(m_squatHandles, index);
 }
+// しゃがみ射撃画像をセット
+void CharacterGraphHandle::switchSquatBullet(int index) {
+	setGraph(m_squatBulletHandles, index);
+}
 // 走り画像をセット
 void CharacterGraphHandle::switchRun(int index){
 	setGraph(m_runHandles, index);
+}
+// 走り射撃画像をセット
+void CharacterGraphHandle::switchRunBullet(int index) {
+	setGraph(m_runBulletHandles, index);
 }
 // 着地画像をセット
 void CharacterGraphHandle::switchLand(int index){

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -94,8 +94,11 @@ private:
 	// 立ち画像
 	GraphHandles* m_standHandles;
 
-	// しゃがみ
+	// しゃがみ画像
 	GraphHandles* m_squatHandles;
+
+	// しゃがみ射撃画像
+	GraphHandles* m_squatBulletHandles;
 
 	// 立ち射撃画像
 	GraphHandles* m_standBulletHandles;
@@ -105,6 +108,9 @@ private:
 
 	// 走り画像
 	GraphHandles* m_runHandles;
+
+	// 走り射撃画像
+	GraphHandles* m_runBulletHandles;
 
 	// 着地画像
 	GraphHandles* m_landHandles;
@@ -148,7 +154,9 @@ public:
 	inline GraphHandles* getStandBulletHandle() { return m_standBulletHandles; }
 	inline GraphHandles* getStandSlashHandle() { return m_standSlashHandles; }
 	inline GraphHandles* getSquatHandle() { return m_squatHandles; }
+	inline GraphHandles* getSquatBulletHandle() { return m_squatBulletHandles; }
 	inline GraphHandles* getRunHandle() { return m_runHandles; }
+	inline GraphHandles* getRunBulletHandle() { return m_runBulletHandles; }
 	inline GraphHandles* getLandHandle() { return m_landHandles; }
 	inline GraphHandles* getJumpHandle() { return m_jumpHandles; }
 	inline GraphHandles* getDownHandle() { return m_downHandles; }
@@ -172,8 +180,12 @@ public:
 	void switchSlash(int index = 0);
 	// しゃがみ画像をセット
 	void switchSquat(int index = 0);
+	// しゃがみ射撃画像をセット
+	void switchSquatBullet(int index = 0);
 	// 走り画像をセット
 	void switchRun(int index = 0);
+	// 走り射撃画像をセット
+	void switchRunBullet(int index = 0);
 	// 着地画像をセット
 	void switchLand(int index = 0);
 	// 上昇画像をセット

--- a/World.cpp
+++ b/World.cpp
@@ -90,9 +90,11 @@ World::World(int areaNum, SoundPlayer* soundPlayer) {
 	m_stageObjects.push_back(object7);
 	Object* object8 = new BoxObject(3000, 400, 3300, 600, WHITE);
 	m_stageObjects.push_back(object8);
+	Object* object9 = new BoxObject(-500, -1000, 10000, -900, WHITE);
+	m_stageObjects.push_back(object9);
 
 	// 主人公をロード キャラの削除はWorldがやる予定
-	Heart* heart = new Heart(100, 100, 0, 0, 0);
+	Heart* heart = new Heart(100, 0, 0, 0);
 	m_characters.push_back(heart);
 
 	// カメラを主人公注目、倍率1.0で作成
@@ -109,7 +111,7 @@ World::World(int areaNum, SoundPlayer* soundPlayer) {
 	// CPUをロード
 	for (int i = 0; i < 3; i++) {
 		// CPUをロード
-		Heart* cp = new Heart(100, 100, 2000 + 100*i, 0, 1);
+		Heart* cp = new Heart(100, 2000 + 100*i, 0, 1);
 		m_characters.push_back(cp);
 		//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
 		NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp));
@@ -117,7 +119,7 @@ World::World(int areaNum, SoundPlayer* soundPlayer) {
 	}
 	for (int i = 0; i < 2; i++) {
 		// CPUをロード
-		Heart* cp = new Heart(100, 100, 200 + 100 * i, 0, 0);
+		Heart* cp = new Heart(100, 200 + 100 * i, 0, 0);
 		m_characters.push_back(cp);
 		//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
 		NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp));


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
- A,Dキーが同時に押されたときの処理がいまいち（移動の向きと画像の向きが逆になるなど）だったので修正。

- 射撃中に斬撃を割り込ませることが可能だったため仕様変更。

- 走り射撃状態、しゃがみ射撃状態の画像を追加。本当に画像を追加しただけで実現した。

- 受け身機能実装！
  - ダメージ状態でジャンプキーを押すと受け身（boost状態）をとれる。
  - 受け身を取るとわずかに体が上昇する。
  - 受け身状態では攻撃が出せる。
  - ただしダメージ状態であることに変わりはない。ふっとびつづける。

- maxHpをCharacterクラスから削除。characterInfoから取ればいいので。

# やったこと
A,Dキーが同時に押されている場合、先に押した方が優先されるようにした。また、その状態から先に押している方を押すのをやめると、後に押している方が認識される。一方で後に押している方を押すのをやめても、先に押している方の認識は終わらない。

射撃中は斬撃ができない、斬撃中は射撃ができないようにした。

Action関連を大きく変更。攻撃可能状態かどうかをboolで返すメンバ関数を追加。
歩くことをやめる処理をstopMoveLeft, Right関数として分離。
jump関数に受け身の処理を追加。
switchHandle関数に受け身状態や走り射撃、しゃがみ射撃の分岐を追加。
ダメージを受けた時にboostCnt=0とする処理を追加。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
A,Dキーでの左右移動がより直感的にできるようになる。

# できなくなること(ユーザ目線)
射撃中に斬撃、斬撃中に射撃ができなくなる。より攻撃の方法を考える必要が出てくる。

# 動作確認
視覚的に確認。斬撃と射撃の命令についてはデバッグモードで値を確認した。

# 懸念点
歩きの処理が少しわかりにくい気がする。機能追加によってバグが生まれそう。

受け身状態、ジャンプ、着地には効果音が欲しい。
理想としては、SoundPlayerのポインタを受け取ったActionインスタンスのみが効果音を鳴らすようにする。

受け身状態の追加でバグが怖い。今のところ見られない。

AIはまだ受け身の命令をするようになっていない。しゃがみ射撃や走り射撃はすでにやっている。

