### PR TITLE
Add TextDrawer

### DIFF
--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -171,6 +171,7 @@
     <ClCompile Include="Sound.cpp" />
     <ClCompile Include="Story.cpp" />
     <ClCompile Include="Text.cpp" />
+    <ClCompile Include="TextDrawer.cpp" />
     <ClCompile Include="World.cpp" />
     <ClCompile Include="WorldDrawer.cpp" />
   </ItemGroup>
@@ -194,6 +195,7 @@
     <ClInclude Include="Sound.h" />
     <ClInclude Include="Story.h" />
     <ClInclude Include="Text.h" />
+    <ClInclude Include="TextDrawer.h" />
     <ClInclude Include="World.h" />
     <ClInclude Include="WorldDrawer.h" />
   </ItemGroup>

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClCompile Include="Text.cpp">
       <Filter>ソース ファイル\api</Filter>
     </ClCompile>
+    <ClCompile Include="TextDrawer.cpp">
+      <Filter>ソース ファイル\ui</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">
@@ -163,6 +166,9 @@
     </ClInclude>
     <ClInclude Include="Text.h">
       <Filter>ヘッダー ファイル\api</Filter>
+    </ClInclude>
+    <ClInclude Include="TextDrawer.h">
+      <Filter>ヘッダー ファイル\ui</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Text.cpp
+++ b/Text.cpp
@@ -23,6 +23,7 @@ Conversation::Conversation(int textNum, World* world, SoundPlayer* soundPlayer) 
 	m_text = "";
 	m_textNow = 0;
 	m_cnt = 0;
+	m_textSpeed = TEXT_SPEED;
 
 	// 効果音
 	m_displaySound = LoadSoundMem("sound/text/display.wav");
