### PR TITLE
Api: ストーリーとイベントの進行機能追加

### DIFF
--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -349,6 +349,17 @@ CharacterController::~CharacterController() {
 	}
 }
 
+void CharacterController::setAction(CharacterAction* action) {
+	delete m_characterAction;
+	m_characterAction = action;
+	m_brain->setCharacterAction(m_characterAction);
+}
+void CharacterController::setBrain(Brain* brain) {
+	delete m_brain;
+	m_brain = brain;
+	m_brain->setCharacterAction(m_characterAction);
+}
+
 // アクションのセッタ
 void CharacterController::setCharacterGrand(bool grand) {
 	m_characterAction->setGrand(grand);

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -79,6 +79,25 @@ public:
 };
 
 /*
+* 全く動かないAI
+*/
+class Freeze :
+	public Brain
+{
+public:
+	Freeze(){ }
+	void debug(int x, int y, int color) const { }
+	bool actionOrder() { return false; }
+	void setCharacterAction(const CharacterAction* characterAction) {  }
+	void bulletTargetPoint(int& x, int& y) {  }
+	void moveOrder(int& right, int& left, int& up, int& down) { right = 0; left = 0; up = 0; down = 0; }
+	int jumpOrder() { return 0; }
+	int squatOrder() { return 0; }
+	int slashOrder() { return 0; }
+	int bulletOrder() { return 0; }
+};
+
+/*
 *  普通に敵と戦うよう命令するＡＩのクラス
 */
 class NormalAI :
@@ -194,6 +213,10 @@ public:
 	// ゲッタ
 	inline const CharacterAction* getAction() const { return m_characterAction; }
 	inline const Brain* getBrain() const { return m_brain; }
