### PR TITLE
Api: 攻撃オブジェクト同士の当たり判定調整＆効果音のパン設定＆ジャンプ、受け身、着地の効果音追加

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -28,6 +28,24 @@ CharacterInfo::CharacterInfo(const char* characterName) {
 	m_handleEx = stod(data["handleEx"]);
 	m_moveSpeed = stoi(data["moveSpeed"]);
 	m_jumpHeight = stoi(data["jumpHeight"]);
+
+	// 効果音をロード
+	string filePath = "sound/stick/";
+	string fileName;
+	fileName = filePath + data["jumpSound"];
+	m_jumpSound = LoadSoundMem(fileName.c_str());
+	fileName = filePath + data["passiveSound"];
+	m_passiveSound = LoadSoundMem(fileName.c_str());
+	fileName = filePath + data["landSound"];
+	m_landSound = LoadSoundMem(fileName.c_str());
+	fileName = filePath + data["runSound"];
+}
+
+CharacterInfo::~CharacterInfo() {
+	// サウンドを削除
+	DeleteSoundMem(m_jumpSound);
+	DeleteSoundMem(m_passiveSound);
+	DeleteSoundMem(m_landSound);
 }
 
 

--- a/Character.h
+++ b/Character.h
@@ -27,11 +27,22 @@ private:
 	// ジャンプ時のY方向の初速
 	int m_jumpHeight;
 
+	// ジャンプ時の音
+	int m_jumpSound;
+
+	// 受け身時の音
+	int m_passiveSound;
+
+	// 着地時の音
+	int m_landSound;
+
 public:
 	// デフォルト値で初期化
 	CharacterInfo();
 	// csvファイルを読み込み、キャラ名で検索しパラメータ取得
 	CharacterInfo(const char* characterName);
+
+	~CharacterInfo();
 
 	// ゲッタのみを持つ
 	inline std::string name() const { return m_name; }
@@ -39,6 +50,9 @@ public:
 	inline double handleEx() const { return m_handleEx; }
 	inline int moveSpeed() const { return m_moveSpeed; }
 	inline int jumpHeight() const { return m_jumpHeight; }
+	inline int jumpSound() const { return m_jumpSound; }
+	inline int passiveSound() const { return m_passiveSound; }
+	inline int landSound() const { return m_landSound; }
 };
 
 
@@ -196,6 +210,9 @@ public:
 	inline int getMoveSpeed() const { return m_characterInfo->moveSpeed(); }
 	inline int getJumpHeight() const { return m_characterInfo->jumpHeight(); }
 	inline std::string getName() const { return m_characterInfo->name(); }
+	inline int getJumpSound() const { return m_characterInfo->jumpSound(); }
+	inline int getPassiveSound() const { return m_characterInfo->passiveSound(); }
+	inline int getLandSound() const { return m_characterInfo->landSound(); }
 
 	// AttackInfoから攻撃のスペックを取得
 	inline int getBulletRapid() const { return m_attackInfo->bulletRapid(); }

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -3,6 +3,7 @@
 
 class Character;
 class Object;
+class SoundPlayer;
 
 
 // キャラクターの状態