@@ -84,7 +85,7 @@ bool Conversation::play() {
 
 	// 表示文字を増やす
 	m_cnt++;
-	if (m_cnt % TEXT_SPEED == 0 && m_textNow < m_text.size()) {
+	if (m_cnt % m_textSpeed == 0 && m_textNow < m_text.size()) {
 		// 日本語表示は１文字がサイズ２分
 		m_textNow = min(m_textNow + 2, (unsigned int)m_text.size());
 		// 効果音
@@ -112,6 +113,17 @@ void Conversation::setNextText() {
 
 	if (FileRead_eof(m_fp) == 0) {
 		FileRead_gets(buff, size, m_fp);
+		string s = buff;
+		if (s == "") {
+			m_textSpeed = TEXT_SPEED;
+		}
+		else {
+			m_textSpeed = stoi(s);
+			FileRead_gets(buff, size, m_fp);
+		}
+	}
+	else {
+		m_textSpeed = TEXT_SPEED;
 	}
 }
 

--- a/Text.cpp
+++ b/Text.cpp
@@ -50,9 +50,10 @@ std::string Conversation::getText() const {
 }
 
 // ‰æ‘œ‚ð•Ô‚·i•`‰æ—pj
-GraphHandle* Conversation::getGraph() {
+GraphHandle* Conversation::getGraph() const {
 	int size = (int)m_speakerGraph->getSize();
 	int index = size - (m_textNow / 2 % size) - 1;
+	index = m_textNow == (unsigned int)m_text.size() ? 0 : index;
 	return m_speakerGraph->getGraphHandle(index);
 }
 

--- a/Text.h
+++ b/Text.h
@@ -60,7 +60,7 @@ public:
 	std::string getText() const;
 	inline std::string getFullText() const { return m_text; }
 	int getTextSize() const;
-	GraphHandle* getGraph();
+	GraphHandle* getGraph() const;
 	inline 	std::string getSpeakerName() const { return m_speakerName; }
 	inline bool getFinishFlag() const { return m_finishFlag; }
 	inline int getTextNow() const { return m_textNow; }

--- a/Text.h
+++ b/Text.h
@@ -20,6 +20,7 @@ private:
 
 	// 文字表示の速さ 1が最速
 	const unsigned int TEXT_SPEED = 5;
+	unsigned int m_textSpeed;
 
 	// テキストを飛ばせるようになるまでの時間
 	const unsigned int MOVE_FINAL_ABLE = 30;

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -1,0 +1,68 @@
+#include "TextDrawer.h"
+#include "Text.h"
+#include "GraphHandle.h"
+#include "Define.h"
+#include "DxLib.h"
+#include <string>
+
+
+using namespace std;
+
+
+ConversationDrawer::ConversationDrawer(Conversation* conversation) {
+
+	m_conversation = conversation;
+
+	// フォントデータ
+	m_textHandle = CreateFontToHandle(NULL, TEXT_SIZE, 3);
+	m_nameHandle = CreateFontToHandle(NULL, NAME_SIZE, 5);
+
+	// 画像
+	m_frameHandle = LoadGraph("picture/textMaterial/frame.png");
+}
+
+ConversationDrawer::~ConversationDrawer() {
+	// フォントデータ削除
+	DeleteFontToHandle(m_textHandle);
+	DeleteFontToHandle(m_nameHandle);
+	// 画像データ削除
+	DeleteGraph(m_frameHandle);
+}
+
+void ConversationDrawer::draw() {
+	string text = m_conversation->getText();
+	string name = m_conversation->getSpeakerName();
+	GraphHandle* graph = m_conversation->getGraph();
+	int graphSize = 0;
+	GetGraphSize(graph->getHandle(), &graphSize, &graphSize);
+
+	// 端の余白
+	static const int EDGE = 52;
+
+	// フキダシのフチの幅
+	static const int TEXT_GRAPH_EDGE = 32;
+
+	// 上端
+	static const int Y1 = 550;
+
+	// フキダシ
+	DrawExtendGraph(EDGE, Y1, GAME_WIDE - EDGE, GAME_HEIGHT - EDGE, m_frameHandle, TRUE);
+
+	// 名前
+	DrawStringToHandle(EDGE * 2 + graphSize, GAME_HEIGHT - EDGE - NAME_SIZE - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
+
+	// テキスト
+	int now = 0;
+	int i = 0;
+	while (now < text.size()) {
+		int next = now + min(MAX_TEXT_LEN, (int)text.size() - now);
+		string disp = text.substr(now, next - now);
+		DrawStringToHandle(EDGE * 3 + graphSize, Y1 + 5 + EDGE + (i * (TEXT_SIZE + 10)), disp.c_str(), BLACK, m_textHandle);
+		now = next;
+		i++;
+	}
+
+	// キャラの顔画像
+	graph->draw(EDGE + TEXT_GRAPH_EDGE + graphSize / 2, Y1 + TEXT_GRAPH_EDGE + graphSize / 2, 1.0);
+
+}

--- a/TextDrawer.h
+++ b/TextDrawer.h
@@ -1,0 +1,38 @@
+#ifndef TEXT_DRAWER_H_INCLUDED
+#define TEXT_DRAWER_H_INCLUDED
+
+
+class Conversation;
+
+
+class ConversationDrawer {
+private:
+	
+	// 会話
+	const Conversation* m_conversation;
+	
+	// フォント（テキスト）
+	int m_textHandle;
+	const int TEXT_SIZE = 50;
+
+	// 一行に表示する文字数
+	const int MAX_TEXT_LEN = 48;
+
+	// フォント（名前）
+	int m_nameHandle;
+	const int NAME_SIZE = 70;
+
+	// フキダシ画像
+	int m_frameHandle;
+
+public:
+	ConversationDrawer(Conversation* conversation);
+	~ConversationDrawer();
+
+	void setConversation(const Conversation* conversation) { m_conversation = conversation; }
+
+	void draw();
+};
+
+
+#endif

--- a/World.h
+++ b/World.h
@@ -73,6 +73,7 @@ public:
 	std::vector<const Animation*> getAnimations() const;
 	inline const int getBackGroundGraph() const { return m_backGroundGraph; }
 	inline const int getBackGroundColor() const { return m_backGroundColor; }
+	inline const Conversation* getConversation() const { return m_conversation_p; }
 
 	//デバッグ
 	void debug(int x, int y, int color) const;

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -5,6 +5,8 @@
 #include "CharacterAction.h"
 #include "ObjectDrawer.h"
 #include "AnimationDrawer.h"
+#include "TextDrawer.h"
+#include "Text.h"
 #include "Define.h"
 #include "DxLib.h"
 #include <queue>
@@ -48,12 +50,14 @@ WorldDrawer::WorldDrawer(const World* world) {
 	m_characterDrawer = new CharacterDrawer(NULL);
 	m_objectDrawer = new ObjectDrawer(NULL);
 	m_animationDrawer = new AnimationDrawer(NULL);
+	m_conversationDrawer = new ConversationDrawer(NULL);
 }
 
 WorldDrawer::~WorldDrawer() {
 	delete m_characterDrawer;
 	delete m_objectDrawer;
 	delete m_animationDrawer;
+	delete m_conversationDrawer;
 }
 
 // 描画する
@@ -119,4 +123,11 @@ void WorldDrawer::draw() {
 	m_targetDrawer.setEx(camera->getEx());
 	m_targetDrawer.draw();
 	SetDrawBright(255, 255, 255);
+
+	// テキストイベント
+	const Conversation* conversation = m_world->getConversation();
+	if (conversation != NULL) {
+		m_conversationDrawer->setConversation(conversation);
+		m_conversationDrawer->draw();
+	}
 }

--- a/WorldDrawer.h
+++ b/WorldDrawer.h
@@ -5,6 +5,7 @@ class World;
 class CharacterDrawer;
 class ObjectDrawer;
 class AnimationDrawer;
+class ConversationDrawer;
 
 
 class TargetDrawer {
@@ -49,6 +50,9 @@ private:
 
 	// マウスカーソル代わり
 	TargetDrawer m_targetDrawer;
+
+	// 会話イベント
+	ConversationDrawer* m_conversationDrawer;
 
 public:
 	WorldDrawer(const World* world);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
会話イベントのUI側実装

# やったこと
ConversationDrawerクラスを実装した。WorldDrawerが保持し、Conversationオブジェクトを渡して会話イベントを描画させる。1行24文字、最大96文字描画できる。（全角文字）

ついでに、テキストの表示速度をtext.txtファイルに記述してセリフごとに変更できるようにした。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
会話イベントを見れるようになる。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。

# 懸念点
文字の大きさが適切かは体験版でフィードバックをもらいたい。