+
+	// セッタ
+	void setAction(CharacterAction* action);
+	void setBrain(Brain* brain);
 
 	// 話しかけたり扉に入ったりするボタンがtrueか
 	virtual bool getActionKey() const { return m_brain->actionOrder(); }

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -313,6 +313,9 @@ void AreaReader::loadCharacter(std::map<std::string, std::string> dataMap) {
 	else if (brainName == "followNormalAI") {
 		brain = new FollowNormalAI();
 	}
+	else if (brainName == "freeze") {
+		brain = new Freeze();
+	}
 
 	if (brain == NULL) { return; }
 

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -114,6 +114,80 @@ vector<map<string, string>> CsvReader::getData() const {
 }
 
 
+// ファイル名を指定してCSVファイルを読み込む
+CsvReader2::CsvReader2(const char* fileName) {
+
+	// ファイルポインタ
+	int fp;
+
+	// バッファ
+	const int size = 512;
+	char buff[size];
+
+	// ファイルを開く
+	fp = FileRead_open(fileName);
+
+	string domainName = "";
+	// ファイルの終端までループ
+	while (FileRead_eof(fp) == 0) {
+		// いったんバッファに一行分のテキストを入れる
+		FileRead_gets(buff, size, fp);
+
+		// 一行分のテキストをデータにしてVectorに変換
+		vector<string> oneDataVector = csv2vector(buff);
+
+		if (oneDataVector[1] == "") {
+			domainName = oneDataVector[0];
+			FileRead_gets(buff, size, fp);
+			m_columnNames[domainName] = csv2vector(buff);
+		}
+		else {
+			// vectorとカラム名を使ってmapを生成
+			map<string, string> oneData;
+			for (int i = 0; i < oneDataVector.size(); i++) {
+				oneData[m_columnNames[domainName][i]] = oneDataVector[i];
+			}
+
+			// 一行分のmapデータをpush_back
+			m_data[domainName].push_back(oneData);
+		}
+	}
+
+	// ファイルを閉じる
+	FileRead_close(fp);
+}
+
+
+/*
+* ドメイン名がdomainNameのデータから、
+* カラム名がvalueのデータを取得
+* 例：findOne("name", "キャラ名");
+* 見つからなかったら空のデータを返す
+*/
+map<string, string> CsvReader2::findOne(const char* domainName, const char* columnName, const char* value) {
+
+	// m_data[i][columnName] == valueとなるiを調べる
+	map<string, string>::iterator ite;
+	for (int i = 0; i < m_data.size(); i++) {
+
+		// カラム名に対応する値を取得
+		ite = m_data[domainName][i].find(columnName);
+
+		// そのカラム名が存在しない
+		if (ite == m_data[domainName][i].end()) { continue; }
+
+		// 条件に一致
+		if (ite->second == value) {
+			return m_data[domainName][i];
+		}
+	}
+
+	// 空のデータを返す
+	map<string, string> res;
+	return res;
+}
+
+
 // 色の名前から色ハンドルを取得
 int str2color(string colorName) {
 	if (colorName == "white") { return WHITE; }
@@ -138,77 +212,36 @@ AreaReader::AreaReader(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer)
 	m_backGroundColor = -1;
 	m_bgmName = "";
 
-	// ファイルポインタ
-	int fp;
-
-	// バッファ
-	char buff[256];
-
 	// ファイルを開く
 	ostringstream fileName;
 	fileName << "data/area/area" << toAreaNum << ".csv";
-	fp = FileRead_open(fileName.str().c_str());
 
-	LOAD_AREA now = LOAD_AREA::BGM;
-	vector<string> columnNames;
+	CsvReader2 csvReader2(fileName.str().c_str());
 
-	while (FileRead_eof(fp) == 0) {
-		FileRead_gets(buff, 256, fp);
-		vector<string> oneData = csv2vector(buff);
-		if (oneData[0] == "") { break; }
-
-		if (oneData[0] == "BGM:") {
-			now = LOAD_AREA::BGM;
-			FileRead_gets(buff, 256, fp);
-			columnNames = csv2vector(buff);
-		}
-		else if (oneData[0] == "CHARACTER:") {
-			now = LOAD_AREA::CHARACTER;
-			FileRead_gets(buff, 256, fp);
-			columnNames = csv2vector(buff);
-		}
-		else if (oneData[0] == "OBJECT:") {
-			now = LOAD_AREA::OBJECT;
-			FileRead_gets(buff, 256, fp);
-			columnNames = csv2vector(buff);
-		}
-		else if (oneData[0] == "BACKGROUND:") {
-			now = LOAD_AREA::BACKGROUND;
-			FileRead_gets(buff, 256, fp);
-			columnNames = csv2vector(buff);
-		}
-		else {
-			// データを1行分読み込んだ場合
-			map<string, string> dataMap;
-			for (int i = 0; i < oneData.size(); i++) {
-				dataMap[columnNames[i]] = oneData[i];
-			}
-			map2instance(dataMap, now);
-		}
+	vector<map<string, string> > data;
+	// BGM
+	data = csvReader2.getDomainData("BGM:");
+	for (unsigned int i = 0; i < data.size(); i++) {
+		loadBGM(data[i]);
 	}
-
-	// ファイルを閉じる
-	FileRead_close(fp);
+	// CHARACTER
+	data = csvReader2.getDomainData("CHARACTER:");
+	for (unsigned int i = 0; i < data.size(); i++) {
+		loadCharacter(data[i]);
+	}
+	// OBJECT
+	data = csvReader2.getDomainData("OBJECT:");
+	for (unsigned int i = 0; i < data.size(); i++) {
+		loadObject(data[i]);
+	}
+	// BACKGROUND
+	data = csvReader2.getDomainData("BACKGROUND:");
+	for (unsigned int i = 0; i < data.size(); i++) {
+		loadBackGround(data[i]);
+	}
 
 	setPlayer();
 	setFollow();
-}
-
-void AreaReader::map2instance(map<string, string> dataMap, LOAD_AREA now) {
-	switch (now) {
-	case LOAD_AREA::BGM:
-		loadBGM(dataMap);
-		break;
-	case LOAD_AREA::CHARACTER:
-		loadCharacter(dataMap);
-		break;
-	case LOAD_AREA::OBJECT:
-		loadObject(dataMap);
-		break;
-	case LOAD_AREA::BACKGROUND:
-		loadBackGround(dataMap);
-		break;
-	}
 }
 
 // BGMのロード

--- a/CsvReader.h
+++ b/CsvReader.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <sstream>
 
+
 class CsvReader {
 private:
 	/*
@@ -33,6 +34,35 @@ public:
 	* 全データを返す
 	*/
 	std::vector<std::map<std::string, std::string> > getData() const;
+};
+
+
+class CsvReader2 {
+private:
+	/*
+	* データ
+	* m_data[行番号]<カラム名, データ>
+	*/
+	std::map<std::string, std::vector<std::map<std::string, std::string> > > m_data;
+
+	/*
+	* カラム名のリスト
+	*/
+	std::map<std::string, std::vector<std::string> > m_columnNames;
+
+public:
+	// ファイル名を指定してCSVファイルを読み込む
+	CsvReader2(const char* fileName);
+
+	/*
+	* ドメイン名がdomainNameのデータから、
+	* カラム名がvalueのデータを取得
+	* 例：findOne("Character", "Name", "キャラ名");
+	*/
+	std::map<std::string, std::string> findOne(const char* domainName, const char* columnName, const char* value);
+
+	std::vector<std::map<std::string, std::string> > getDomainData(const char* domainName) { return m_data[domainName]; }
+
 };
 
 
@@ -82,13 +112,6 @@ private:
 	// プレイヤーのキャラのポインタ
 	Character* m_playerCharacter_p;
 
-	enum class LOAD_AREA {
-		BGM,
-		CHARACTER,
-		OBJECT,
-		BACKGROUND
-	};
-
 public:
 	AreaReader(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer);
 
@@ -116,7 +139,6 @@ public:
 	}
 
 private:
-	void map2instance(std::map<std::string, std::string> dataMap, LOAD_AREA now);
 	void loadBGM(std::map<std::string, std::string> dataMap);
 	void loadCharacter(std::map<std::string, std::string> dataMap);
 	void loadObject(std::map<std::string, std::string> dataMap);

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -15,7 +15,8 @@
 // Gameクラスのデバッグ
 void Game::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**GAME**");
-	m_world->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE, color);
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "StoryNum=%d", m_gameData->getStoryNum());
+	m_world->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 }
 
 

