### PR TITLE
Api: AIの修正(ジャンプの仕方の修正と受け身処理追加)

### DIFF
--- a/Debug.cpp
+++ b/Debug.cpp
@@ -32,7 +32,7 @@ void debugObjects(int x, int y, int color, std::vector<Object*> objects) {
 void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, anime=%d", m_characters.size(), m_characterControllers.size(), m_animations.size());
-	m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+	//m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 }
 
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -67,7 +67,7 @@ Game::Game() {
 	m_soundPlayer->setVolume(50);
 
 	// ¢ŠE
-	int startAreaNum = 0;
+	int startAreaNum = 1;
 	m_world = new World(-1, startAreaNum, m_soundPlayer);
 
 	// ƒf[ƒ^‚ğ¢ŠE‚É”½‰f


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
AIを修正する。ジャンプにバグ（常に最大ジャンプになる）があった。

# やったこと
ダメージを食らったときに目標地点をリセットする。
jumpOrder関数の戻り値を修正し、常に最大ジャンプになるバグを修正。
ダメージを食らっているときに確率でjumpOrderが1を返し、受け身をとる。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
戦っている敵が、ダメージを食らい続けても目標地点へ移動しようとして突っ込んでくることがなくなる。
敵のジャンプの高さにばらつきが出て面白い。
敵が受け身をとるため強くなった？

# できなくなること(ユーザ目線)
記入欄

# 動作確認
目視で確認。

# 懸念点
将来的に敵の攻撃確率はもう少し検討した方がいいかも。
