### PR TITLE
Api: いろいろ調整する

### DIFF
--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -461,6 +461,8 @@ void StickAction::jump(int cnt) {
 		}
 		return;
 	}
+	// 斬撃中はジャンプ不可
+	if (m_slashCnt > 0) { return; }
 	// 宙に浮いたらジャンプ中止
 	if (!m_grand) {
 		m_preJumpCnt = -1;
@@ -522,6 +524,11 @@ Object* StickAction::slashAttack(int gx, int gy) {
 	}
 	// 攻撃開始
 	if (ableAttack()) {
+		// ジャンプはキャンセル
+		m_preJumpCnt = -1;
+		if (getState() == CHARACTER_STATE::PREJUMP) {
+			setState(CHARACTER_STATE::STAND);
+		}
 		m_attackLeftDirection = m_character_p->getCenterX() > gx;
 		m_slashCnt = m_character_p->getSlashCountSum() + m_character_p->getSlashInterval();
 		// 攻撃の方向へ向く

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -119,7 +119,7 @@ public:
 	void setLeftLock(bool lock);
 	void setUpLock(bool lock);
 	void setDownLock(bool lock);
-	inline void setBoost() { m_boostCnt = BOOST_TIME; }
+	inline void setBoost() { if(!m_grand) m_boostCnt = BOOST_TIME; }
 	inline void setGrandRightSlope(bool grand) { m_grandRightSlope = grand; }
 	inline void setGrandLeftSlope(bool grand) { m_grandLeftSlope = grand; }
 

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -108,7 +108,7 @@ void NormalAI::moveOrder(int& right, int& left, int& up, int& down) {
 
 	// (•Ç‚É‚Â‚Á‚©‚¦‚é‚È‚Ç‚Å)ˆÚ“®‚Å‚«‚Ä‚È‚¢‚©‚ç’ú‚ß‚é
 	//DrawFormatString(800, 50, GetColor(255, 255, 255), "moveCnt = %d, x(%d) -> gx(%d)", m_moveCnt, x, m_gx);
-	if (m_moveCnt == GIVE_UP_MOVE_CNT) {
+	if (m_moveCnt >= GIVE_UP_MOVE_CNT) {
 		m_gx = x;
 		m_gy = y;
 	}

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -343,7 +343,7 @@ void AreaReader::setPlayer() {
 			for (int j = 0; j < m_doorObjects.size(); j++) {
 				if (m_doorObjects[j]->getAreaNum() == m_fromAreaNum) {
 					m_characters[i]->setX(m_doorObjects[j]->getX1());
-					m_characters[i]->setY(m_doorObjects[j]->getY1());
+					m_characters[i]->setY(m_doorObjects[j]->getY2() - m_characters[i]->getHeight());
 				}
 			}
 			break;

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -86,7 +86,16 @@ void StickAction::debug(int x, int y, int color) const {
 // Characterクラスのデバッグ
 void Character::debugCharacter(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**Character**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "(x,y)=(%d,%d), left=%d, id=%d, groupId=%d", m_x, m_y, m_leftDirection, m_id, m_groupId);
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "(x,y)=(%d,%d), left=%d, id=%d, groupId=%d, m_handle=%d", m_x, m_y, m_leftDirection, m_id, m_groupId, m_graphHandle->getHandle());
+	bool flag = false;
+	for (int i = 0; i < m_graphHandle->getRunHandle()->getSize(); i++) {
+		if (m_graphHandle->getHandle()->getHandle() == m_graphHandle->getRunHandle()->getHandle(i)) {
+			flag = true;
+		}
+	}
+	if (!flag) {
+		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "!!!!!!!!!!!!!!!!!!!!!!!!!!");
+	}
 	// DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "(wide, height)=(%d,%d), handle=%d", m_wide, m_height, m_graphHandle->getHandle());
 	// 画像
 	// m_graphHandle->draw(GAME_WIDE - (m_wide / 2), (m_height / 2), m_graphHandle->getEx());

--- a/Game.cpp
+++ b/Game.cpp
@@ -20,7 +20,7 @@ CharacterData::CharacterData(const char* name) {
 GameData::GameData() {
 	m_saveFilePath = "data/save/savedata1.dat";
 
-	m_areaNum = 0;
+	m_areaNum = 1;
 
 	// 主要キャラを設定
 	m_characterData.push_back("ハート");

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -224,7 +224,7 @@ void CharacterGraphHandle::switchJump(int index){
 }
 // 降下画像をセット
 void CharacterGraphHandle::switchDown(int index){
-	setGraph(m_preJumpHandles, index);
+	setGraph(m_downHandles, index);
 }
 // ジャンプ前画像をセット
 void CharacterGraphHandle::switchPreJump(int index){

--- a/Object.cpp
+++ b/Object.cpp
@@ -109,9 +109,9 @@ bool BoxObject::atari(CharacterController* characterController) {
 		// 右に移動中のキャラが左から当たっているか判定
 		if (characterX2 <= m_x1 && characterX2 + characterVx >= m_x1) {
 			// 段差とみなして乗り越える
-			if (characterY2 - STAIR_HEIGHT <= m_y1 && characterX2 == m_x1) {
+			if (characterY2 - STAIR_HEIGHT <= m_y1) {
 				// 適切な座標へ
-				characterController->setCharacterX(characterX1 + characterWide / 2);
+				characterController->setCharacterX(m_x1 - characterWide / 2 - characterVx);
 				characterController->setCharacterY(m_y1 - characterHeight);
 				// 着地
 				characterController->setCharacterGrand(true);
@@ -128,10 +128,9 @@ bool BoxObject::atari(CharacterController* characterController) {
 		}
 		// 左に移動中のキャラが右から当たっているか判定
 		else if (characterX1 >= m_x2 && characterX1 + characterVx <= m_x2) {
-			// 段差とみなして乗り越える
-			if (characterY2 - STAIR_HEIGHT <= m_y1 && characterX1 == m_x2) {
+			if (characterY2 - STAIR_HEIGHT <= m_y1) {
 				// 適切な座標へ
-				characterController->setCharacterX(characterX1 - characterWide / 2);
+				characterController->setCharacterX(m_x2 - characterWide / 2 + characterVx);
 				characterController->setCharacterY(m_y1 - characterHeight);
 				// 着地
 				characterController->setCharacterGrand(true);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
いろいろ調整する。
大したことはやらない。
同時進行でやっている画像作成メインで。

# やったこと
- 落下中の画像を間違えてpreJump画像にしていたので修正した。
- 斬撃攻撃中はジャンプできないようにした。
- エリア移動やゲーム開始時に地上にいるはずのキャラが空中でスタートしないように調整
- 段差を上がるときの座標移動を調整

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
