### PR TITLE
Api: 攻撃開始時の効果音追加＆その他いろいろ調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+data/
+picture/
+sound/
+x64/
+DuplicationHeart.vcxproj.user
+Log.txt
+.vs/

--- a/Character.h
+++ b/Character.h
@@ -8,6 +8,7 @@ class Object;
 class GraphHandle;
 class GraphHandles;
 class CharacterGraphHandle;
+class SoundPlayer;
 
 
 class CharacterInfo {
@@ -112,8 +113,14 @@ private:
 	// 射撃攻撃が当たったときのサウンド
 	int m_bulletSoundHandle;
 
+	// 弾発射音
+	int m_bulletStartSoundHandle;
+
 	// 斬撃攻撃が当たったときのサウンド
 	int m_slashSoundHandle;
+
+	// 斬撃開始サウンド
+	int m_slashStartSoundHandle;
 
 public:
 	// デフォルト値で初期化
@@ -145,6 +152,8 @@ public:
 	GraphHandles* slashEffectHandle() const { return m_slashEffectHandles; }
 	int bulletSoundeHandle() const { return m_bulletSoundHandle; }
 	int slashSoundHandle() const { return m_slashSoundHandle; }
+	int bulletStartSoundeHandle() const { return m_bulletStartSoundHandle; }
+	int slashStartSoundHandle() const { return m_slashStartSoundHandle; }
 };
 
 
@@ -268,10 +277,10 @@ public:
 	void moveDown(int d);
 
 	// 射撃攻撃をする(キャラごとに違う)
-	virtual Object* bulletAttack(int gx, int gy) = 0;
+	virtual Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) { return NULL; }
 
 	// 斬撃攻撃をする(キャラごとに違う) 左を向いているか、今何カウントか
-	virtual Object* slashAttack(bool leftDirection, int cnt) = 0;
+	virtual Object* slashAttack(bool leftDirection, int cnt, SoundPlayer* soundPlayer) { return NULL; }
 };
 
 
@@ -309,10 +318,10 @@ public:
 	void switchPreJump(int cnt = 0);
 
 	// 射撃攻撃をする(キャラごとに違う)
-	Object* bulletAttack(int gx, int gy);
+	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer);
 
 	// 斬撃攻撃をする(キャラごとに違う)
-	Object* slashAttack(bool leftDirection, int cnt);
+	Object* slashAttack(bool leftDirection, int cnt, SoundPlayer* soundPlayer);
 };
 
 

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -509,7 +509,7 @@ Object* StickAction::bulletAttack(int gx, int gy) {
 		// 撃つ方向へ向く
 		m_character_p->setLeftDirection(m_character_p->getCenterX() > gx);
 		// 攻撃を返す
-		return m_character_p->bulletAttack(gx, gy);
+		return m_character_p->bulletAttack(gx, gy, m_soundPlayer_p);
 	}
 	return NULL;
 }
@@ -528,7 +528,7 @@ Object* StickAction::slashAttack(int gx, int gy) {
 		m_character_p->setLeftDirection(m_attackLeftDirection);
 	}
 	// 攻撃のタイミングじゃないならNULLが返る
-	return m_character_p->slashAttack(m_attackLeftDirection, m_slashCnt);
+	return m_character_p->slashAttack(m_attackLeftDirection, m_slashCnt, m_soundPlayer_p);
 }
 
 // ダメージを受ける

--- a/Control.cpp
+++ b/Control.cpp
@@ -83,6 +83,12 @@ int controlSpace()
 	return Key[KEY_INPUT_SPACE];
 }
 
