### PR TITLE
Ui: 扉オブジェクトの描画

### DIFF
--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -35,7 +35,7 @@ void KeyboardBrain::bulletTargetPoint(int& x, int& y) {
 
 // 話しかけたり扉入ったり
 bool KeyboardBrain::actionOrder() {
-	return controlW() > 0;
+	return controlW() == 1;
 }
 
 // 移動（上下左右の入力）

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -164,7 +164,7 @@ void SlashObject::debug(int x, int y, int color) const {
 */
 void DoorObject::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**DoorObject**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "GoTo=%d, text=%s", m_areaNum, m_text == nullptr ? "" : m_text);
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "GoTo=%d, text=%s", m_areaNum, m_text == "" ? "" : m_text);
 	debugObject(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	DrawBox(m_x1, m_y1, m_x2, m_y2, color, FALSE);
 }

--- a/Object.cpp
+++ b/Object.cpp
@@ -655,7 +655,7 @@ void SlashObject::action() {
 DoorObject::DoorObject(int x1, int y1, int x2, int y2, const char* fileName, int areaNum) :
 	Object(x1, y1, x2, y2)
 {
-	m_graph = new GraphHandle(fileName);
+	m_graph = new GraphHandle(fileName, 1.0, 0.0, true);
 	m_areaNum = areaNum;
 	m_text = nullptr;
 }

--- a/Object.cpp
+++ b/Object.cpp
@@ -657,12 +657,16 @@ DoorObject::DoorObject(int x1, int y1, int x2, int y2, const char* fileName, int
 {
 	m_graph = new GraphHandle(fileName, 1.0, 0.0, true);
 	m_areaNum = areaNum;
-	m_text = nullptr;
+	m_text = "";
 }
 DoorObject::~DoorObject() {
 	delete m_graph;
 }
 bool DoorObject::atari(CharacterController* characterController) {
+	if (!characterController->getAction()->ableDamage() || !characterController->getAction()->getGrand()) {
+		m_text = "";
+		return false;
+	}
 	// キャラの情報　座標と移動スピード
 	int characterX1 = characterController->getAction()->getCharacter()->getX();
 	int characterY1 = characterController->getAction()->getCharacter()->getY();
@@ -670,13 +674,11 @@ bool DoorObject::atari(CharacterController* characterController) {
 	int characterY2 = characterY1 + characterController->getAction()->getCharacter()->getHeight();
 
 	// 当たり判定
-	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2 && characterController->getAction()->ableDamage()) {
-		ostringstream text;
-		text << "Ｗキーで入る";
-		m_text = text.str().c_str();
+	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2) {
+		m_text = "Ｗキーで入る";
 		return true;
 	}
-	m_text = nullptr;
+	m_text = "";
 	return false;
 }
 

--- a/Object.h
+++ b/Object.h
@@ -1,6 +1,8 @@
 #ifndef OBJECT_H_INCLUDED
 #define OBJECT_H_INCLUDED
 
+#include <string>
+
 class Character;
 class CharacterController;
 class AttackInfo;
@@ -72,7 +74,7 @@ public:
 	virtual GraphHandle* getHandle() const { return nullptr; }
 
 	// テキストを返す ないならNULL
-	virtual inline const char* getText() { return nullptr; }
+	virtual inline std::string getText() const { return ""; }
 
 	// オブジェクト描画（画像がないときに使う）
 	virtual void drawObject(int x1, int y1, int x2, int y2) const {};
@@ -318,7 +320,7 @@ private:
 	int m_areaNum;
 
 	// チュートリアルのテキスト
-	const char* m_text;
+	std::string m_text;
 
 public:
 	DoorObject(int x1, int y1, int x2, int y2, const char* fileName, int areaNum);
@@ -329,7 +331,7 @@ public:
 	// ゲッタ
 	GraphHandle* getHandle() const { return m_graph; }
 	inline int getAreaNum() { return m_areaNum; }
-	inline const char* getText() { return m_text; }
+	inline std::string getText() const { return m_text; }
 
 	// キャラとの当たり判定
 	virtual bool atari(CharacterController* characterController);

--- a/ObjectDrawer.cpp
+++ b/ObjectDrawer.cpp
@@ -2,6 +2,7 @@
 #include "Camera.h"
 #include "Object.h"
 #include "GraphHandle.h"
+#include "Define.h"
 #include "DxLib.h"
 
 
@@ -28,15 +29,13 @@ void ObjectDrawer::drawObject(const Camera* const camera) {
 		m_object->drawObject(x1, y1, x2, y2);
 	}
 	else {
-		//// ‰æ‘œ‚Ì’†S‚ðÀ•W‚Æ‚·‚é
-		//x1 = (x1 + x2) / 2;
-		//y1 = (y1 + y2) / 2;
-		// ‰æ‘œŒÅ—L‚ÌŠg‘å—¦Žæ“¾
-		// ex = graphHandle->getEx();
-		// ƒJƒƒ‰‚Å’²®
 		camera->setCamera(&x1, &y1, &ex);
 		camera->setCamera(&x2, &y2, &ex);
 		// •`‰æ
 		graphHandle->extendDraw(x1, y1, x2, y2);
-	}	
+	}
+	if (m_object->getText() != "") {
+		DrawBox(x1, y1 - 50, x2, y1 - 10, WHITE, TRUE);
+		DrawFormatString(x1, y1 - 40, BLACK, "%s", m_object->getText());
+	}
 }

