### PR TITLE
Api: オブジェクトの破壊機能実装＆斬撃の後隙追加

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -44,6 +44,7 @@ AttackInfo::AttackInfo(const char* characterName, double drawEx) {
 	map<string, string> data = reader.findOne("name", characterName);
 
 	// パラメータを設定
+	m_bulletHp = stoi(data["bulletHp"]);
 	m_bulletDamage = stoi(data["bulletDamage"]);
 	m_bulletRx = stoi(data["bulletRx"]);
 	m_bulletRy = stoi(data["bulletRy"]);
@@ -52,10 +53,12 @@ AttackInfo::AttackInfo(const char* characterName, double drawEx) {
 	m_bulletDistance = stoi(data["bulletDistance"]);
 	m_bulletImpactX = stoi(data["bulletImpactX"]);
 	m_bulletImpactY = stoi(data["bulletImpactY"]);
+	m_slashHp = stoi(data["slashHp"]);
 	m_slashDamage = stoi(data["slashDamage"]);
 	m_slashLenX = stoi(data["slashLenX"]);
 	m_slashLenY = stoi(data["slashLenY"]);
 	m_slashCountSum = stoi(data["slashCountSum"]);
+	m_slashInterval = stoi(data["slashInterval"]);
 	m_slashImpactX = stoi(data["slashImpactX"]);
 	m_slashImpactY = stoi(data["slashImpactY"]);
 
@@ -267,6 +270,7 @@ Object* Heart::slashAttack(bool leftDirection, int cnt) {
 	}
 
 	// 攻撃の画像と持続時間(cntを考慮して決定)
+	cnt -= m_attackInfo->slashInterval();
 	int index = 0;
 	int slashCountSum = m_attackInfo->slashCountSum() / 3 + 1;
 	SlashObject* attackObject = NULL;

--- a/Character.h
+++ b/Character.h
@@ -44,6 +44,9 @@ public:
 
 class AttackInfo {
 private:
+	// 弾丸のHP
+	int m_bulletHp;
+
 	// 弾丸のダメージ
 	int m_bulletDamage;
 
@@ -65,6 +68,9 @@ private:
 	// 弾丸の吹っ飛び(Y方向の初速)
 	int m_bulletImpactY;
 
+	// 斬撃のHP
+	int m_slashHp;
+
 	// 斬撃のダメージ
 	int m_slashDamage;
 
@@ -73,6 +79,9 @@ private:
 
 	// 斬撃の全体フレーム
 	int m_slashCountSum;
+
+	// 斬撃の後隙
+	int m_slashInterval;
 
 	// 斬撃の吹っ飛び(X方向の初速)
 	int m_slashImpactX;
@@ -101,6 +110,7 @@ public:
 	~AttackInfo();
 	
 	// ゲッタのみを持つ
+	int bulletHp() const { return m_bulletHp; }
 	int bulletDamage() const { return m_bulletDamage; }
 	int bulletRx() const { return m_bulletRx; }
 	int bulletRy() const { return m_bulletRy; }
@@ -109,10 +119,12 @@ public:
 	int bulletDistance() const { return m_bulletDistance; }
 	int bulletImpactX() const { return m_bulletImpactX; }
 	int bulletImpactY() const { return m_bulletImpactY; }
+	int slashHp() const { return m_slashHp; }
 	int slashDamage() const { return m_slashDamage; }
 	int slashLenX() const { return m_slashLenX; }
 	int slashLenY() const { return m_slashLenY; }
 	int slashCountSum() const { return m_slashCountSum; }
+	int slashInterval() const { return m_slashInterval; }
 	int slashImpactX() const { return m_slashImpactX; }
 	int slashImpactY() const { return m_slashImpactY; }
 	GraphHandles* bulletEffectHandle() const { return m_bulletEffectHandles; }
@@ -188,6 +200,7 @@ public:
 	// AttackInfoから攻撃のスペックを取得
 	inline int getBulletRapid() const { return m_attackInfo->bulletRapid(); }
 	inline int getSlashCountSum() const { return m_attackInfo->slashCountSum(); }
+	inline int getSlashInterval() const { return m_attackInfo->slashInterval(); }
 
 	// 画像の情報を取得
 	int getCenterX() const;

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -500,7 +500,7 @@ Object* StickAction::slashAttack(int gx, int gy) {
 	// UŒ‚ŠJŽn
 	if (ableAttack()) {
 		m_attackLeftDirection = m_character_p->getCenterX() > gx;
-		m_slashCnt = m_character_p->getSlashCountSum();
+		m_slashCnt = m_character_p->getSlashCountSum() + m_character_p->getSlashInterval();
 		// UŒ‚‚Ì•ûŒü‚ÖŒü‚­
 		m_character_p->setLeftDirection(m_attackLeftDirection);
 	}

--- a/World.h
+++ b/World.h
@@ -90,6 +90,8 @@ private:
 	// •Ç‚â°<->UŒ‚‚Ì“–‚½‚è”»’è
 	void atariStageAndAttack();
 
+	// UŒ‚<->UŒ‚‚Ì“–‚½‚è”»’è
+	void atariAttackAndAttack();
 };
 
 #endif


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
壁や床を攻撃で破壊できるようになる。
攻撃同士がぶつかると相殺orどちらかが一方的に破壊される。
斬撃攻撃に後隙ができた。

# やったこと
ObjectクラスにHPをメンバ変数として追加。
攻撃オブジェクトがぶつかるとHPが減り、0になると破壊される。
破壊不可能オブジェクトはHP=-1とする。
どちらかが破壊不可能オブジェクトなら、オブジェクト同士の当たりは起きない。
攻撃オブジェクト同士でも同様で、互いに破壊可能なら当たり判定が起きる。
攻撃オブジェクト同士なら互いにHPを減らし合う。そのため一方の攻撃力やHPが高いと一方が勝つ。当然相討ちもある。

斬撃攻撃の後隙はAttackInfo::slashIntervalとして扱う。

# やらないこと
攻撃が当たったオブジェクトは一定時間点滅するようにしたい。けどUI側の仕事。ダメージを食らったときに一定時間m_damageCntが1以上になる処理を追加したため、それを使って点滅させる予定。

# できるようになること(ユーザ目線)
破壊可能オブジェクトを、破壊可能攻撃で破壊できるようになる。
相手の破壊可能攻撃を、破壊可能攻撃で破壊できるようになる。
斬撃攻撃に後隙ができる。これによって連打すればよいわけではなくなる。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。

# 懸念点
斬撃攻撃の後隙の間も移動ができる。これは不自然？
