### PR TITLE
Api: エリアを移動したとき、前にいたエリアを考慮してプレイヤーの初期位置が決まる機能

### DIFF
--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -23,7 +23,7 @@ CharacterDrawer::CharacterDrawer(const CharacterAction* const characterAction) {
 }
 
 // キャラを描画する
-void CharacterDrawer::drawCharacter(const Camera* const camera) {
+void CharacterDrawer::drawCharacter(const Camera* const camera, int bright) {
 	// 描画するキャラクター
 	const Character* character = m_characterAction->getCharacter();
 
@@ -44,10 +44,14 @@ void CharacterDrawer::drawCharacter(const Camera* const camera) {
 
 	// 描画
 	if (m_characterAction->getState() == CHARACTER_STATE::DAMAGE && ++m_cnt / 2 % 2 == 1) {
-		SetDrawBright(100, 100, 100);
+		int dark = max(0, bright - 100);
+		SetDrawBright(dark, dark, dark);
+		graphHandle->draw(x, y, ex);
+		SetDrawBright(bright, bright, bright);
 	}
-	graphHandle->draw(x, y, ex);
-	SetDrawBright(255, 255, 255);
+	else {
+		graphHandle->draw(x, y, ex);
+	}
 
 	// 体力バーの座標をカメラで調整
 	x = character->getX() + (character->getWide() / 2);

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -24,7 +24,7 @@ public:
 	// ƒZƒbƒ^
 	void setCharacterAction(const CharacterAction* action) { m_characterAction = action; }
 
-	void drawCharacter(const Camera* const camera);
+	void drawCharacter(const Camera* const camera, int bright = 255);
 };
 
 #endif

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -126,7 +126,8 @@ int str2color(string colorName) {
 * Character等をnewするため、このクラスをnewした後はgetして削除すること。
 * このクラスでnewされたCharacter等はこのクラスで削除しない。
 */
-AreaReader::AreaReader(int m_areaNum, SoundPlayer* soundPlayer) {
+AreaReader::AreaReader(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) {
+	m_fromAreaNum = fromAreaNum;
 	m_soundPlayer_p = soundPlayer;
 
 	m_camera_p = NULL;
@@ -144,7 +145,7 @@ AreaReader::AreaReader(int m_areaNum, SoundPlayer* soundPlayer) {
 
 	// ファイルを開く
 	ostringstream fileName;
-	fileName << "data/area/area" << m_areaNum << ".csv";
+	fileName << "data/area/area" << toAreaNum << ".csv";
 	fp = FileRead_open(fileName.str().c_str());
 
 	LOAD_AREA now = LOAD_AREA::BGM;
@@ -186,6 +187,8 @@ AreaReader::AreaReader(int m_areaNum, SoundPlayer* soundPlayer) {
 
 	// ファイルを閉じる
 	FileRead_close(fp);
+
+	setPlayer();
 }
 
 void AreaReader::map2instance(map<string, string> dataMap, LOAD_AREA now) {
@@ -236,14 +239,14 @@ void AreaReader::loadCharacter(std::map<std::string, std::string> dataMap) {
 	}
 
 	// カメラをセット
-	if (cameraFlag&& m_camera_p == NULL) {
+	if (cameraFlag && m_camera_p == NULL && character != NULL) {
 		m_camera_p = new Camera(0, 0, 1.0);
 		m_camera_p->setPoint(character->getCenterX(), character->getCenterY());
 		m_focusId = character->getId();
 	}
 
 	// プレイヤーが操作中のキャラとしてセット
-	if (playerFlag && m_playerId == -1) {
+	if (playerFlag && m_playerId == -1 && character != NULL) {
 		m_playerId = character->getId();
 	}
 
@@ -326,4 +329,19 @@ void AreaReader::loadBackGround(std::map<std::string, std::string> dataMap) {
 	}
 	// 背景色
 	m_backGroundColor = str2color(color);
+}
+
+// プレイヤーの初期位置を、前いたエリアを元に設定
+void AreaReader::setPlayer() {
+	for (int i = 0; i < m_characters.size(); i++) {
+		if (m_playerId == m_characters[i]->getId()) {
+			for (int j = 0; j < m_doorObjects.size(); j++) {
+				if (m_doorObjects[j]->getAreaNum() == m_fromAreaNum) {
+					m_characters[i]->setX(m_doorObjects[j]->getX1());
+					m_characters[i]->setY(m_doorObjects[j]->getY1());
+				}
+			}
+			break;
+		}
+	}
 }

--- a/CsvReader.h
+++ b/CsvReader.h
@@ -45,6 +45,9 @@ class Camera;
 
 class AreaReader {
 private:
+	// 移動元
+	int m_fromAreaNum;
+
 	// アクション作成する用
 	SoundPlayer* m_soundPlayer_p;
 
@@ -84,7 +87,7 @@ private:
 	};
 
 public:
-	AreaReader(int m_areaNum, SoundPlayer* soundPlayer);
+	AreaReader(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer);
 
 	inline Camera* getCamera() const { return m_camera_p; }
 
@@ -115,6 +118,7 @@ private:
 	void loadCharacter(std::map<std::string, std::string> dataMap);
 	void loadObject(std::map<std::string, std::string> dataMap);
 	void loadBackGround(std::map<std::string, std::string> dataMap);
+	void setPlayer();
 };
 
 #endif

--- a/Game.cpp
+++ b/Game.cpp
@@ -20,6 +20,8 @@ CharacterData::CharacterData(const char* name) {
 GameData::GameData() {
 	m_saveFilePath = "data/save/savedata1.dat";
 
+	m_areaNum = 0;
+
 	// 主要キャラを設定
 	m_characterData.push_back("ハート");
 
@@ -66,7 +68,7 @@ Game::Game() {
 
 	// 世界
 	int startAreaNum = 0;
-	m_world = new World(startAreaNum, m_soundPlayer);
+	m_world = new World(-1, startAreaNum, m_soundPlayer);
 
 	// データを世界に反映
 	m_gameData->asignWorld(m_world);
@@ -89,7 +91,8 @@ void Game::play() {
 		int nextAreaNum = m_world->getAreaNum();
 		m_gameData->asignedWorld(m_world);
 		delete m_world;
-		m_world = new World(nextAreaNum, m_soundPlayer);
+		m_world = new World(m_gameData->getAreaNum(), nextAreaNum, m_soundPlayer);
 		m_gameData->asignWorld(m_world);
+		m_gameData->setAreaNum(nextAreaNum);
 	}
 }

--- a/Game.cpp
+++ b/Game.cpp
@@ -67,7 +67,7 @@ Game::Game() {
 	m_soundPlayer->setVolume(50);
 
 	// ¢ŠE
-	int startAreaNum = 0;
+	int startAreaNum = 1;
 	m_world = new World(-1, startAreaNum, m_soundPlayer);
 
 	// ƒf[ƒ^‚ğ¢ŠE‚É”½‰f

--- a/Game.h
+++ b/Game.h
@@ -33,9 +33,18 @@ private:
 	// キャラのデータ
 	std::vector<CharacterData> m_characterData;
 
+	// 今いるエリア
+	int m_areaNum;
+
 public:
 	GameData();
 	GameData(const char* saveFilePath);
+
+	// ゲッタ
+	inline int getAreaNum() const { return m_areaNum; }
+
+	// セッタ
+	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }
 
 	// 自身のデータをWorldにデータ反映させる
 	void asignWorld(World* world);

--- a/ObjectDrawer.cpp
+++ b/ObjectDrawer.cpp
@@ -36,6 +36,6 @@ void ObjectDrawer::drawObject(const Camera* const camera) {
 	}
 	if (m_object->getText() != "") {
 		DrawBox(x1, y1 - 50, x2, y1 - 10, WHITE, TRUE);
-		DrawFormatString(x1, y1 - 40, BLACK, "%s", m_object->getText());
+		DrawFormatString(x1, y1 - 40, BLACK, "%s", m_object->getText().c_str());
 	}
 }

--- a/World.cpp
+++ b/World.cpp
@@ -67,17 +67,17 @@ void penetrationCharacterAndObject(CharacterController* controller, vector<Objec
 /*
 * オブジェクトのロードなど
 */
-World::World(int areaNum, SoundPlayer* soundPlayer) {
+World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) {
 	m_brightValue = 255;
 
 	// サウンドプレイヤー
 	m_soundPlayer_p = soundPlayer;
 
 	// 主人公のスタート地点
-	m_areaNum = areaNum;
+	m_areaNum = toAreaNum;
 
 	// エリアをロード
-	const AreaReader data(areaNum, m_soundPlayer_p);
+	const AreaReader data(fromAreaNum, toAreaNum, m_soundPlayer_p);
 	m_camera = data.getCamera();
 	m_focusId = data.getFocusId();
 	m_playerId = data.getPlayerId();

--- a/World.cpp
+++ b/World.cpp
@@ -166,7 +166,7 @@ vector<const Animation*> World::getAnimations() const {
 void World::battle() {
 	// ‰æ–ÊˆÃ“]’†
 	if (m_brightValue != 255) {
-		m_brightValue--;
+		m_brightValue = max(0, m_brightValue - 10);
 		return;
 	}
 

--- a/World.h
+++ b/World.h
@@ -55,7 +55,7 @@ private:
 	int m_backGroundColor;
 
 public:
-	World(int areaNum, SoundPlayer* soundPlayer);
+	World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer);
 	~World();
 
 	// ƒQƒbƒ^

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -58,6 +58,8 @@ WorldDrawer::~WorldDrawer() {
 
 // •`‰æ‚·‚é
 void WorldDrawer::draw() {
+	int bright = m_world->getBrightValue();
+	SetDrawBright(bright, bright, bright);
 	// ”wŒi
 	int groundGraph = m_world->getBackGroundGraph();
 	if (groundGraph != -1) {
@@ -89,7 +91,7 @@ void WorldDrawer::draw() {
 		m_characterDrawer->setCharacterAction(actions[i]);
 
 		// ƒJƒƒ‰‚ðŽg‚Á‚ÄƒLƒƒƒ‰‚ð•`‰æ
-		m_characterDrawer->drawCharacter(camera);
+		m_characterDrawer->drawCharacter(camera, bright);
 	}
 
 	// ŠeObject‚ð•`‰æ
@@ -116,4 +118,5 @@ void WorldDrawer::draw() {
 
 	m_targetDrawer.setEx(camera->getEx());
 	m_targetDrawer.draw();
+	SetDrawBright(0, 0, 0);
 }


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
扉をくぐってエリアを移動すると、次のエリアで対応する扉の前でスタートする。その扉をくぐると、当然元居たエリアに戻れる。

# やったこと
GameDataクラスに、現在地のareaNumをメンバ変数として追加。エリアが変わるとき、areaNumをAreaReaderに渡す。
AreaReaderはfromAreaNumとtoAreaNumを受け取る。そして、playerIdを持つキャラの座標を、fromAreaNumと一致するareaNumを持つdoorObjectの前に移動させる。

エリア移動の際画面が暗転するようにした。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
エリア間の移動が直感的でわかりやすくなる。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
目視で確認。

# 懸念点
計算量が多くてエリア間の移動に時間がかかる(やっぱそうでもなかった、許容範囲)。せめてロード画面を表示した方が安心だと思う。