--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -161,6 +161,7 @@
     <ClCompile Include="Control.cpp" />
     <ClCompile Include="CsvReader.cpp" />
     <ClCompile Include="Debug.cpp" />
+    <ClCompile Include="Event.cpp" />
     <ClCompile Include="Game.cpp" />
     <ClCompile Include="GameDrawer.cpp" />
     <ClCompile Include="GraphHandle.cpp" />
@@ -168,6 +169,7 @@
     <ClCompile Include="Object.cpp" />
     <ClCompile Include="ObjectDrawer.cpp" />
     <ClCompile Include="Sound.cpp" />
+    <ClCompile Include="Story.cpp" />
     <ClCompile Include="World.cpp" />
     <ClCompile Include="WorldDrawer.cpp" />
   </ItemGroup>
@@ -182,12 +184,14 @@
     <ClInclude Include="Control.h" />
     <ClInclude Include="CsvReader.h" />
     <ClInclude Include="Define.h" />
+    <ClInclude Include="Event.h" />
     <ClInclude Include="Game.h" />
     <ClInclude Include="GameDrawer.h" />
     <ClInclude Include="GraphHandle.h" />
     <ClInclude Include="Object.h" />
     <ClInclude Include="ObjectDrawer.h" />
     <ClInclude Include="Sound.h" />
+    <ClInclude Include="Story.h" />
     <ClInclude Include="World.h" />
     <ClInclude Include="WorldDrawer.h" />
   </ItemGroup>

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -90,6 +90,12 @@
     <ClCompile Include="AnimationDrawer.cpp">
       <Filter>ソース ファイル\ui</Filter>
     </ClCompile>
