### PR TITLE
Api: 会話機能の追加

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -134,6 +134,7 @@ Character::Character(int hp, int x, int y, int groupId) {
 	m_characterInfo = NULL;
 	m_attackInfo = NULL;
 	m_graphHandle = NULL;
+	m_faceHandle = NULL;
 }
 
 Character::~Character() {
@@ -148,6 +149,10 @@ Character::~Character() {
 	// GraphHandleの削除
 	if (m_graphHandle != NULL) {
 		delete m_graphHandle;
+	}
+	// FaceHandleの削除
+	if (m_faceHandle != NULL) {
+		delete m_faceHandle;
 	}
 }
 
@@ -244,6 +249,7 @@ Heart::Heart(const char* name, int hp, int x, int y, int groupId) :
 
 	// 各画像のロード
 	m_graphHandle = new CharacterGraphHandle(name, m_characterInfo->handleEx());
+	m_faceHandle = new FaceGraphHandle(name, 1.0);
 
 	// とりあえず立ち画像でスタート
 	switchStand();

--- a/Character.h
+++ b/Character.h
@@ -8,6 +8,7 @@ class Object;
 class GraphHandle;
 class GraphHandles;
 class CharacterGraphHandle;
+class FaceGraphHandle;
 class SoundPlayer;
 
 
@@ -185,8 +186,11 @@ protected:
 	// 攻撃の情報
 	AttackInfo* m_attackInfo;
 
-	// 画像
+	// キャラ画像
 	CharacterGraphHandle* m_graphHandle;
+
+	// 顔画像
+	FaceGraphHandle* m_faceHandle;
 
 public:
 	// コンストラクタ
@@ -205,6 +209,7 @@ public:
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline bool getLeftDirection() const { return m_leftDirection; }
+	FaceGraphHandle* getFaceHandle() const { return m_faceHandle; }
 
 	// セッタ
 	inline void setHp(int hp) { m_hp = (hp > m_characterInfo->maxHp()) ? m_characterInfo->maxHp() : hp; }

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -226,7 +226,7 @@ int NormalAI::bulletOrder() {
 		return 0;
 	}
 	// ランダムで射撃
-	if (GetRand(50) == 0) { 
+	if (GetRand(30) == 0) { 
 		return 1;
 	}
 	return 0;
@@ -253,6 +253,18 @@ bool NormalAI::needSearchTarget() const {
 		return true;
 	}
 	return false;
+}
+
+
+void ParabolaAI::bulletTargetPoint(int& x, int& y) {
+	if (m_target_p == NULL) {
+		x = 0;
+		y = 0;
+	}
+	else { // ターゲットに向かって射撃攻撃
+		x = m_target_p->getCenterX() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2);
+		y = m_target_p->getCenterY() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2) - 200;
+	}
 }
 
 

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -104,8 +104,6 @@ class NormalAI :
 	public Brain
 {
 private:
-	// 攻撃対象
-	const Character* m_target_p;
 
 	// 攻撃対象を認知する距離
 	const int TARGET_DISTANCE = 2000;
@@ -120,6 +118,9 @@ private:
 	int m_squatCnt;
 
 protected:
+	// 攻撃対象
+	const Character* m_target_p;
+
 	// 射撃の精度
 	const int BULLET_ERROR = 400;
 
@@ -158,6 +159,13 @@ public:
 protected:
 	// スティック操作
 	void stickOrder(int& right, int& left, int& up, int& down);
+};
+
+
+class ParabolaAI :
+	public NormalAI
+{
+	void bulletTargetPoint(int& x, int& y);
 };
 
 

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -7,6 +7,9 @@
 #include "GraphHandle.h"
 #include "Animation.h"
 #include "Define.h"
+#include "Text.h"
+#include "Event.h"
+#include "Story.h"
 #include "DxLib.h"
 
 /*
@@ -16,7 +19,8 @@
 void Game::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**GAME**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "StoryNum=%d", m_gameData->getStoryNum());
-	m_world->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+	//m_story->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+	m_world->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
 }
 
 
@@ -33,7 +37,20 @@ void debugObjects(int x, int y, int color, std::vector<Object*> objects) {
 void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, anime=%d", m_characters.size(), m_characterControllers.size(), m_animations.size());
+	if (m_conversation_p != NULL) {
+		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "cnt=%d, now=%d, text:%s", m_conversation_p->getCnt(), m_conversation_p->getTextNow(), m_conversation_p->getText().c_str());
+		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "size=%d, fullText:%s", m_conversation_p->getTextSize(), m_conversation_p->getFullText().c_str());
+		m_conversation_p->getGraph()->draw(GAME_WIDE-500, 500, 1.0);
+	}
 	//m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+}
+
+
+/*
+* Story
+*/
+void Story::debug(int x, int y, int color) {
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "**Story**");
 }
 
 

