### PR TITLE
Api: 扉オブジェクトの作成＆エリア間の移動を可能にする

### DIFF
--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -33,6 +33,11 @@ void KeyboardBrain::bulletTargetPoint(int& x, int& y) {
 	y = mouseY;
 }
 
+// 話しかけたり扉入ったり
+bool KeyboardBrain::actionOrder() {
+	return controlW() > 0;
+}
+
 // 移動（上下左右の入力）
 void KeyboardBrain::moveOrder(int& right, int& left, int& up, int& down) {
 	right = controlD();

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -16,6 +16,9 @@ protected:
 public:
 	Brain();
 
+	// 話しかけたり扉入ったり
+	virtual bool actionOrder() { return false; }
+
 	// セッタ
 	virtual void setCharacterAction(const CharacterAction* characterAction) = 0;
 	
@@ -58,6 +61,7 @@ public:
 	KeyboardBrain(const Camera* camera);
 	inline void setCharacterAction(const CharacterAction* characterAction) { m_characterAction_p = characterAction; }
 	void bulletTargetPoint(int& x, int& y);
+	bool actionOrder();
 	void moveOrder(int& right, int& left, int& up, int& down);
 	int jumpOrder();
 	int squatOrder();
@@ -143,6 +147,9 @@ public:
 	// ゲッタ
 	inline const CharacterAction* getAction() const { return m_characterAction; }
 	inline const Brain* getBrain() const { return m_brain; }
+
+	// 話しかけたり扉に入ったりするボタンがtrueか
+	virtual bool getActionKey() const { return m_brain->actionOrder(); }
 
 	// アクションのセッタ
 	void setCharacterGrand(bool grand);

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -301,8 +301,13 @@ void AreaReader::loadObject(std::map<std::string, std::string> dataMap) {
 		if (other == "leftDown") { leftDown = true; }
 		object = new TriangleObject(x1, y1, x2, y2, colorHandle, leftDown, hp);
 	}
-
 	if (object != NULL) { m_objects.push_back(object); }
+
+	// 扉オブジェクトは別に分ける
+	if (name == "Door") {
+		graph = "picture/stageMaterial/" + graph;
+		m_doorObjects.push_back(new DoorObject(x1, y1, x2, y2, graph.c_str(), stoi(other)));
+	}
 }
 
 // 背景のロード

--- a/CsvReader.h
+++ b/CsvReader.h
@@ -39,6 +39,7 @@ public:
 class Character;
 class CharacterController;
 class Object;
+class DoorObject;
 class SoundPlayer;
 class Camera;
 
@@ -69,6 +70,9 @@ private:
 	// オブジェクト
 	std::vector<Object*> m_objects;
 
+	// 扉オブジェクト
+	std::vector<DoorObject*> m_doorObjects;
+
 	// 背景画像と色
 	int m_backGroundGraph, m_backGroundColor;
 
@@ -97,6 +101,8 @@ public:
 	inline std::vector<CharacterController*> getCharacterControllers() const { return m_characterControllers; }
 
 	inline std::vector<Object*> getObjects() const { return m_objects; }