@@ -21,6 +22,9 @@ enum class CHARACTER_STATE {
 */
 class CharacterAction {
 protected:
+	// サウンドプレイヤー
+	SoundPlayer* m_soundPlayer_p;
+
 	// キャラの状態
 	CHARACTER_STATE m_state;
 
@@ -87,7 +91,7 @@ protected:
 
 public:
 	CharacterAction();
-	CharacterAction(Character* character);
+	CharacterAction(Character* character, SoundPlayer* soundPlayer_p);
 
 	// デバッグ
 	void debugAction(int x, int y, int color) const;
@@ -152,7 +156,7 @@ public:
 	virtual Object* slashAttack(int gx, int gy) = 0;
 
 	// ダメージ
-	virtual void damage(int vx, int vy, int damageValue, int soundHandle) = 0;
+	virtual void damage(int vx, int vy, int damageValue) = 0;
 
 	// 今無敵時間じゃない
 	bool ableDamage() const;
@@ -188,7 +192,7 @@ private:
 	void switchHandle();
 
 public:
-	StickAction(Character* character);
+	StickAction(Character* character, SoundPlayer* soundPlayer_p);
 
 	void debug(int x, int y, int color) const;
 
@@ -211,7 +215,7 @@ public:
 	Object* slashAttack(int gx, int gy);
 
 	// ダメージ
-	void damage(int vx, int vy, int damageValue, int soundHandle);
+	void damage(int vx, int vy, int damageValue);
 };
 
 #endif

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -177,6 +177,8 @@ int NormalAI::squatOrder() {
 }
 
 int NormalAI::slashOrder() {
+	if (m_target_p == NULL) { return 0; }
+	// ‰“‹——£‚Ì“G‚É‚ÍŽaŒ‚‚µ‚È‚¢
 	if (m_target_p != NULL && abs(m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX()) > 500) {
 		return 0;
 	}
@@ -188,6 +190,7 @@ int NormalAI::slashOrder() {
 }
 
 int NormalAI::bulletOrder() {
+	if (m_target_p == NULL) { return 0; }
 	// ƒ‰ƒ“ƒ_ƒ€‚ÅŽËŒ‚
 	if (GetRand(50) == 0) { 
 		return 1;
@@ -343,6 +346,6 @@ Object* NormalController::slashAttack() {
 	return NULL;
 }
 
-void NormalController::damage(int vx, int vy, int damageValue, int soundHandle) {
-	m_characterAction->damage(vx, vy, damageValue, soundHandle);
+void NormalController::damage(int vx, int vy, int damageValue) {
+	m_characterAction->damage(vx, vy, damageValue);
 }

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -177,7 +177,7 @@ public:
 	virtual Object* slashAttack() = 0;
 
 	// ダメージ
-	virtual void damage(int vx, int vy, int damageValue, int soundHandle) = 0;
+	virtual void damage(int vx, int vy, int damageValue) = 0;
 };
 
 /*
@@ -204,7 +204,7 @@ public:
 	Object* slashAttack();
 
 	// ダメ―ジ
-	void damage(int vx, int vy, int damageValue, int soundHandle);
+	void damage(int vx, int vy, int damageValue);
 };
 
 #endif

--- a/Object.cpp
+++ b/Object.cpp
@@ -511,7 +511,7 @@ bool BulletObject::atari(CharacterController* characterController) {
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2 && characterController->getAction()->ableDamage()) {
 		// 貫通弾じゃないなら消滅
 		m_deleteFlag = true;
-		characterController->damage(m_vx / 2, m_vy / 2, m_damage, -1);
+		characterController->damage(m_vx / 2, m_vy / 2, m_damage);
 		return true;
 	}
 	return false;
@@ -520,7 +520,9 @@ bool BulletObject::atari(CharacterController* characterController) {
 // 他攻撃オブジェクトとの当たり判定
 bool BulletObject::atariObject(Object* object) {
 	// どちらかが破壊不能オブジェクト
-	if (!object->getAbleDelete() || !getAbleDelete()) { return false; }
+	if (!object->getAbleDelete() || !getAbleDelete() || m_groupId == object->getGroupId()) { 
+		return false;
+	}
 	// 当たっているなら
 	if (m_x2 > object->getX1() && m_x1 < object->getX2() && m_y2 > object->getY1() && m_y1 < object->getY2()) {
 		object->decreaseHp(m_damage);
@@ -611,10 +613,10 @@ bool SlashObject::atari(CharacterController* characterController) {
 		// 貫通弾じゃないなら消滅
 		 // m_deleteFlag = true;
 		if (characterX1 + characterX2 < m_x1 + m_x2) {
-			characterController->damage(-m_slashImpactX, -m_slashImpactY, m_damage, -1);
+			characterController->damage(-m_slashImpactX, -m_slashImpactY, m_damage);
 		}
 		else {
-			characterController->damage(m_slashImpactX, -m_slashImpactY, m_damage, -1);
+			characterController->damage(m_slashImpactX, -m_slashImpactY, m_damage);
 		}
 		return true;
 	}
@@ -624,7 +626,9 @@ bool SlashObject::atari(CharacterController* characterController) {
 // 他攻撃オブジェクトとの当たり判定
 bool SlashObject::atariObject(Object* object) {
 	// どちらかが破壊不能オブジェクト
-	if (!object->getAbleDelete() || !getAbleDelete()) { return false; }
+	if (!object->getAbleDelete() || !getAbleDelete() || m_groupId == object->getGroupId()) {
+		return false;
+	}
 	// 当たっているなら
 	if (m_x2 > object->getX1() && m_x1 < object->getX2() && m_y2 > object->getY1() && m_y1 < object->getY2()) {
 		object->decreaseHp(m_damage);

--- a/Object.h
+++ b/Object.h
@@ -55,6 +55,7 @@ public:
 	inline int getSoundHandle() const { return m_soundHandle_p; }
 	inline int getHp() const { return m_hp; }
 	inline int getDamageCnt() const { return m_damageCnt; }
+	virtual inline int getGroupId() const { return -1; }
 
 	// 攻撃力 攻撃オブジェクト用
 	virtual inline int getDamage() const { return 0; }
@@ -205,6 +206,9 @@ public:
 	// オブジェクト描画（画像がないときに使う）
 	void drawObject(int x1, int y1, int x2, int y2) const;
 
+	// ゲッタ
+	inline int getGroupId() const { return m_groupId; }
+
 	// セッタ
 	// キャラクターIDをセット
 	inline void setCharacterId(int id) { m_characterId = id; }
@@ -271,6 +275,9 @@ public:
 
 	// 画像を返す　ないならNULL
 	GraphHandle* getHandle() const { return m_handle; }
+
+	// ゲッタ
+	inline int getGroupId() const { return m_groupId; }
 
 	// オブジェクト描画（画像がないときに使う）
 	void drawObject(int x1, int y1, int x2, int y2) const;

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -1,4 +1,5 @@
 #include "Sound.h"
+#include "Define.h"
 #include "DxLib.h"
 #include <algorithm>
 
@@ -6,8 +7,23 @@ using namespace std;
 
 
 // 音量調節
-void changeSoundVolume(int soundHandle, int volume) {
+void changeSoundVolume(int volume, int soundHandle) {
 	ChangeVolumeSoundMem(255 * (volume) / 100, soundHandle);
+}
+
+// カメラのパンを調整する。
+int adjustPanSound(int x, int cameraX) {
+	int d = x - cameraX;
+	int panPal = 0;
+	if (d > 0) { // 右で音が鳴る
+		panPal = 255 * d / (GAME_WIDE / 2);
+		panPal = min(panPal, 255);
+	}
+	else {
+		panPal = 255 * d / (GAME_WIDE / 2);
+		panPal = max(panPal, -255);
+	}
+	return panPal;
 }
 
 
@@ -15,7 +31,7 @@ SoundPlayer::SoundPlayer() {
 	m_volume = 50;
 	m_bgmName = "";
 	m_bgmHandle = -1;
-
+	m_cameraX = 0;
 }
 
 SoundPlayer::~SoundPlayer() {
@@ -49,16 +65,17 @@ void SoundPlayer::stopBGM() {
 }
 
 // 効果音の再生待機列へプッシュ
-void SoundPlayer::pushSoundQueue(int soundHandle) {
-	m_soundQueue.push(soundHandle);
+void SoundPlayer::pushSoundQueue(int soundHandle, int panPal) {
+	m_soundQueue.push(make_pair(soundHandle, panPal));
 }
 
 // 効果音を鳴らす
 void SoundPlayer::play() {
 	while (!m_soundQueue.empty()) {
-		int handle = m_soundQueue.front();
-		m_soundQueue.pop();
-		changeSoundVolume(handle, m_volume);
+		int handle = m_soundQueue.front().first;
+		changeSoundVolume(m_volume, handle);
+		ChangeNextPlayPanSoundMem(m_soundQueue.front().second, handle);
 		PlaySoundMem(handle, DX_PLAYTYPE_BACK);
+		m_soundQueue.pop();
 	}
 }

--- a/Sound.h
+++ b/Sound.h
@@ -4,8 +4,14 @@
 #include <queue>
 #include <string>
 
+// カメラのパンを調整する用
+int adjustPanSound(int x, int cameraX);
+
 class SoundPlayer {
 private:
+	// 座標 パンの設定に使う
+	int m_cameraX;
+
 	// 音量
 	int m_volume;
 
@@ -16,7 +22,7 @@ private:
 	int m_bgmHandle;
 
 	// 再生予定の効果音
-	std::queue<int> m_soundQueue;
+	std::queue<std::pair<int, int> > m_soundQueue;
 
 public:
 	SoundPlayer();
@@ -24,6 +30,8 @@ public:
 
 	void setVolume(int volume);
 	inline int getVolume() const { return m_volume; }
+	inline int getCameraX() const { return m_cameraX; }
+	inline void setCameraX(int cameraX) { m_cameraX = cameraX; }
 
 	// BGMをセット（変更）
 	void setBGM(std::string bgmName);
@@ -38,7 +46,7 @@ public:
 	void stopBGM();
 
 	// 効果音の再生待機列へプッシュ
-	void pushSoundQueue(int soundHandle);
+	void pushSoundQueue(int soundHandle, int panPal = 0);
 
 	// 効果音を鳴らす
 	void play();

--- a/World.cpp
+++ b/World.cpp
@@ -105,24 +105,24 @@ World::World(int areaNum, SoundPlayer* soundPlayer) {
 	updateCamera();
 
 	//主人公のコントローラ作成 BrainとActionの削除はControllerがやる。
-	NormalController* heartController = new NormalController(new KeyboardBrain(m_camera), new StickAction(heart));
+	NormalController* heartController = new NormalController(new KeyboardBrain(m_camera), new StickAction(heart, m_soundPlayer_p));
 	m_characterControllers.push_back(heartController);
 
 	// CPUをロード
-	for (int i = 0; i < 1; i++) {
+	for (int i = 0; i < 3; i++) {
 		// CPUをロード
 		Heart* cp = new Heart(100, 2000 + 100*i, 0, 1);
 		m_characters.push_back(cp);
 		//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
-		NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp));
+		NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp, NULL));
 		m_characterControllers.push_back(cpController);
 	}
-	for (int i = 0; i < 0; i++) {
+	for (int i = 0; i < 2; i++) {
 		// CPUをロード
 		Heart* cp = new Heart(100, 200 + 100 * i, 0, 0);
 		m_characters.push_back(cp);
 		//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
-		NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp));
+		NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp, NULL));
 		m_characterControllers.push_back(cpController);
 	}
 	
@@ -193,6 +193,9 @@ void World::battle() {
 
 	// カメラの更新
 	updateCamera();
+
+	// サウンドプレイヤーのパン設定用
+	m_soundPlayer_p->setCameraX(m_camera->getX());
 
 	// アニメーションの更新
 	updateAnimation();
@@ -282,7 +285,9 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 			int x = controller->getAction()->getCharacter()->getCenterX();
 			int y = controller->getAction()->getCharacter()->getCenterY();
 			m_animations.push_back(objects[i]->createAnimation(x, y, 3));
-			m_soundPlayer_p->pushSoundQueue(objects[i]->getSoundHandle());
+			int soundHandle = objects[i]->getSoundHandle();
+			int panPal = adjustPanSound(x, m_camera->getX());
+			m_soundPlayer_p->pushSoundQueue(soundHandle, panPal);
 		}
 		// deleteFlagがtrueなら削除する
 		if (objects[i]->getDeleteFlag()) {
@@ -351,7 +356,9 @@ void World::atariStageAndAttack() {
 				int x = m_attackObjects[i]->getCenterX();
 				int y = m_attackObjects[i]->getCenterY();
 				m_animations.push_back(m_attackObjects[i]->createAnimation(x, y, 3));
-				m_soundPlayer_p->pushSoundQueue(m_attackObjects[i]->getSoundHandle());
+				int soundHandle = m_attackObjects[i]->getSoundHandle();
+				int panPal = adjustPanSound(x, m_camera->getX());
+				m_soundPlayer_p->pushSoundQueue(soundHandle, panPal);
 			}
 			// 壁床のdeleteFlagがtrueなら削除する
 			if (m_stageObjects[j]->getDeleteFlag()) {
@@ -382,7 +389,9 @@ void World::atariAttackAndAttack() {
 				int x = m_attackObjects[i]->getCenterX();
 				int y = m_attackObjects[i]->getCenterY();
 				m_animations.push_back(m_attackObjects[j]->createAnimation(x, y, 3));
-				m_soundPlayer_p->pushSoundQueue(m_attackObjects[i]->getSoundHandle());
+				int soundHandle = m_attackObjects[i]->getSoundHandle();
+				int panPal = adjustPanSound(x, m_camera->getX());
+				m_soundPlayer_p->pushSoundQueue(soundHandle, panPal);
 			}
 		}
 	}


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
攻撃オブジェクト同士の当たり判定で、味方同士なら当たらないように変更。
画面の右側で起きた音なら、右から効果音が聞こえるようになる。（左も同様）
ジャンプ、受け身、着地時に効果音が鳴る。（自分が操作しているキャラのみ）

# やったこと
攻撃オブジェクト同士の当たり判定に条件追加。

画面の中心からの距離を用いて左右の音の比率を計算し、SoundPlayerに設定する処理を追加。

CharacterInfoに効果音の情報を追加し、それを引っ張ってきてCharacterActionが効果音をキューに入れる。

# やらないこと
走り始めた時の効果音も追加したが、ジャマだったので除去。

# できるようになること(ユーザ目線)
より細かい音が提供され、臨場感が増す（はず）。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
デバッグモードで数値を見てパン設定の数値は間違っていないことを確認。
あとは自分の耳で聞いて確認。

# 懸念点
CharacterActionのコードがだいぶ汚くなってきた。
