### PR TITLE
Ui: issues#24の解決＆ダメージを食らったときに点滅等をする処理の追加

### DIFF
--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -19,6 +19,7 @@ int CharacterDrawer::DAMAGE_COLOR = GetColor(255, 0, 0);
 
 CharacterDrawer::CharacterDrawer(const CharacterAction* const characterAction) {
 	m_characterAction = characterAction;
+	m_cnt = 0;
 }
 
 // キャラを描画する
@@ -42,7 +43,11 @@ void CharacterDrawer::drawCharacter(const Camera* const camera) {
 	camera->setCamera(&x, &y, &ex);
 
 	// 描画
+	if (m_characterAction->getState() == CHARACTER_STATE::DAMAGE && ++m_cnt / 2 % 2 == 1) {
+		SetDrawBright(100, 100, 100);
+	}
 	graphHandle->draw(x, y, ex);
+	SetDrawBright(255, 255, 255);
 
 	// 体力バーの座標をカメラで調整
 	x = character->getX() + (character->getWide() / 2);

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -15,6 +15,9 @@ private:
 	static int HP_COLOR;
 	static int DAMAGE_COLOR;
 
+	// “_–Å—p
+	int m_cnt;
+
 public:
 	CharacterDrawer(const CharacterAction* const characterAction);
 

--- a/Object.cpp
+++ b/Object.cpp
@@ -649,22 +649,42 @@ void SlashObject::action() {
 // 描画用
 // オブジェクト描画（画像がないときに使う）
 void BoxObject::drawObject(int x1, int y1, int x2, int y2) const {
-	DrawBox(x1, y1, x2, y2, m_color, TRUE);
+	if (m_damageCnt > 0) {
+		DrawBox(x1, y1, x2, y2, RED, TRUE);
+	}
+	else {
+		DrawBox(x1, y1, x2, y2, m_color, TRUE);
+	}
 }
 // オブジェクト描画（画像がないときに使う）
 void TriangleObject::drawObject(int x1, int y1, int x2, int y2) const {
 	if (m_leftDown) {
-		DrawTriangle(x2, y1, x2, y2, x1, y2, m_color, TRUE);
+		if (m_damageCnt > 0) {
+			DrawTriangle(x2, y1, x2, y2, x1, y2, RED, TRUE);
+		}
+		else {
+			DrawTriangle(x2, y1, x2, y2, x1, y2, m_color, TRUE);
+		}
 	}
 	else {
-		DrawTriangle(x1, y1, x2, y2, x1, y2, m_color, TRUE);
+		if (m_damageCnt > 0) {
+			DrawTriangle(x1, y1, x2, y2, x1, y2, RED, TRUE);
+		}
+		else {
+			DrawTriangle(x1, y1, x2, y2, x1, y2, m_color, TRUE);
+		}
 	}
 }
 // オブジェクト描画（画像がないときに使う）
 void BulletObject::drawObject(int x1, int y1, int x2, int y2) const {
 	int rx = abs(x2 - x1) / 2;
 	int ry = abs(y2 - y1) / 2;
-	DrawOval(x1 + rx, y1 + ry, rx, ry, m_color, TRUE);
+	if (m_damageCnt > 0) {
+		DrawOval(x1 + rx, y1 + ry, rx, ry, RED, TRUE);
+	}
+	else {
+		DrawOval(x1 + rx, y1 + ry, rx, ry, m_color, TRUE);
+	}
 }
 // オブジェクト描画（画像がないときに使う）
 void SlashObject::drawObject(int x1, int y1, int x2, int y2) const {

--- a/Object.h
+++ b/Object.h
@@ -25,7 +25,7 @@ protected:
 
 	// ダメージ状態（描画用）
 	int m_damageCnt;
-	const int DAMAGE_CNT_SUM = 30;
+	const int DAMAGE_CNT_SUM = 5;
 
 	// 削除フラグ trueならWorldに消してもらう
 	bool m_deleteFlag;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
キャラがダメージを食らったときに点滅する。
オブジェクトがダメージを受けると一定時間赤くなる。

# やったこと
キャラを点滅させるためにCharacterDrawerはCharacterActionの機能を使用する。
そのため、必然的にclose #24 。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
キャラやオブジェクトが攻撃を受けたことが分かりやすくなった（はず）。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。

# 懸念点
棒人間、体黒いから点滅分かりにくい！！
オブジェクトも赤色に光らせたが、他の色の方がいい？わからない。