+
+	inline std::vector<DoorObject*> getDoorObjects() const { return m_doorObjects; }
 
 	inline void getBackGround(int& graphHandle, int& colorHandle) const {
 		graphHandle = m_backGroundGraph;

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -35,7 +35,8 @@ void World::debug(int x, int y, int color) const {
 	m_characterControllers[0]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	//m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE + 600, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	// オブジェクト
-	// debugObjects(x, y, color, m_stageObjects);
+	//debugObjects(x, y, color, m_stageObjects);
+	m_doorObjects[0]->debug(x + 500, y, RED);
 	debugObjects(x + 500, y, RED, m_attackObjects);
 	//for (unsigned int i = 0; i < m_animations.size(); i++) {
 	//	m_animations[i]->getHandle()->draw(GAME_WIDE - 200, 200, m_animations[i]->getHandle()->getEx());
@@ -155,4 +156,15 @@ void SlashObject::debug(int x, int y, int color) const {
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "cnt=%d", m_cnt);
 	debugObject(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	// DrawBox(m_x1, m_y1, m_x2, m_y2, color, FALSE);
+}
+
+
+/*
+* 扉オブジェクトのデバッグ
+*/
+void DoorObject::debug(int x, int y, int color) const {
+	DrawFormatString(x, y, color, "**DoorObject**");
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "GoTo=%d, text=%s", m_areaNum, m_text == nullptr ? "" : m_text);
+	debugObject(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+	DrawBox(m_x1, m_y1, m_x2, m_y2, color, FALSE);
 }

--- a/Game.cpp
+++ b/Game.cpp
@@ -44,7 +44,12 @@ void GameData::asignWorld(World* world) {
 }
 
 void GameData::asignedWorld(World* world) {
-
+	size_t size = m_characterData.size();
+	for (unsigned int i = 0; i < size; i++) {
+		int hp = 0;
+		world->asignCharacterData(m_characterData[i].name(), hp);
+		m_characterData[i].setHp(hp);
+	}
 }
 
 
@@ -78,4 +83,13 @@ void Game::play() {
 
 	// ‰¹
 	m_soundPlayer->play();
+
+	// ƒGƒŠƒAˆÚ“®
+	if (m_world->getBrightValue() == 0) {
+		int nextAreaNum = m_world->getAreaNum();
+		m_gameData->asignedWorld(m_world);
+		delete m_world;
+		m_world = new World(nextAreaNum, m_soundPlayer);
+		m_gameData->asignWorld(m_world);
+	}
 }

--- a/Object.cpp
+++ b/Object.cpp
@@ -8,6 +8,9 @@
 #include "DxLib.h"
 #include <algorithm>
 #include <cmath>
+#include <sstream>
+
+using namespace std;
 
 
 Object::Object() :
@@ -649,6 +652,33 @@ void SlashObject::action() {
 	}
 }
 
+DoorObject::DoorObject(int x1, int y1, int x2, int y2, const char* fileName, int areaNum) :
+	Object(x1, y1, x2, y2)
+{
+	m_graph = new GraphHandle(fileName);
+	m_areaNum = areaNum;
+	m_text = nullptr;
+}
+DoorObject::~DoorObject() {
+	delete m_graph;
+}
+bool DoorObject::atari(CharacterController* characterController) {
+	// キャラの情報　座標と移動スピード
+	int characterX1 = characterController->getAction()->getCharacter()->getX();
+	int characterY1 = characterController->getAction()->getCharacter()->getY();
+	int characterX2 = characterX1 + characterController->getAction()->getCharacter()->getWide();
+	int characterY2 = characterY1 + characterController->getAction()->getCharacter()->getHeight();
+
+	// 当たり判定
+	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2 && characterController->getAction()->ableDamage()) {
+		ostringstream text;
+		text << "Ｗキーで入る";
+		m_text = text.str().c_str();
+		return true;
+	}
+	m_text = nullptr;
+	return false;
+}
 
 // 描画用
 // オブジェクト描画（画像がないときに使う）
@@ -689,8 +719,4 @@ void BulletObject::drawObject(int x1, int y1, int x2, int y2) const {
 	else {
 		DrawOval(x1 + rx, y1 + ry, rx, ry, m_color, TRUE);
 	}
-}
-// オブジェクト描画（画像がないときに使う）
-void SlashObject::drawObject(int x1, int y1, int x2, int y2) const {
-	
 }

--- a/Object.h
+++ b/Object.h
@@ -55,6 +55,14 @@ public:
 	inline int getSoundHandle() const { return m_soundHandle_p; }
 	inline int getHp() const { return m_hp; }
 	inline int getDamageCnt() const { return m_damageCnt; }
+
+	// セッタ
+	inline void setDeleteFlag(bool deleteFlag) { m_deleteFlag = deleteFlag; }
+
+	// HPを減らす
+	void decreaseHp(int damageValue);
+
+	// グループIDのゲッタ
 	virtual inline int getGroupId() const { return -1; }
 
 	// 攻撃力 攻撃オブジェクト用
@@ -63,26 +71,23 @@ public:
 	// 画像を返す　ないならNULL
 	virtual GraphHandle* getHandle() const { return nullptr; }
 
+	// テキストを返す ないならNULL
+	virtual inline const char* getText() { return nullptr; }
+
 	// オブジェクト描画（画像がないときに使う）
-	virtual void drawObject(int x1, int y1, int x2, int y2) const = 0;
-
-	// セッタ
-	inline void setDeleteFlag(bool deleteFlag) { m_deleteFlag = deleteFlag; }
-
-	// HPを減らす
-	void decreaseHp(int damageValue);
+	virtual void drawObject(int x1, int y1, int x2, int y2) const {};
 
 	// キャラとの当たり判定
-	virtual bool atari(CharacterController* character) = 0;
+	virtual bool atari(CharacterController* characterController) = 0;
 
 	// キャラがオブジェクトに入り込んでいるときの処理
 	virtual void penetration(CharacterController* characterController) {};
 
 	// 攻撃オブジェクトとの当たり判定
-	virtual bool atariObject(Object* object) = 0;
+	virtual bool atariObject(Object* object) { return false; }
 
 	// 動くオブジェクト用 毎フレーム行う
-	virtual void action() = 0;
+	virtual void action() {};
 
 	// アニメーション作成
 	virtual Animation* createAnimation(int x, int y, int flameCnt) { return nullptr; };
@@ -112,7 +117,7 @@ public:
 
 	// キャラとの当たり判定
 	// 当たっているならキャラを操作する。
-	bool atari(CharacterController* character);
+	bool atari(CharacterController* characterController);
 
 	// キャラがオブジェクトに入り込んでいるときの処理
 	void penetration(CharacterController* characterController);
@@ -149,7 +154,7 @@ public:
 
 	// キャラとの当たり判定
 	// 当たっているならキャラを操作する。