+    <ClCompile Include="Story.cpp">
+      <Filter>ソース ファイル\api</Filter>
+    </ClCompile>
+    <ClCompile Include="Event.cpp">
+      <Filter>ソース ファイル\api</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">
@@ -145,6 +151,12 @@
     </ClInclude>
     <ClInclude Include="AnimationDrawer.h">
       <Filter>ヘッダー ファイル\ui</Filter>
+    </ClInclude>
+    <ClInclude Include="Story.h">
+      <Filter>ヘッダー ファイル\api</Filter>
+    </ClInclude>
+    <ClInclude Include="Event.h">
+      <Filter>ヘッダー ファイル\api</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Event.cpp
+++ b/Event.cpp
@@ -1,0 +1,175 @@
+#include "Event.h"
+#include "World.h"
+#include "Sound.h"
+#include "CsvReader.h"
+#include <sstream>
+
+using namespace std;
+
+
+// csvから取得したparam1～paramNのmapをvectorに変換
+vector<string> mapParam2vector(map<string, string> paramMap) {
+	vector<string> res;
+	int paramNum = 0;
+	while (true) {
+		ostringstream oss;
+		oss << "param" << paramNum;
+		if (paramMap.find(oss.str()) != paramMap.end()) {
+			res.push_back(paramMap[oss.str()]);
+			paramNum++;
+		}
+		else {
+			break;
+		}
+	}
+	return res;
+}
+
+
+/*
+* イベント
+*/
+Event::Event(int eventNum, World* world, SoundPlayer* soundPlayer) {
+
+	m_eventNum = eventNum;
+	m_nowElement = 0;
+
+	ostringstream oss;
+	oss << "data/event/event" << eventNum << ".csv";
+	CsvReader2 csvReader2(oss.str().c_str());
+
+	// 発火条件
+	vector<map<string, string> > fireData = csvReader2.getDomainData("FIRE:");
+	for (unsigned int i = 0; i < fireData.size(); i++) {
+		m_eventFire.push_back(new CharacterPointFire(world, mapParam2vector(fireData[i])));
+	}
+
+	// イベントの内容
+	vector<map<string, string> > elementsData = csvReader2.getDomainData("ELEMENT:");
+	for (unsigned int i = 0; i < elementsData.size(); i++) {
+		m_eventElement.push_back(new ChangeBrainEvent(world, mapParam2vector(elementsData[i])));
+	}
+
+}
+
+// Fireの作成
+void Event::createFire(vector<string> param, World* world, SoundPlayer* soundPlayer) {
+	string param0 = param[0];
+	EventFire* fire = NULL;
+
+	if (param0 == "CharacterPoint") {
+		fire = new CharacterPointFire(world, param);
+	}
+
+	if (fire != NULL) { m_eventFire.push_back(fire); }
+}
+
+// Elementの作成
+void Event::createElement(vector<string> param, World* world, SoundPlayer* soundPlayer) {
+	string param0 = param[0];
+	EventElement* element = NULL;
+
+	if (param0 == "ChangeBrain") {
+		element = new ChangeBrainEvent(world, param);
+	}
+
+	if (element != NULL) { m_eventElement.push_back(element); }
+}
+
+Event::~Event() {
+	for (unsigned int i = 0; i < m_eventFire.size(); i++) {
+		delete m_eventFire[i];
+	}
+	for (unsigned int i = 0; i < m_eventElement.size(); i++) {
+		delete m_eventElement[i];
+	}
+}
+
+bool Event::fire() {
+	for (unsigned int i = 0; i < m_eventFire.size(); i++) {
+		if (!m_eventFire[i]->fire()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+EVENT_RESULT Event::play() {
+
+	EVENT_RESULT result = m_eventElement[m_nowElement]->play();
+
+	// Elementが一つ成功した
+	if (result == EVENT_RESULT::SUCCESS) {
+		// 次のエレメントへ
+		m_nowElement++;
+		if (m_nowElement == m_eventElement.size()) { 
+			// イベントおわり
+			return EVENT_RESULT::SUCCESS;
+		}
+		else { 
+			// まだイベント続く
+			return EVENT_RESULT::NOW;
+		}
+	}
+
+	return result;
+}
+
+
+
+/*
+* イベントの発火条件
+*/
+EventFire::EventFire(World* world) {
+	m_world_p = world;
+}
+
+// 特定のキャラが指定した座標にいる
+CharacterPointFire::CharacterPointFire(World* world, std::vector<std::string> param) :
+	EventFire(world)
+{
+	m_characterName = param[1];
+	m_areaNum = stoi(param[2]);
+	m_x = stoi(param[3]);
+	m_y = stoi(param[4]);
+	m_dx = stoi(param[5]);
+	m_dy = stoi(param[6]);
+}
+bool CharacterPointFire::fire() {
+	// 特定のキャラが指定した場所にいるか判定
+	return false;
+}
+
+
+
+/*
+* イベントの構成要素
+*/
+EventElement::EventElement(World* world) {
+	m_world_p = world;
+}
+
+
+// キャラのBrainを変更する
+ChangeBrainEvent::ChangeBrainEvent(World* world, std::vector<string> param) :
+	EventElement(world)
+{
+	m_brainName = param[1];
+	m_characterName = param[2];
+}
+EVENT_RESULT ChangeBrainEvent::play() {
+	// 対象のキャラのBrainを変更する
+	return EVENT_RESULT::SUCCESS;
+}
+
+// 特定のキャラのHPが0になるまで戦う
+DeadCharacterEvent::DeadCharacterEvent(World* world, std::vector<std::string> param) :
+	EventElement(world)
+{
+	m_characterName = param[0];
+}
+EVENT_RESULT DeadCharacterEvent::play() {
+	m_world_p->battle();
+	// 対象のキャラのHPをチェックする
+	return EVENT_RESULT::SUCCESS;
+}

--- a/Event.h
+++ b/Event.h
@@ -7,6 +7,8 @@
 
 class World;
 class SoundPlayer;
+class CharacterController;
+class Character;
 
 
 enum class EVENT_RESULT {
@@ -91,7 +93,7 @@ class CharacterPointFire :
 {
 private:
 	// キャラの名前
-	std::string m_characterName;
+	Character* m_character_p;
 
 	// エリア番号
 	int m_areaNum;
@@ -122,7 +124,7 @@ private:
 	std::string m_brainName;
 
 	// 対象のキャラ
-	std::string m_characterName;
+	CharacterController* m_controller_p;
 
 public:
 	ChangeBrainEvent(World* world, std::vector<std::string> param);
@@ -137,7 +139,7 @@ class DeadCharacterEvent :
 private:
 
 	// 対象のキャラ
-	std::string m_characterName;
+	Character* m_character_p;
 
 public:
 	DeadCharacterEvent(World* world, std::vector<std::string> param);

--- a/Event.h
+++ b/Event.h
@@ -1,0 +1,148 @@
+#ifndef EVENT_H_INCLUDED
+#define EVENT_H_INCLUDED
+
+#include <vector>
+#include <string>
+
+
+class World;
+class SoundPlayer;
+
+
+enum class EVENT_RESULT {
+	NOW,
+	SUCCESS,
+	FAILURE
+};
+
+
+/*
+* イベントの発火条件 Worldに変化を加えない
+*/
+class EventFire {
+protected:
+
+	// イベントが起きるWorld
+	const World* m_world_p;
+
+public:
+	EventFire(World* world);
+
+	virtual bool fire() = 0;
+};
+
+
+/*
+* イベントを構成する要素
+*/
+class EventElement {
+protected:
+
+	// イベントが起きているWorld
+	World* m_world_p;
+
+public:
+	EventElement(World* world);
+	virtual EVENT_RESULT play() = 0;
+};
+
+
+/*
+* イベント
+* EventElementを管理する
+*/
+class Event {
+private:
+
+	// イベント番号
+	int m_eventNum;
+
+	// イベントの発火条件
+	std::vector<EventFire*> m_eventFire;
+
+	// イベントの要素
+	std::vector<EventElement*> m_eventElement;
+
+	// イベントの進捗(EventElementのインデックス)
+	int m_nowElement;
+
+public:
+	Event(int eventNum, World* world, SoundPlayer* soundPlayer);
+	~Event();
+
+	// 発火
+	bool fire();
+
+	// イベント進行
+	EVENT_RESULT play();
+
+private:
+	void createFire(std::vector<std::string> param, World* world, SoundPlayer* soundPlayer);
+	void createElement(std::vector<std::string> param, World* world, SoundPlayer* soundPlayer);
+};
+
+
+/*
+* EventFireの派生クラス
+*/
+// 特定のキャラが指定した座標にいる
+class CharacterPointFire :
+	public	EventFire
+{
+private:
+	// キャラの名前
+	std::string m_characterName;
+
+	// エリア番号
+	int m_areaNum;
+
+	// 目標座標
+	int m_x, m_y;
+
+	// 座標のずれの許容
+	int m_dx, m_dy;
+
+public:
+	CharacterPointFire(World* world, std::vector<std::string> param);
+
+	bool fire();
+};
+
+
+/*
+* EventElementの派生クラス
+*/
+// キャラのAIを変える
+class ChangeBrainEvent :
+	public EventElement
+{
+private:
+
+	// Brainのクラス名
+	std::string m_brainName;
+
+	// 対象のキャラ
+	std::string m_characterName;
+
+public:
+	ChangeBrainEvent(World* world, std::vector<std::string> param);
+
+	EVENT_RESULT play();
+};
+
+// 特定のキャラのHPが0になるまで戦う
+class DeadCharacterEvent :
+	public EventElement
+{
+private:
+
+	// 対象のキャラ
+	std::string m_characterName;
+
+public:
+	DeadCharacterEvent(World* world, std::vector<std::string> param);
+
+	EVENT_RESULT play();
+};
+
+#endif

--- a/Game.cpp
+++ b/Game.cpp
@@ -2,6 +2,7 @@
 #include "World.h"
 #include "Define.h"
 #include "Sound.h"
+#include "Story.h"
 #include "DxLib.h"
 
 /*
@@ -21,6 +22,7 @@ GameData::GameData() {
 	m_saveFilePath = "data/save/savedata1.dat";
 
 	m_areaNum = 1;
+	m_storyNum = 1;
 
 	// 主要キャラを設定
 	m_characterData.push_back("ハート");
@@ -67,11 +69,14 @@ Game::Game() {
 	m_soundPlayer->setVolume(50);
 
 	// 世界
-	int startAreaNum = 1;
+	int startAreaNum = 0;
 	m_world = new World(-1, startAreaNum, m_soundPlayer);
 
 	// データを世界に反映
 	m_gameData->asignWorld(m_world);
+
+	// ストーリー
+	m_story = new Story(m_gameData->getStoryNum(), m_world, m_soundPlayer);
 }
 
 Game::~Game() {
@@ -82,7 +87,15 @@ Game::~Game() {
 
 bool Game::play() {
 	// 戦わせる
-	m_world->battle();
+	// m_world->battle();
+	
+	// ストーリー進行
+	if (m_story->play()) {
+		// 次のストーリーへ
+		m_gameData->setStoryNum(m_gameData->getStoryNum() + 1);
+		delete m_story;
+		m_story = new Story(m_gameData->getStoryNum(), m_world, m_soundPlayer);
+	}
 
 	// 音
 	m_soundPlayer->play();

--- a/Game.cpp
+++ b/Game.cpp
@@ -21,8 +21,8 @@ CharacterData::CharacterData(const char* name) {
 GameData::GameData() {
 	m_saveFilePath = "data/save/savedata1.dat";
 
-	m_areaNum = 1;
-	m_storyNum = 1;
+	m_areaNum = 0;
+	m_storyNum = 0;
 
 	// 主要キャラを設定
 	m_characterData.push_back("ハート");
@@ -86,8 +86,8 @@ Game::~Game() {
 }
 
 bool Game::play() {
-	// 戦わせる
-	// m_world->battle();
+	 // 戦わせる
+	 // m_world->battle();
 	
 	// ストーリー進行
 	if (m_story->play()) {

--- a/Game.h
+++ b/Game.h
@@ -5,6 +5,7 @@
 
 class SoundPlayer;
 class World;
+class Story;
 
 
 // キャラのセーブデータ
@@ -36,15 +37,20 @@ private:
 	// 今いるエリア
 	int m_areaNum;
 
+	// 今やっているストーリー
+	int m_storyNum;
+
 public:
 	GameData();
 	GameData(const char* saveFilePath);
 
 	// ゲッタ
 	inline int getAreaNum() const { return m_areaNum; }
+	inline int getStoryNum() const { return m_storyNum; }
 
 	// セッタ
 	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }
+	inline void setStoryNum(int storyNum) { m_storyNum = storyNum; }
 
 	// 自身のデータをWorldにデータ反映させる
 	void asignWorld(World* world);
@@ -63,6 +69,9 @@ private:
 
 	// 世界
 	World* m_world;
+
+	// ストーリー
+	Story* m_story;
 
 public:
 	Game();

--- a/Story.cpp
+++ b/Story.cpp
@@ -1,0 +1,77 @@
+#include "Story.h"
+#include "Event.h"
+#include "CsvReader.h"
+#include "World.h"
+#include "Sound.h"
+#include <sstream>
+
+using namespace std;
+
+
+Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer) {
+	m_world_p = world;
+	m_nowEvent = NULL;
+	m_storyNum = storyNum;
+
+	ostringstream oss;
+	oss << "data/story/story" << storyNum << ".csv";
+	CsvReader2 csvReader2(oss.str().c_str());
+
+	// イベント生成
+	vector<map<string, string> > eventData = csvReader2.getDomainData("EVENT:");
+	for (unsigned int i = 0; i < eventData.size(); i++) {
+		int eventNum = stoi(eventData[i]["num"]);
+		bool mustFlag = (bool)stoi(eventData[i]["mustFlag"]);
+		Event* eventOne = new Event(eventNum, world, soundPlayer);
+		if (mustFlag) { m_mustEvent.push_back(eventOne); }
+		else { m_subEvent.push_back(eventOne); }
+	}
+}
+
+Story::~Story() {
+	for (unsigned int i = 0; i < m_mustEvent.size(); i++) {
+		delete m_mustEvent[i];
+	}
+	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
+		delete m_subEvent[i];
+	}
+}
+
+bool Story::play() {
+	if (m_nowEvent == NULL) {
+		// 普通に世界を動かす
+		m_world_p->battle();
+		// イベントの発火確認
+		for (unsigned int i = 0; i < m_mustEvent.size(); i++) {
+			if (m_mustEvent[i]->fire()) {
+				m_nowEvent = m_mustEvent[i];
+				m_mustEvent[i] = m_mustEvent.back();
+				m_mustEvent.pop_back();
+				i--;
+			}
+		}
+		for (unsigned int i = 0; i < m_subEvent.size(); i++) {
+			if (m_subEvent[i]->fire()) {
+				m_nowEvent = m_subEvent[i];
+				m_subEvent[i] = m_subEvent.back();
+				m_subEvent.pop_back();
+				i--;
+			}
+		}
+	}
+	else {
+		// イベント進行中
+		EVENT_RESULT result = m_nowEvent->play();
+		// イベント終了
+		if (result != EVENT_RESULT::NOW) {
+			delete m_nowEvent;
+			m_nowEvent = NULL;
+		}
+	}
+
+	// 必須イベント全て終わり
+	if (m_mustEvent.size() == 0 && m_nowEvent == NULL) { 
+		return true;
+	}
+	return false;
+}

--- a/Story.h
+++ b/Story.h
@@ -1,0 +1,37 @@
+#ifndef STORY_H_INCLUDED
+#define STORY_H_INCLUDED
+
+#include <vector>
+
+class Event;
+class World;
+class SoundPlayer;
+
+// ストーリ－
+class Story {
+private:
+
+	// 対象の世界
+	World* m_world_p;
+
+	// ストーリー番号
+	int m_storyNum;
+
+	// 進行中のイベント
+	Event* m_nowEvent;
+	
+	// クリア必須イベント
+	std::vector<Event*> m_mustEvent;
+	
+	// クリア任意イベント
+	std::vector<Event*> m_subEvent;
+
+public:
+	Story(int storyNum, World* world, SoundPlayer* soundPlayer);
+	~Story();
+
+	bool play();
+};
+
+
+#endif

--- a/World.cpp
+++ b/World.cpp
@@ -442,3 +442,22 @@ void World::atariAttackAndAttack() {
 void World::talk() {
 
 }
+
+
+Character* World::getCharacterWithName(string characterName) const {
+	for (unsigned int i = 0; i < m_characters.size(); i++) {
+		if (m_characters[i]->getName() == characterName) {
+			return m_characters[i];
+		}
+	}
+	return NULL;
+}
+
+CharacterController* World::getControllerWithName(string characterName) const {
+	for (unsigned int i = 0; i < m_characters.size(); i++) {
+		if (m_characterControllers[i]->getAction()->getCharacter()->getName() == characterName) {
+			return m_characterControllers[i];
+		}
+	}
+	return NULL;
+}

--- a/World.h
+++ b/World.h
@@ -2,6 +2,7 @@
 #define WORLD_H_INCLUDE
 
 #include <vector>
+#include <string>
 
 class CharacterController;
 class CharacterAction;
@@ -83,6 +84,12 @@ public:
 
 	// キャラの状態を教える
 	void asignCharacterData(const char* name, int& hp);
+
+	/*
+	* イベント用
+	*/
+	Character* getCharacterWithName(std::string characterName) const;
+	CharacterController* getControllerWithName(std::string characterName) const;
 
 private:
 	// キャラクターとオブジェクトの当たり判定


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
csvファイルを読み込みストーリーに沿って世界が動くようになる。
ストーリーはいくつかのイベントで構成される。
完了が必須のイベントがすべて終わると次のストーリーが読み込まれる。

また、イベントはいくつかのFireとEventElementで構成される。
Fireはイベントの発火条件を意味する。すべてが発火するとイベントがスタートする。
イベントがスタートすると、各EventElementがキャラの移動や変更、BGMの変更、会話などを行う。

# やったこと
Storyクラス、Eventクラス、EventFireクラス、EventElementクラス実装。
Brainの派生クラスとしてFreezeクラスを実装。一切操作しないAI。

GameDataクラスはstoryNumを保持し、ストーリーが１つ終わるとインクリメントしStoryクラスを作り直す。

StoryクラスはコンストラクタでEventクラスを作成、必須と任意のイベントに分けて保持する。
最初イベントはスタートしていない状態。for文ですべてのEventのfireを確認する。trueのイベント1つがスタートする。
同時に2つ以上のイベントは発火しない。
動いているイベントがあるときは、終わるまでそのイベントの処理をする。

Eventクラスは保持するFireクラスで発火状態をStoryに知らせる。FireはWorldクラスをconstで保持する。
イベント進行時はEventクラスのplayを呼び出す。playはEventが保持するEventElementを1つ実行する。
EventElementはWorldクラスを保持しており、Worldに変更を加えることができる。
EventElementが終わると、Eventは次のEventElementを実行するようになる。
すべてのEventElementが終わると、そのEventは終了する。

Storyはイベントが終わると、再びすべてのイベントの発火状態を確認する処理に戻る。
すべての必須イベントが終わったならStoryはGameにそれを知らせる。
Gameはそれを知らされると、Storyをdeleteし、前述したように次のストーリーへ移る。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
story0.csvとevent0.csvで最低限の処理を確認。
Freeze状態のシエスタに近づくと敵対し攻撃してくる。
倒すと次のストーリーへ移る。
GameData::storyNumが加算されていることをデバッグモードで確認した。

# 懸念点
キャラやオブジェクトの座標指定が面倒。複数のファイルで整合性をとるように気を付ける必要がある。
当初の予定ではEventのスタート時の初期化処理を実装するつもりだった。しかし初期化処理は実装せずEventElementに入れても問題ないと思う。
