### PR TITLE
Api: エリア読み込み機能の実装

### DIFF
--- a/Camera.cpp
+++ b/Camera.cpp
@@ -15,7 +15,7 @@ Camera::Camera(int x, int y, double ex, int speed) {
 	m_gy = y;
 	m_ex = ex;
 	m_speed = 1;
-	m_maxSpeed = speed;
+	m_maxSpeed = speed == 0 ? CAMERA_SPEED_DEFAULT : speed;
 	m_centerX = GAME_WIDE / 2;
 	m_centerY = GAME_HEIGHT / 2;
 }

--- a/Camera.h
+++ b/Camera.h
@@ -4,6 +4,9 @@
 
 class Camera {
 private:
+	// カメラの移動速度の初期値
+	const int CAMERA_SPEED_DEFAULT = 5;
+
 	// カメラの座標(画面の中心)
 	int m_x, m_y;
 
@@ -22,7 +25,7 @@ private:
 
 public:
 	Camera();
-	Camera(int x, int y, double ex, int speed);
+	Camera(int x, int y, double ex, int speed=0);
 
 	// ゲッタとセッタ
 	inline void getPoint(int* x, int* y) { *x = m_x; *y = m_y; }

--- a/Character.cpp
+++ b/Character.cpp
@@ -224,20 +224,21 @@ void Character::switchAirSlash(int cnt) { m_graphHandle->switchAirSlash(); }
 /*
 * ハート
 */
-Heart::Heart(int hp, int x, int y, int groupId) :
+Heart::Heart(const char* name, int hp, int x, int y, int groupId) :
 	Character(hp, x, y, groupId)
 {
 	// キャラ固有の情報設定
-	m_characterInfo = new CharacterInfo(NAME);
-	m_attackInfo = new AttackInfo(NAME, m_characterInfo->handleEx());
+	m_characterInfo = new CharacterInfo(name);
+	m_attackInfo = new AttackInfo(name, m_characterInfo->handleEx());
 
 	m_hp = m_characterInfo->maxHp();
 
 	// 各画像のロード
-	m_graphHandle = new CharacterGraphHandle(NAME, m_characterInfo->handleEx());
+	m_graphHandle = new CharacterGraphHandle(name, m_characterInfo->handleEx());
 
 	// とりあえず立ち画像でスタート
 	switchStand();
+	m_y -= getHeight();
 }
 
 // デストラクタ

--- a/Character.h
+++ b/Character.h
@@ -192,14 +192,12 @@ public:
 	// ゲッタ
 	inline int getId() const { return m_id; }
 	inline int getGroupId() const { return m_groupId; }
-	inline int getMaxHp() const { return m_characterInfo->maxHp(); }
 	inline int getHp() const { return m_hp; }
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline bool getLeftDirection() const { return m_leftDirection; }
 
 	// セッタ
-	//inline void setMaxHp(int maxHp) { m_maxHp = maxHp; }
 	inline void setHp(int hp) { m_hp = (hp > m_characterInfo->maxHp()) ? m_characterInfo->maxHp() : hp; }
 	inline void setX(int x) { m_x = x; }
 	inline void setY(int y) { m_y = y; }
@@ -207,9 +205,10 @@ public:
 	void setLeftDirection(bool leftDirection);
 
 	// CharacterInfoからキャラのスペックを取得
+	inline std::string getName() const { return m_characterInfo->name(); }
+	inline int getMaxHp() const { return m_characterInfo->maxHp(); }
 	inline int getMoveSpeed() const { return m_characterInfo->moveSpeed(); }
 	inline int getJumpHeight() const { return m_characterInfo->jumpHeight(); }
-	inline std::string getName() const { return m_characterInfo->name(); }
 	inline int getJumpSound() const { return m_characterInfo->jumpSound(); }
 	inline int getPassiveSound() const { return m_characterInfo->passiveSound(); }
 	inline int getLandSound() const { return m_characterInfo->landSound(); }
@@ -283,9 +282,6 @@ class Heart :
 	public Character
 {
 private:
-	// キャラの名前
-	const char* const NAME = "ハート";
-
 	//// 走りアニメのスピード
 	const int RUN_ANIME_SPEED = 6;
 	
@@ -294,7 +290,7 @@ private:
 	
 public:
 	// コンストラクタ
-	Heart(int hp, int x, int y, int groupId);
+	Heart(const char* name, int hp, int x, int y, int groupId);
 
 	// デストラクタ
 	~Heart();

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -177,7 +177,9 @@ int NormalAI::squatOrder() {
 }
 
 int NormalAI::slashOrder() {
-	if (m_target_p == NULL) { return 0; }
+	if (m_target_p == NULL || m_target_p->getHp() == 0) {
+		return 0;
+	}
 	// ‰“‹——£‚Ì“G‚É‚ÍŽaŒ‚‚µ‚È‚¢
 	if (m_target_p != NULL && abs(m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX()) > 500) {
 		return 0;
@@ -190,7 +192,9 @@ int NormalAI::slashOrder() {
 }
 
 int NormalAI::bulletOrder() {
-	if (m_target_p == NULL) { return 0; }
+	if (m_target_p == NULL || m_target_p->getHp() == 0) { 
+		return 0;
+	}
 	// ƒ‰ƒ“ƒ_ƒ€‚ÅŽËŒ‚
 	if (GetRand(50) == 0) { 
 		return 1;

--- a/CsvReader.h
+++ b/CsvReader.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <sstream>
 
 class CsvReader {
 private:
@@ -32,6 +33,82 @@ public:
 	* 全データを返す
 	*/
 	std::vector<std::map<std::string, std::string> > getData() const;
+};
+
+
+class Character;
+class CharacterController;
+class Object;
+class SoundPlayer;
+class Camera;
+
+class AreaReader {
+private:
+	// アクション作成する用
+	SoundPlayer* m_soundPlayer_p;
+
+	// カメラはこのクラスで作成する
+	Camera* m_camera_p;
+
+	// 今カメラで見ているキャラ
+	int m_focusId;
+
+	// プレイヤーが操作するキャラ
+	int m_playerId;
+
+	// BGM
+	std::string m_bgmName;
+	int m_bgmVolume;
+
+	// キャラクター
+	std::vector<Character*> m_characters;
+
+	// コントローラ
+	std::vector<CharacterController*> m_characterControllers;
+
+	// オブジェクト
+	std::vector<Object*> m_objects;
+
+	// 背景画像と色
+	int m_backGroundGraph, m_backGroundColor;
+
+	enum class LOAD_AREA {
+		BGM,
+		CHARACTER,
+		OBJECT,
+		BACKGROUND
+	};
+
+public:
+	AreaReader(int m_areaNum, SoundPlayer* soundPlayer);
+
+	inline Camera* getCamera() const { return m_camera_p; }
+
+	inline int getFocusId() const { return m_focusId; }
+
+	inline int getPlayerId() const { return m_playerId; }
+
+	inline std::string getBgm() const { return m_bgmName; }
+
+	inline int getBgmVolume() const { return m_bgmVolume; }
+
+	inline std::vector<Character*> getCharacters() const { return m_characters; }
+
+	inline std::vector<CharacterController*> getCharacterControllers() const { return m_characterControllers; }
+
+	inline std::vector<Object*> getObjects() const { return m_objects; }
+
+	inline void getBackGround(int& graphHandle, int& colorHandle) const {
+		graphHandle = m_backGroundGraph;
+		colorHandle = m_backGroundColor;
+	}
+
+private:
+	void map2instance(std::map<std::string, std::string> dataMap, LOAD_AREA now);
+	void loadBGM(std::map<std::string, std::string> dataMap);
+	void loadCharacter(std::map<std::string, std::string> dataMap);
+	void loadObject(std::map<std::string, std::string> dataMap);
+	void loadBackGround(std::map<std::string, std::string> dataMap);
 };
 
 #endif

--- a/Define.h
+++ b/Define.h
@@ -18,5 +18,6 @@ const int GRAY = GetColor(100, 100, 100);
 const int GRAY2 = GetColor(200, 200, 200);
 const int WHITE = GetColor(255, 255, 255);
 const int RED = GetColor(255, 0, 0);
+const int LIGHT_BLUE = GetColor(100, 100, 255);
 
 #endif

--- a/Game.cpp
+++ b/Game.cpp
@@ -4,8 +4,57 @@
 #include "Sound.h"
 #include "DxLib.h"
 
+/*
+* キャラのデータ
+*/
+CharacterData::CharacterData(const char* name) {
+	m_name = name;
+	m_hp = -1;
+}
 
+
+/*
+* ゲームのセーブデータ
+*/
+// 初期状態のデータを作成
+GameData::GameData() {
+	m_saveFilePath = "data/save/savedata1.dat";
+
+	// 主要キャラを設定
+	m_characterData.push_back("ハート");
+
+}
+
+// ファイルを指定してデータを復元
+GameData::GameData(const char* saveFilePath):
+	GameData()
+{
+	m_saveFilePath = saveFilePath;
+	// セーブデータを読み込んで初期状態のデータを上書き
+
+}
+
+void GameData::asignWorld(World* world) {
+	size_t size = m_characterData.size();
+	for (unsigned int i = 0; i < size; i++) {
+		int hp = m_characterData[i].hp();
+		if (hp == -1) { continue; }
+		world->asignedCharacterData(m_characterData[i].name(), hp);
+	}
+}
+
+void GameData::asignedWorld(World* world) {
+
+}
+
+
+/*
+* ゲーム本体
+*/
 Game::Game() {
+	// データ
+	m_gameData = new GameData();
+
 	// サウンドプレイヤー
 	m_soundPlayer = new SoundPlayer();
 	m_soundPlayer->setVolume(50);
@@ -13,6 +62,9 @@ Game::Game() {
 	// 世界
 	int startAreaNum = 0;
 	m_world = new World(startAreaNum, m_soundPlayer);
+
+	// データを世界に反映
+	m_gameData->asignWorld(m_world);
 }
 
 Game::~Game() {

--- a/Game.h
+++ b/Game.h
@@ -1,16 +1,58 @@
 #ifndef GAME_H_INCLUDED
 #define GAME_H_INCLUDED
 
+#include <vector>
 
 class SoundPlayer;
 class World;
 
 
+// キャラのセーブデータ
+class CharacterData {
+private:
+	const char* m_name;
+	int m_hp;
+public:
+	CharacterData(const char* name);
+
+	// ゲッタ
+	inline const char* name() const { return m_name; }
+	inline int hp() const { return m_hp; }
+
+	// セッタ
+	inline void setHp(int hp) { m_hp = hp; }
+};
+
+
+// セーブデータ
+class GameData {
+private:
+	// セーブする場所
+	const char* m_saveFilePath;
+
+	// キャラのデータ
+	std::vector<CharacterData> m_characterData;
+
+public:
+	GameData();
+	GameData(const char* saveFilePath);
+
+	// 自身のデータをWorldにデータ反映させる
+	void asignWorld(World* world);
+
+	// Worldのデータを自身に反映させる
+	void asignedWorld(World* world);
+};
+
+
 class Game {
 private:
+	GameData* m_gameData;
+
 	// サウンドプレイヤー
 	SoundPlayer* m_soundPlayer;
 
+	// 世界
 	World* m_world;
 
 public:

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -47,11 +47,13 @@ void SoundPlayer::setVolume(int volume) {
 }
 
 // BGMをセット（変更）
-void SoundPlayer::setBGM(std::string bgmName) {
+void SoundPlayer::setBGM(std::string bgmName, int volume) {
+	if (bgmName == m_bgmName) { return; }
+	if (m_bgmHandle != -1) { DeleteSoundMem(m_bgmHandle); }
 	m_bgmName = bgmName;
 	m_bgmHandle = LoadSoundMem(bgmName.c_str());
 	// 音量調整
-	changeSoundVolume(m_bgmHandle, m_volume);
+	changeSoundVolume(m_volume * volume / 100, m_bgmHandle);
 }
 
 // BGMを再生

--- a/Sound.h
+++ b/Sound.h
@@ -34,7 +34,7 @@ public:
 	inline void setCameraX(int cameraX) { m_cameraX = cameraX; }
 
 	// BGMをセット（変更）
-	void setBGM(std::string bgmName);
+	void setBGM(std::string bgmName, int volume = 100);
 
 	// 今流している音楽をチェックする
 	inline bool sameBGM(std::string bgmName) const { return m_bgmName == bgmName; }

--- a/World.cpp
+++ b/World.cpp
@@ -6,6 +6,7 @@
 #include "Camera.h"
 #include "Animation.h"
 #include "Sound.h"
+#include "CsvReader.h"
 #include "Define.h"
 #include "DxLib.h"
 #include <algorithm>
@@ -73,59 +74,18 @@ World::World(int areaNum, SoundPlayer* soundPlayer) {
 	// 主人公のスタート地点
 	m_areaNum = areaNum;
 
-	// エリアに存在するオブジェクトをロード
-	Object* object1 = new BoxObject(-500, 900, 10000, 1080, WHITE);
-	m_stageObjects.push_back(object1);
-	Object* object2 = new TriangleObject(700, 600, 1300, 900, WHITE, false, 100);
-	m_stageObjects.push_back(object2);
-	Object* object3 = new BoxObject(300, 600, 700, 900, WHITE, 100);
-	m_stageObjects.push_back(object3);
-	Object* object4 = new TriangleObject(2000, 600, 2600, 900, WHITE, true);
-	m_stageObjects.push_back(object4);
-	Object* object5 = new BoxObject(2600, 600, 4000, 900, WHITE);
-	m_stageObjects.push_back(object5);
-	Object* object6 = new BoxObject(-500, -1000, -400, 1080, WHITE);
-	m_stageObjects.push_back(object6);
-	Object* object7 = new BoxObject(5000, -1000, 5100, 1080, WHITE);
-	m_stageObjects.push_back(object7);
-	Object* object8 = new BoxObject(3000, 400, 3300, 600, WHITE);
-	m_stageObjects.push_back(object8);
-	Object* object9 = new BoxObject(-500, -1000, 10000, -900, WHITE);
-	m_stageObjects.push_back(object9);
-
-	// 主人公をロード キャラの削除はWorldがやる予定
-	Heart* heart = new Heart(100, 0, 0, 0);
-	m_characters.push_back(heart);
-
-	// カメラを主人公注目、倍率1.0で作成
-	m_playerId = heart->getId();
-	m_focusId = m_playerId;
-	m_camera = new Camera(0, 0, 1.0, CAMERA_SPEED_DEFAULT);
-	m_camera->setPoint(heart->getCenterX(), heart->getCenterY());
-	updateCamera();
-
-	//主人公のコントローラ作成 BrainとActionの削除はControllerがやる。
-	NormalController* heartController = new NormalController(new KeyboardBrain(m_camera), new StickAction(heart, m_soundPlayer_p));
-	m_characterControllers.push_back(heartController);
-
-	// CPUをロード
-	for (int i = 0; i < 3; i++) {
-		// CPUをロード
-		Heart* cp = new Heart(100, 2000 + 100*i, 0, 1);
-		m_characters.push_back(cp);
-		//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
-		NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp, NULL));
-		m_characterControllers.push_back(cpController);
-	}
-	for (int i = 0; i < 2; i++) {
-		// CPUをロード
-		Heart* cp = new Heart(100, 200 + 100 * i, 0, 0);
-		m_characters.push_back(cp);
-		//CPUのコントローラ作成 BrainとActionの削除はControllerがやる。
-		NormalController* cpController = new NormalController(new NormalAI(), new StickAction(cp, NULL));
-		m_characterControllers.push_back(cpController);
-	}
+	// エリアをロード
+	const AreaReader data(areaNum, m_soundPlayer_p);
+	m_camera = data.getCamera();
+	m_focusId = data.getFocusId();
+	m_playerId = data.getPlayerId();
+	m_soundPlayer_p->setBGM(data.getBgm(), data.getBgmVolume());
+	m_characters = data.getCharacters();
+	m_characterControllers = data.getCharacterControllers();
+	m_stageObjects = data.getObjects();
+	data.getBackGround(m_backGroundGraph, m_backGroundColor);
 	
+	m_soundPlayer_p->playBGM();
 }
 
 World::~World() {

--- a/World.cpp
+++ b/World.cpp
@@ -85,6 +85,7 @@ World::World(int areaNum, SoundPlayer* soundPlayer) {
 	m_stageObjects = data.getObjects();
 	data.getBackGround(m_backGroundGraph, m_backGroundColor);
 	
+	// BGM再生
 	m_soundPlayer_p->playBGM();
 }
 
@@ -99,6 +100,27 @@ World::~World() {
 	// 全コントローラを削除する。
 	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
 		delete m_characterControllers[i];
+	}
+}
+
+// キャラの状態を変更する
+void World::asignedCharacterData(const char* name, int hp) {
+	size_t size = m_characters.size();
+	for (unsigned i = 0; i < size; i++) {
+		if (name == m_characters[i]->getName()) {
+			m_characters[i]->setHp(hp);
+		}
+	}
+}
+
+// キャラの状態を教える
+void World::asignCharacterData(const char* name, int& hp) {
+	size_t size = m_characters.size();
+	for (unsigned i = 0; i < size; i++) {
+		if (name == m_characters[i]->getName()) {
+			hp = m_characters[i]->getHp();
+			return;
+		}
 	}
 }
 

--- a/World.h
+++ b/World.h
@@ -16,9 +16,6 @@ private:
 	// サウンドプレイヤー
 	SoundPlayer* m_soundPlayer_p;
 
-	// カメラの移動速度の初期値
-	const int CAMERA_SPEED_DEFAULT = 5;
-
 	// カメラで見ているキャラのID
 	int m_focusId;
 
@@ -46,6 +43,10 @@ private:
 	// エフェクト等のアニメーション Worldがデリートする
 	std::vector<Animation*> m_animations;
 
+	// 背景
+	int m_backGroundGraph;
+	int m_backGroundColor;
+
 public:
 	World(int areaNum, SoundPlayer* soundPlayer);
 	~World();
@@ -55,6 +56,8 @@ public:
 	std::vector<const CharacterAction*> getActions() const;
 	std::vector<const Object*> getObjects() const;
 	std::vector<const Animation*> getAnimations() const;
+	inline const int getBackGroundGraph() const { return m_backGroundGraph; }
+	inline const int getBackGroundColor() const { return m_backGroundColor; }
 
 	//デバッグ
 	void debug(int x, int y, int color) const;

--- a/World.h
+++ b/World.h
@@ -1,7 +1,7 @@
 #ifndef WORLD_H_INCLUDED
 #define WORLD_H_INCLUDE
 
-#include<vector>
+#include <vector>
 
 class CharacterController;
 class CharacterAction;
@@ -67,6 +67,12 @@ public:
 
 	// キャラに会話させる
 	void talk();
+
+	// キャラの状態を変更
+	void asignedCharacterData(const char* name, int hp);
+
+	// キャラの状態を教える
+	void asignCharacterData(const char* name, int& hp);
 
 private:
 	// キャラクターとオブジェクトの当たり判定

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -59,7 +59,13 @@ WorldDrawer::~WorldDrawer() {
 // •`‰æ‚·‚é
 void WorldDrawer::draw() {
 	// ”wŒi
-	DrawBox(0, 0, GAME_WIDE, GAME_HEIGHT, GetColor(100, 100, 100), TRUE);
+	int groundGraph = m_world->getBackGroundGraph();
+	if (groundGraph != -1) {
+
+	}
+	else {
+		DrawBox(0, 0, GAME_WIDE, GAME_HEIGHT, m_world->getBackGroundColor(), TRUE);
+	}
 
 	// ƒJƒƒ‰‚ðŽæ“¾
 	const Camera* camera = m_world->getCamera();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
Worldクラスがキャラの配置、オブジェクトの配置、背景、BGM等の設定をファイルから読み込むようにする。
また、Gameクラスが主要キャラのHP等の情報をセーブデータとして保持し、Worldクラスが持つキャラに反映させる。これでエリアを移動（Worldを作り直）しても主要キャラの状態は引き継がれる。

# やったこと
CsvReaderファイルにAreaReaderクラスを定義。data/area/area?.csvファイルから情報を読み込む。WorldクラスはAreaReaderのゲッタを用いて必要なデータを受け取る。

GameDataクラスを実装。セーブすべきデータをすべて保持する。また、キャラクターのデータはCharacterDataクラスとしてまとめてある。今のところHPの情報しか持たない。
CharacterDataはセーブする情報に加えてキャラの名前も持っており、これを使ってWorldが持つキャラへの変更や、逆にキャラの情報取得を行う
GameDataクラスはセーブデータのファイル名も保持しており、今後複数のセーブデータを用意できる実装を予定している。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
設定ファイルを変更すると、ちゃんとゲームに反映されることを確認した。

# 懸念点
メモリリークが怖い。AreaReaderクラスがデータを作成し、Worldクラスがデータを削除する実装。Worldクラスがデータを削除することはこれまでと同様で変更されていないので、今回のPRによってメモリリークが起きることはないと思うが。