-	bool atari(CharacterController* character);
+	bool atari(CharacterController* characterController);
 
 	// キャラがオブジェクトに入り込んでいるときの処理
 	void penetration(CharacterController* characterController);
@@ -219,7 +224,7 @@ public:
 
 	// キャラとの当たり判定
 	// 当たっているならキャラを操作する。
-	bool atari(CharacterController* character);
+	bool atari(CharacterController* characterController);
 
 	// 攻撃オブジェクトとの当たり判定
 	bool atariObject(Object* object);
@@ -279,9 +284,6 @@ public:
 	// ゲッタ
 	inline int getGroupId() const { return m_groupId; }
 
-	// オブジェクト描画（画像がないときに使う）
-	void drawObject(int x1, int y1, int x2, int y2) const;
-
 	// セッタ
 	inline void setCharacterId(int id) { m_characterId = id; }
 	inline void setGroupId(int id) { m_groupId = id; }
@@ -291,7 +293,7 @@ public:
 
 	// キャラとの当たり判定
 	// 当たっているならキャラを操作する。
-	bool atari(CharacterController* character);
+	bool atari(CharacterController* characterController);
 
 	// 攻撃オブジェクトとの当たり判定
 	bool atariObject(Object* object);
@@ -301,6 +303,36 @@ public:
 
 	// アニメーション作成
 	Animation* createAnimation(int x, int y, int flameCnt);
+};
+
+
+// 扉オブジェクト
+class DoorObject :
+	public Object 
+{
+private:
+	// 画像
+	GraphHandle* m_graph;
+
+	// 行先のエリア番号
+	int m_areaNum;
+
+	// チュートリアルのテキスト
+	const char* m_text;
+
+public:
+	DoorObject(int x1, int y1, int x2, int y2, const char* fileName, int areaNum);
+	~DoorObject();
+
+	void debug(int x, int y, int color) const;
+
+	// ゲッタ
+	GraphHandle* getHandle() const { return m_graph; }
+	inline int getAreaNum() { return m_areaNum; }
+	inline const char* getText() { return m_text; }
+
+	// キャラとの当たり判定
+	virtual bool atari(CharacterController* characterController);
 };
 
 #endif

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -54,6 +54,7 @@ void SoundPlayer::setBGM(std::string bgmName, int volume) {
 	m_bgmHandle = LoadSoundMem(bgmName.c_str());
 	// ‰¹—Ê’²®
 	changeSoundVolume(m_volume * volume / 100, m_bgmHandle);
+	playBGM();
 }
 
 // BGM‚ğÄ¶

--- a/World.h
+++ b/World.h
@@ -7,6 +7,7 @@ class CharacterController;
 class CharacterAction;
 class Character;
 class Object;
+class DoorObject;
 class Camera;
 class Animation;
 class SoundPlayer;
@@ -15,6 +16,9 @@ class World {
 private:
 	// サウンドプレイヤー
 	SoundPlayer* m_soundPlayer_p;
+
+	// 画面の明るさ
+	int m_brightValue;
 
 	// カメラで見ているキャラのID
 	int m_focusId;
@@ -37,6 +41,9 @@ private:
 	// 壁や床のオブジェクト Worldがデリートする
 	std::vector<Object*> m_stageObjects;
 
+	// エリア間をつなげる扉 Worldがデリートする
+	std::vector<DoorObject*> m_doorObjects;
+
 	// 攻撃のあたり判定のオブジェクト Worldがデリートする
 	std::vector<Object*> m_attackObjects;
 
@@ -52,6 +59,8 @@ public:
 	~World();
 
 	// ゲッタ
+	inline int getBrightValue() const { return m_brightValue; }
+	inline int getAreaNum() const { return m_areaNum; }
 	inline const Camera* getCamera() const { return m_camera; }
 	std::vector<const CharacterAction*> getActions() const;
 	std::vector<const Object*> getObjects() const;
@@ -77,6 +86,9 @@ public:
 private:
 	// キャラクターとオブジェクトの当たり判定
 	void atariCharacterAndObject(CharacterController* controller, std::vector<Object*>& objects);
+
+	// キャラクターと扉の当たり判定
+	void atariCharacterAndDoor(CharacterController* controller, std::vector<DoorObject*>& objects);
 
 	// アニメーションの更新
 	void updateAnimation();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
エリアに設置された扉をくぐると別のエリアに移動できるようになる。
そして、エリアを移動しても主要キャラのＨＰは維持される。

# やったこと
DoorObjectクラスを作成した。壁や床とは当たったときの処理がWorld自体に影響を及ぼすため、DoorObjectは壁や床とは別に保持することにした。
アクションオーダー(話しかけたり扉をくぐる命令)をBrainが出しているとき、扉とキャラが当たっていれば、エリア移動が起きる。Worldは暗転し、完全に真っ暗になったときGameがWorldを作り直す。

# やらないこと
扉の描画

# できるようになること(ユーザ目線)
別のエリアへ移動できる。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
どのエリアから来てもスタート地点が同じになってしまう。