--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="ObjectDrawer.cpp" />
     <ClCompile Include="Sound.cpp" />
     <ClCompile Include="Story.cpp" />
+    <ClCompile Include="Text.cpp" />
     <ClCompile Include="World.cpp" />
     <ClCompile Include="WorldDrawer.cpp" />
   </ItemGroup>
@@ -192,6 +193,7 @@
     <ClInclude Include="ObjectDrawer.h" />
     <ClInclude Include="Sound.h" />
     <ClInclude Include="Story.h" />
+    <ClInclude Include="Text.h" />
     <ClInclude Include="World.h" />
     <ClInclude Include="WorldDrawer.h" />
   </ItemGroup>

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClCompile Include="Event.cpp">
       <Filter>ソース ファイル\api</Filter>
     </ClCompile>
+    <ClCompile Include="Text.cpp">
+      <Filter>ソース ファイル\api</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">
@@ -156,6 +159,9 @@
       <Filter>ヘッダー ファイル\api</Filter>
     </ClInclude>
     <ClInclude Include="Event.h">
+      <Filter>ヘッダー ファイル\api</Filter>
+    </ClInclude>
+    <ClInclude Include="Text.h">
       <Filter>ヘッダー ファイル\api</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Event.h
+++ b/Event.h
@@ -9,6 +9,7 @@ class World;
 class SoundPlayer;
 class CharacterController;
 class Character;
+class Conversation;
 
 
 enum class EVENT_RESULT {
@@ -143,6 +144,21 @@ private:
 
 public:
 	DeadCharacterEvent(World* world, std::vector<std::string> param);
+
+	EVENT_RESULT play();
+};
+
+// 会話イベント
+class TalkEvent :
+	public EventElement
+{
+private:
+
+	Conversation* m_conversation;
+
+public:
+	TalkEvent(World* world, SoundPlayer* soundPlayer, std::vector<std::string> param);
+	~TalkEvent();
 
 	EVENT_RESULT play();
 };

