### PR TITLE
Api: 中立のキャラ実装

### DIFF
--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -240,8 +240,9 @@ void NormalAI::searchTarget(const Character* character) {
 		if (abs(x - character->getCenterX()) > TARGET_DISTANCE) {
 			return;
 		}
-		// Ž©•ªŽ©g‚â–¡•û‚¶‚á‚È‚¯‚ê‚Î
-		if (character->getId() != m_characterAction_p->getCharacter()->getId() && character->getGroupId() != m_characterAction_p->getCharacter()->getGroupId()) {
+		// –¡•û‚¶‚á‚È‚¯‚ê‚Î&’†—§‚¶‚á‚È‚¯‚ê‚Î
+		int groupId = character->getGroupId();
+		if (groupId != m_characterAction_p->getCharacter()->getGroupId() && groupId != -1) {
 			m_target_p = character;
 		}
 	}

--- a/Object.cpp
+++ b/Object.cpp
@@ -497,8 +497,9 @@ bool BulletObject::atari(CharacterController* characterController) {
 	if (m_characterId == characterController->getAction()->getCharacter()->getId()) {
 		return false;
 	}
-	// ƒ`[ƒ€ƒLƒ‹–hŽ~
-	if (m_groupId == characterController->getAction()->getCharacter()->getGroupId()) {
+	// ƒ`[ƒ€ƒLƒ‹–hŽ~ && ’†—§ƒLƒƒƒ‰‚É‚Í“–‚½‚ç‚È‚¢
+	int groupId = characterController->getAction()->getCharacter()->getGroupId();
+	if (m_groupId == groupId || groupId == -1) {
 		return false;
 	}
 
@@ -623,7 +624,8 @@ bool SlashObject::atari(CharacterController* characterController) {
 		return false;
 	}
 	// ƒ`[ƒ€ƒLƒ‹–hŽ~
-	if (m_groupId == characterController->getAction()->getCharacter()->getGroupId()) {
+	int groupId = characterController->getAction()->getCharacter()->getGroupId();
+	if (m_groupId == groupId || groupId == -1) {
 		return false;
 	}
 

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -43,7 +43,7 @@ void ConversationDrawer::draw() {
 	static const int TEXT_GRAPH_EDGE = 32;
 
 	// 上端
-	static const int Y1 = 550;
+	static const int Y1 = 551;
 
 	// フキダシ
 	DrawExtendGraph(EDGE, Y1, GAME_WIDE - EDGE, GAME_HEIGHT - EDGE, m_frameHandle, TRUE);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
groupIdが-1のキャラは攻撃されないし、AIにターゲットにされない。

# やったこと
groupId == -1 の場合の処理を追加しただけ。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
目視で確認。

# 懸念点
間違えてUIブランチで実装したけど気にしない。