+//左Shiftキー
+int controlLeftShift()
+{
+	return Key[KEY_INPUT_LSHIFT];
+}
+
 //ゲーム終了用
 int controlEsc() {
 	if (Key[KEY_INPUT_ESCAPE] == 1) { //ESCキーが1カウント押されていたら

--- a/Control.h
+++ b/Control.h
@@ -28,6 +28,9 @@ int controlDebug();
 //スペースキー
 int controlSpace();
 
+// 左Shiftキー
+int controlLeftShift();
+
 //ESCキー：ゲーム終了
 int controlEsc();
 

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -41,13 +41,14 @@ CsvReader::CsvReader(const char* fileName) {
 	int fp;
 
 	// バッファ
-	char buff[256];
+	const int size = 512;
+	char buff[size];
 
 	// ファイルを開く
 	fp = FileRead_open(fileName);
 
 	// バッファに一行目（カラム名）のテキストを入れる
-	FileRead_gets(buff, 256, fp);
+	FileRead_gets(buff, size, fp);
 
 	// カラム名のリストを取得
 	m_columnNames = csv2vector(buff);
@@ -55,7 +56,7 @@ CsvReader::CsvReader(const char* fileName) {
 	// ファイルの終端までループ
 	while (FileRead_eof(fp) == 0) {
 		// いったんバッファに一行分のテキストを入れる
-		FileRead_gets(buff, 256, fp);
+		FileRead_gets(buff, size, fp);
 
 		// 一行分のテキストをデータにしてVectorに変換
 		vector<string> oneDataVector;
@@ -154,6 +155,7 @@ AreaReader::AreaReader(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer)
 	while (FileRead_eof(fp) == 0) {
 		FileRead_gets(buff, 256, fp);
 		vector<string> oneData = csv2vector(buff);
+		if (oneData[0] == "") { break; }
 
 		if (oneData[0] == "BGM:") {
 			now = LOAD_AREA::BGM;
@@ -235,6 +237,9 @@ void AreaReader::loadCharacter(std::map<std::string, std::string> dataMap) {
 		character = new Heart(name.c_str(), 100, x, y, groupId);
 	}
 	else if (name == "ハート") {
+		character = new Heart(name.c_str(), 100, x, y, groupId);
+	}
+	else {
 		character = new Heart(name.c_str(), 100, x, y, groupId);
 	}
 

--- a/CsvReader.h
+++ b/CsvReader.h
@@ -74,7 +74,7 @@ private:
 	std::vector<Object*> m_objects;
 
 	// 扉オブジェクト
-	std::vector<DoorObject*> m_doorObjects;
+	std::vector<Object*> m_doorObjects;
 
 	// 背景画像と色
 	int m_backGroundGraph, m_backGroundColor;
@@ -105,7 +105,7 @@ public:
 
 	inline std::vector<Object*> getObjects() const { return m_objects; }
 
-	inline std::vector<DoorObject*> getDoorObjects() const { return m_doorObjects; }
+	inline std::vector<Object*> getDoorObjects() const { return m_doorObjects; }
 
 	inline void getBackGround(int& graphHandle, int& colorHandle) const {
 		graphHandle = m_backGroundGraph;

--- a/Game.cpp
+++ b/Game.cpp
@@ -75,11 +75,12 @@ Game::Game() {
 }
 
 Game::~Game() {
+	delete m_gameData;
 	delete m_soundPlayer;
 	delete m_world;
 }
 
-void Game::play() {
+bool Game::play() {
 	// í‚í‚¹‚é
 	m_world->battle();
 
@@ -91,8 +92,11 @@ void Game::play() {
 		int nextAreaNum = m_world->getAreaNum();
 		m_gameData->asignedWorld(m_world);
 		delete m_world;
+		InitGraph();
 		m_world = new World(m_gameData->getAreaNum(), nextAreaNum, m_soundPlayer);
 		m_gameData->asignWorld(m_world);
 		m_gameData->setAreaNum(nextAreaNum);
+		return true;
 	}
+	return false;
 }

--- a/Game.h
+++ b/Game.h
@@ -75,7 +75,7 @@ public:
 	void debug(int x, int y, int color) const;
 
 	// ƒQ[ƒ€‚ğƒvƒŒƒC‚·‚é
-	void play();
+	bool play();
 };
 
 #endif

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -129,6 +129,7 @@ CharacterGraphHandle::CharacterGraphHandle(const char* characterName, double dra
 
 	// キャラ名でデータを検索
 	map<string, string> data = reader.findOne("name", characterName);
+	if (data.size() == 0) { data = reader.findOne("name", "テスト"); }
 
 	// ロード
 	loadCharacterGraph(characterName, m_standHandles, "stand", data, m_ex);

--- a/Main.cpp
+++ b/Main.cpp
@@ -55,12 +55,12 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	////マウス関連////
 	SetMouseDispFlag(MOUSE_DISP);//マウス表示
 	//SetMousePoint(320, 240);//マウスカーソルの初期位置
-	//SetDrawMode(DX_DRAWMODE_BILINEAR);
-	SetDrawMode(DX_DRAWMODE_NEAREST);
+	SetDrawMode(DX_DRAWMODE_BILINEAR);
+	//SetDrawMode(DX_DRAWMODE_NEAREST);
 	//ゲーム本体
 	Game game;
 	// ゲーム描画用
-	GameDrawer gameDrawer(&game);
+	GameDrawer* gameDrawer = new GameDrawer(&game);
 	bool title_flag = false;//trueならタイトル画面終了
 	while (ScreenFlip() == 0 && ProcessMessage() == 0 && ClearDrawScreen() == 0)
 	{
@@ -68,8 +68,11 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		mouseClick();
 
 		/////メイン////
-		game.play();
-		gameDrawer.draw();
+		if (game.play()) {
+			delete gameDrawer;
+			gameDrawer = new GameDrawer(&game);
+		}
+		gameDrawer->draw();
 		///////////////
 
 		//FPS操作

--- a/Object.cpp
+++ b/Object.cpp
@@ -50,7 +50,6 @@ Animation* BulletObject::createAnimation(int x, int y, int flameCnt) {
 		return NULL;
 	}
 	return new Animation((m_x1 + m_x2) / 2, (m_y1 + m_y2) / 2, 3, m_effectHandles_p);
-	return new Animation(x, y, flameCnt, m_effectHandles_p);
 }
 
 // アニメーション作成

--- a/Object.h
+++ b/Object.h
@@ -70,6 +70,9 @@ public:
 	// 攻撃力 攻撃オブジェクト用
 	virtual inline int getDamage() const { return 0; }
 
+	// 扉用
+	virtual inline int getAreaNum() const { return -1; }
+
 	// 画像を返す　ないならNULL
 	virtual GraphHandle* getHandle() const { return nullptr; }
 
@@ -330,7 +333,7 @@ public:
 
 	// ゲッタ
 	GraphHandle* getHandle() const { return m_graph; }
-	inline int getAreaNum() { return m_areaNum; }
+	inline int getAreaNum() const { return m_areaNum; }
 	inline std::string getText() const { return m_text; }
 
 	// キャラとの当たり判定

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -49,7 +49,7 @@ void SoundPlayer::setVolume(int volume) {
 // BGMをセット（変更）
 void SoundPlayer::setBGM(std::string bgmName, int volume) {
 	if (bgmName == m_bgmName) { return; }
-	if (m_bgmHandle != -1) { DeleteSoundMem(m_bgmHandle); }
+	DeleteSoundMem(m_bgmHandle);
 	m_bgmName = bgmName;
 	m_bgmHandle = LoadSoundMem(bgmName.c_str());
 	// 音量調整

--- a/World.h
+++ b/World.h
@@ -42,7 +42,7 @@ private:
 	std::vector<Object*> m_stageObjects;
 
 	// エリア間をつなげる扉 Worldがデリートする
-	std::vector<DoorObject*> m_doorObjects;
+	std::vector<Object*> m_doorObjects;
 
 	// 攻撃のあたり判定のオブジェクト Worldがデリートする
 	std::vector<Object*> m_attackObjects;
@@ -89,7 +89,7 @@ private:
 	void atariCharacterAndObject(CharacterController* controller, std::vector<Object*>& objects);
 
 	// キャラクターと扉の当たり判定
-	void atariCharacterAndDoor(CharacterController* controller, std::vector<DoorObject*>& objects);
+	void atariCharacterAndDoor(CharacterController* controller, std::vector<Object*>& objects);
 
 	// アニメーションの更新
 	void updateAnimation();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
攻撃をしたときの効果音（当たったときではなく、発動したとき）を追加。

メモリリーク対策をした(#38 )。 おそらくDxライブラリに問題がある。

area?.csvファイルに書いたキャラが見つからないとき、デフォルトでテストキャラが生成されるようになった。

# やったこと
attackInfo.csvに書かれるテキストが長くなったため、バッファには512文字まで含められるようにした。
DXライブラリの問題でメモリリークが発生しているため、エリア移動時にInitGraphで画像を全除去するようにした。面倒だが、現状これしか解決策がない。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
攻撃時の効果音で、攻撃していることが分かりやすくなった。なお、soundPlayerを持たない周りのキャラはジャンプ音などと同様に攻撃音もならない。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
実際にプレイして確認。

# 懸念点
もしかしたら音ファイルでもメモリリークが発生しているかも。（DXライブラリの問題で）
しかし現状、タスクマネージャで見た感じメモリリークは確認できない。