--- a/Game.cpp
+++ b/Game.cpp
@@ -88,6 +88,11 @@ Game::~Game() {
 bool Game::play() {
 	 // 戦わせる
 	 // m_world->battle();
+
+	// これ以上ストーリーを進ませない（テスト用）
+	if (m_gameData->getStoryNum() == 1) {
+		return false;
+	}
 	
 	// ストーリー進行
 	if (m_story->play()) {

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -104,11 +104,11 @@ void GraphHandles::draw(int x, int y, int index) {
 * キャラの画像
 */
 // 画像ロード用
-void loadCharacterGraph(const char* characterName, GraphHandles*& handles, string stateName, map<string, string>& data, double ex) {
+void loadCharacterGraph(const char* dir, const char* characterName, GraphHandles*& handles, string stateName, map<string, string>& data, double ex) {
 	int n = stoi(data[stateName]);
 	if (n > 0) {
 		ostringstream oss;
-		oss << "picture/stick/" << characterName << "/" << stateName;
+		oss << dir << characterName << "/" << stateName;
 		handles = new GraphHandles(oss.str().c_str(), n, ex, 0.0, true);
 	}
 	else {
@@ -132,23 +132,24 @@ CharacterGraphHandle::CharacterGraphHandle(const char* characterName, double dra
 	if (data.size() == 0) { data = reader.findOne("name", "テスト"); }
 
 	// ロード
-	loadCharacterGraph(characterName, m_standHandles, "stand", data, m_ex);
-	loadCharacterGraph(characterName, m_slashHandles, "slash", data, m_ex);
-	loadCharacterGraph(characterName, m_bulletHandles, "bullet", data, m_ex);
-	loadCharacterGraph(characterName, m_squatHandles, "squat", data, m_ex);
-	loadCharacterGraph(characterName, m_squatBulletHandles, "squatBullet", data, m_ex);
-	loadCharacterGraph(characterName, m_standBulletHandles, "standBullet", data, m_ex);
-	loadCharacterGraph(characterName, m_standSlashHandles, "standSlash", data, m_ex);
-	loadCharacterGraph(characterName, m_runHandles, "run", data, m_ex);
-	loadCharacterGraph(characterName, m_runBulletHandles, "runBullet", data, m_ex);
-	loadCharacterGraph(characterName, m_landHandles, "land", data, m_ex);
-	loadCharacterGraph(characterName, m_jumpHandles, "jump", data, m_ex);
-	loadCharacterGraph(characterName, m_downHandles, "down", data, m_ex);
-	loadCharacterGraph(characterName, m_preJumpHandles, "preJump", data, m_ex);
-	loadCharacterGraph(characterName, m_damageHandles, "damage", data, m_ex);
-	loadCharacterGraph(characterName, m_boostHandles, "boost", data, m_ex);
-	loadCharacterGraph(characterName, m_airBulletHandles, "airBullet", data, m_ex);
-	loadCharacterGraph(characterName, m_airSlashHandles, "airSlash", data, m_ex);
+	const char* dir = "picture/stick/";
+	loadCharacterGraph(dir, characterName, m_standHandles, "stand", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_slashHandles, "slash", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_bulletHandles, "bullet", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_squatHandles, "squat", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_squatBulletHandles, "squatBullet", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_standBulletHandles, "standBullet", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_standSlashHandles, "standSlash", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_runHandles, "run", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_runBulletHandles, "runBullet", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_landHandles, "land", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_jumpHandles, "jump", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_downHandles, "down", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_preJumpHandles, "preJump", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_damageHandles, "damage", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_boostHandles, "boost", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_airBulletHandles, "airBullet", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_airSlashHandles, "airSlash", data, m_ex);
 
 	switchStand();
 }
@@ -247,4 +248,31 @@ void CharacterGraphHandle::switchAirBullet(int index){
 // 空中斬撃画像をセット
 void CharacterGraphHandle::switchAirSlash(int index){
 	setGraph(m_airSlashHandles, index);
+}
+
+
+
+FaceGraphHandle::FaceGraphHandle():
+	FaceGraphHandle("テスト", 1.0)
+{
+
+}
+FaceGraphHandle::FaceGraphHandle(const char* characterName, double drawEx) {
+	m_ex = drawEx;
+	
+	CsvReader reader("data/faceGraph.csv");
+	// キャラ名でデータを検索
+	map<string, string> data = reader.findOne("name", characterName);
+	if (data.size() == 0) { data = reader.findOne("name", "テスト"); }
+
+	// ロード
+	const char* dir = "picture/face/";
+	loadCharacterGraph(dir, characterName, m_normalHandles, "通常", data, m_ex);
+
+}
+FaceGraphHandle::~FaceGraphHandle() {
+	delete m_normalHandles;
+}
+GraphHandles* FaceGraphHandle::getGraphHandle(const char* faceName) {
+	return m_normalHandles;
 }

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -209,4 +209,22 @@ public:
 };
 
 
+/*
+* ƒLƒƒƒ‰‚ÌŠç‰æ‘œ
+*/
+class FaceGraphHandle {
+private:
+	double m_ex;
+	// ’Êí
+	GraphHandles* m_normalHandles;
+
+public:
+	FaceGraphHandle();
+	FaceGraphHandle(const char* characterName, double drawEx);
+	~FaceGraphHandle();
+
+	GraphHandles* getGraphHandle(const char* faceName);
+};
+
+
 #endif

--- a/Main.cpp
+++ b/Main.cpp
@@ -83,8 +83,8 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		Update();
 		// デバッグ
 		if (debug == TRUE) {
-			Draw(0, 0, WHITE);
-			game.debug(0, DRAW_FORMAT_STRING_SIZE, WHITE);
+			Draw(0, 0, BLACK);
+			game.debug(0, DRAW_FORMAT_STRING_SIZE, BLACK);
 		}
 		Wait();
 		if (controlEsc() == TRUE) { DxLib_End(); }

--- a/Story.h
+++ b/Story.h
@@ -30,6 +30,8 @@ public:
 	Story(int storyNum, World* world, SoundPlayer* soundPlayer);
 	~Story();
 
+	void debug(int x, int y, int color);
+
 	bool play();
 };
 

--- a/Text.cpp
+++ b/Text.cpp
@@ -1,0 +1,120 @@
+#include "Text.h"
+#include "World.h"
+#include "GraphHandle.h"
+#include "Control.h"
+#include "Sound.h"
+#include "Character.h"
+#include "DxLib.h"
+#include <algorithm>
+#include <string>
+#include <sstream>
+
+
+using namespace std;
+
+
+Conversation::Conversation(int textNum, World* world, SoundPlayer* soundPlayer) {
+
+	m_finishFlag = false;
+	m_world_p = world;
+	m_soundPlayer_p = soundPlayer;
+	m_speakerName = "";
+	m_speakerGraph = NULL;
+	m_text = "";
+	m_textNow = 0;
+	m_cnt = 0;
+
+	// 効果音
+	m_displaySound = LoadSoundMem("sound/text/display.wav");
+	m_nextSound = LoadSoundMem("sound/text/next.wav");
+
+	// 対象のファイルを開く
+	ostringstream oss;
+	oss << "data/text/text" << textNum << ".txt";
+	m_fp = FileRead_open(oss.str().c_str());
+	setNextText();
+
+}
+
+Conversation::~Conversation() {
+	// 効果音削除
+	DeleteSoundMem(m_displaySound);
+	DeleteSoundMem(m_nextSound);
+	// ファイルを閉じる
+	FileRead_close(m_fp);
+}
+
+// テキストを返す（描画用）
+std::string Conversation::getText() const {
+	return m_text.substr(0, m_textNow);
+}
+
+// 画像を返す（描画用）
+GraphHandle* Conversation::getGraph() {
+	//int size = (int)m_speakerGraph->getSize();
+	//int index = m_textNow / 2 % size;
+	return m_speakerGraph->getGraphHandle(0);
+}
+
+int Conversation::getTextSize() const {
+	return (int)m_text.size();
+}
+
+bool Conversation::play() {
+
+	// プレイヤーからのアクション（スペースキー入力）
+	if (controlSpace() == 1 || leftClick() == 1) {
+		if (m_textNow == m_text.size()) {
+			// 全ての会話が終わった
+			if (FileRead_eof(m_fp) != 0) {
+				m_finishFlag = true;
+				return true;
+			}
+			// 次のテキストへ移る
+			setNextText();
+			// 効果音
+			m_soundPlayer_p->pushSoundQueue(m_nextSound);
+		}
+		else if(m_cnt > MOVE_FINAL_ABLE) {
+			// 最後までテキストを飛ばす
+			m_textNow = (unsigned int)m_text.size();
+		}
+	}
+
+	// 表示文字を増やす
+	m_cnt++;
+	if (m_cnt % TEXT_SPEED == 0 && m_textNow < m_text.size()) {
+		// 日本語表示は１文字がサイズ２分
+		m_textNow = min(m_textNow + 2, (unsigned int)m_text.size());
+		// 効果音
+		m_soundPlayer_p->pushSoundQueue(m_displaySound);
+	}
+
+	return false;
+}
+
+void Conversation::setNextText() {
+	m_cnt = 0;
+	m_textNow = 0;
+	// バッファ
+	const int size = 512;
+	char buff[size];
+	// 発言者
+	FileRead_gets(buff, size, m_fp);
+	m_speakerName = buff;
+	// 画像
+	FileRead_gets(buff, size, m_fp);
+	setSpeakerGraph(buff);
+	// テキスト
+	FileRead_gets(buff, size, m_fp);
+	m_text = buff;
+
+	if (FileRead_eof(m_fp) == 0) {
+		FileRead_gets(buff, size, m_fp);
+	}
+}
+
+void Conversation::setSpeakerGraph(const char* faceName) {
+	Character* c = m_world_p->getCharacterWithName(m_speakerName);
+	m_speakerGraph = c->getFaceHandle()->getGraphHandle(faceName);
+}

--- a/Text.cpp
+++ b/Text.cpp
@@ -51,9 +51,9 @@ std::string Conversation::getText() const {
 
 // ‰æ‘œ‚ð•Ô‚·i•`‰æ—pj
 GraphHandle* Conversation::getGraph() {
-	//int size = (int)m_speakerGraph->getSize();
-	//int index = m_textNow / 2 % size;
-	return m_speakerGraph->getGraphHandle(0);
+	int size = (int)m_speakerGraph->getSize();
+	int index = size - (m_textNow / 2 % size) - 1;
+	return m_speakerGraph->getGraphHandle(index);
 }
 
 int Conversation::getTextSize() const {

--- a/Text.h
+++ b/Text.h
@@ -1,0 +1,78 @@
+#ifndef TEXT_H_INCLUDED
+#define TEXT_H_INCLUDED
+
+
+#include <string>
+#include <vector>
+
+
+class SoundPlayer;
+class World;
+class GraphHandle;
+class GraphHandles;
+
+
+class Conversation {
+private:
+
+	// イベント終了したか
+	bool m_finishFlag;
+
+	// 文字表示の速さ 1が最速
+	const unsigned int TEXT_SPEED = 5;
+
+	// テキストを飛ばせるようになるまでの時間
+	const unsigned int MOVE_FINAL_ABLE = 30;
+
+	// ファイルポインタ
+	int m_fp;
+
+	World* m_world_p;
+
+	SoundPlayer* m_soundPlayer_p;
+
+	// 発言者の名前
+	std::string m_speakerName;
+
+	// 発言者の顔画像
+	GraphHandles* m_speakerGraph;
+
+	// 発言
+	std::string m_text;
+
+	// 今何文字目まで発言したか
+	unsigned int m_textNow;
+
+	// カウント
+	unsigned int m_cnt;
+
+	// 文字表示効果音
+	int m_displaySound;
+
+	// 決定効果音
+	int m_nextSound;
+
+public:
+	Conversation(int textNum, World* world, SoundPlayer* soundPlayer);
+	~Conversation();
+
+	// ゲッタ
+	std::string getText() const;
+	inline std::string getFullText() const { return m_text; }
+	int getTextSize() const;
+	GraphHandle* getGraph();
+	inline 	std::string getSpeakerName() const { return m_speakerName; }
+	inline bool getFinishFlag() const { return m_finishFlag; }
+	inline int getTextNow() const { return m_textNow; }
+	inline int getCnt() const { return m_cnt; }
+
+	// 会話を行う
+	bool play();
+
+private:
+	void setNextText();
+	void setSpeakerGraph(const char* faceName);
+};
+
+
+#endif

--- a/World.cpp
+++ b/World.cpp
@@ -9,6 +9,7 @@
 #include "CsvReader.h"
 #include "Control.h"
 #include "Define.h"
+#include "Text.h"
 #include "DxLib.h"
 #include <algorithm>
 
@@ -73,6 +74,9 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) {
 
 	// サウンドプレイヤー
 	m_soundPlayer_p = soundPlayer;
+
+	// 会話イベント
+	m_conversation_p = NULL;
 
 	// 主人公のスタート地点
 	m_areaNum = toAreaNum;
@@ -440,7 +444,12 @@ void World::atariAttackAndAttack() {
 
 // 会話させる
 void World::talk() {
-
+	if (m_conversation_p != NULL) {
+		// 会話終了
+		if (m_conversation_p->play()) {
+			m_conversation_p = NULL;
+		}
+	}
 }
 
 

--- a/World.h
+++ b/World.h
@@ -12,11 +12,15 @@ class DoorObject;
 class Camera;
 class Animation;
 class SoundPlayer;
+class Conversation;
 
 class World {
 private:
 	// サウンドプレイヤー
 	SoundPlayer* m_soundPlayer_p;
+
+	// 会話イベント EventElementクラスからもらう
+	Conversation* m_conversation_p;
 
 	// 画面の明るさ
 	int m_brightValue;
@@ -90,6 +94,7 @@ public:
 	*/
 	Character* getCharacterWithName(std::string characterName) const;
 	CharacterController* getControllerWithName(std::string characterName) const;
+	inline void setConversation(Conversation* conversation){ m_conversation_p = conversation; }
 
 private:
 	// キャラクターとオブジェクトの当たり判定

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -118,5 +118,5 @@ void WorldDrawer::draw() {
 
 	m_targetDrawer.setEx(camera->getEx());
 	m_targetDrawer.draw();
-	SetDrawBright(0, 0, 0);
+	SetDrawBright(255, 255, 255);
 }


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
キャラが会話する機能を実装。
イベントの種類の１つとして会話機能が存在する形で実装している。

# やったこと
Conversationクラスを実装。txtファイルを読み込んでセリフを取得し、プレイヤーの操作を受け付けて会話を進める。
TalkEventクラスを実装。ConversationクラスをnewしてWorldオブジェクトに渡す。
Worldオブジェクトはtalk関数を呼ばれることで、会話をplayする。
FaceGraphHandleクラスを実装。会話時のキャラの顔画像を管理する。

# やらないこと
UI側は別のPRで実装する。

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
デバッグモードで確認。
セリフ、画像、効果音も実際に手動で確認した。

# 懸念点
単純な会話機能のみ実装している。
オートで会話が進んだり、効果音を鳴らしたりBGMを変更する機能はない。まあEventElementを分けて別イベント要素にやってもらえば済む話だが。