--- a/World.cpp
+++ b/World.cpp
@@ -135,11 +135,20 @@ vector<const CharacterAction*> World::getActions() const {
 }
 
 // Object‚Ìvector‚ð•Ô‚·
-vector<const Object*> World::getObjects() const {
+vector<const Object*> World::getFrontObjects() const {
 
 	vector<const Object*> allObjects;
 	allObjects.insert(allObjects.end(), m_stageObjects.begin(), m_stageObjects.end());
 	allObjects.insert(allObjects.end(), m_attackObjects.begin(), m_attackObjects.end());
+
+	return allObjects;
+}
+
+// ƒLƒƒƒ‰‚æ‚èŒã‚ë‚É•`‰æ‚·‚éObject‚Ìvector‚ð•Ô‚·
+vector<const Object*> World::getBackObjects() const {
+
+	vector<const Object*> allObjects;
+	allObjects.insert(allObjects.end(), m_doorObjects.begin(), m_doorObjects.end());
 
 	return allObjects;
 }

--- a/World.cpp
+++ b/World.cpp
@@ -296,7 +296,7 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 	}
 }
 
-// キャラクターとオブジェクトの当たり判定
+// キャラクターと扉オブジェクトの当たり判定
 void World::atariCharacterAndDoor(CharacterController* controller, vector<DoorObject*>& objects) {
 	// 壁や床オブジェクトの処理 (当たり判定と動き)
 	for (unsigned int i = 0; i < objects.size(); i++) {
@@ -321,7 +321,9 @@ void World::controlCharacter() {
 		// オブジェクトとの当たり判定
 		atariCharacterAndObject(controller, m_stageObjects);
 		atariCharacterAndObject(controller, m_attackObjects);
-		atariCharacterAndDoor(controller, m_doorObjects);
+		if (controller->getAction()->getCharacter()->getId() == m_playerId) {
+			atariCharacterAndDoor(controller, m_doorObjects);
+		}
 
 		// 操作
 		controller->control();

--- a/World.h
+++ b/World.h
@@ -63,7 +63,8 @@ public:
 	inline int getAreaNum() const { return m_areaNum; }
 	inline const Camera* getCamera() const { return m_camera; }
 	std::vector<const CharacterAction*> getActions() const;
-	std::vector<const Object*> getObjects() const;
+	std::vector<const Object*> getFrontObjects() const;
+	std::vector<const Object*> getBackObjects() const;
 	std::vector<const Animation*> getAnimations() const;
 	inline const int getBackGroundGraph() const { return m_backGroundGraph; }
 	inline const int getBackGroundColor() const { return m_backGroundColor; }

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -70,9 +70,20 @@ void WorldDrawer::draw() {
 	// カメラを取得
 	const Camera* camera = m_world->getCamera();
 
+	// 各Objectを描画
+	vector<const Object*> objects = m_world->getBackObjects();
+	size_t size = objects.size();
+	for (unsigned int i = 0; i < size; i++) {
+		// ObjectをDrawerにセット
+		m_objectDrawer->setObject(objects[i]);
+
+		// カメラを使ってObjectを描画
+		m_objectDrawer->drawObject(camera);
+	}
+
 	// 各Actionを描画
 	vector<const CharacterAction*> actions = m_world->getActions();
-	size_t size = actions.size();
+	size = actions.size();
 	for (unsigned int i = 0; i < size; i++) {
 		// キャラをDrawerにセット
 		m_characterDrawer->setCharacterAction(actions[i]);
@@ -82,7 +93,7 @@ void WorldDrawer::draw() {
 	}
 
 	// 各Objectを描画
-	vector<const Object*> objects = m_world->getObjects();
+	objects = m_world->getFrontObjects();
 	size = objects.size();
 	for (unsigned int i = 0; i < size; i++) {
 		// ObjectをDrawerにセット


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
新たに実装された扉オブジェクトを描画する。

# やったこと
扉オブジェクトはキャラの奥に、壁、床、攻撃オブジェクトはキャラの手前に描画するように実装した。

空中では扉に入れないようにした。（API側でやるべきだったけど）

扉には入れるとき、扉の上にチュートリアルのテキストを表示("Wキーで入る")

# やらないこと
記入欄

# できるようになること(ユーザ目線)
扉の位置が分かる。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
真っ黒な扉だと棒人間の体見えなくなる。
テキストの見栄え悪い。いつか修正する。