### PR TITLE
Api: 主人公のスキル実装

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -12,9 +12,14 @@ Animation::Animation(int x, int y, int flameCnt, GraphHandles* graphHandles) {
 	m_finishFlag = false;
 }
 
-Animation::~Animation() {
-	// delete m_handles;
+Animation* Animation::createCopy() {
+	Animation* res = new Animation(m_x, m_y, m_flameCnt, m_handles);
+	res->setCnt(m_cnt);
+	res->setFinishCnt(m_finishCnt);
+	res->setFinishFlag(m_finishFlag);
+	return res;
 }
+
 
 // ƒJƒEƒ“ƒg
 void Animation::count() { 

--- a/Animation.h
+++ b/Animation.h
@@ -26,12 +26,18 @@ private:
 
 public:
 	Animation(int x, int y, int flameCnt, GraphHandles* graphHandles);
-	~Animation();
+
+	Animation* createCopy();
 
 	// ゲッタ
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline bool getFinishFlag() const { return m_finishFlag; }
+
+	// セッタ
+	inline void setCnt(int cnt) { m_cnt = cnt; }
+	inline void setFinishCnt(int finishCnt) { m_finishCnt = finishCnt; }
+	inline void setFinishFlag(int finishFlag) { m_finishFlag = finishFlag; }
 
 	// カウント
 	void count();

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -1,0 +1,386 @@
+#include "Brain.h"
+#include "Character.h"
+#include "CharacterAction.h"
+#include "Camera.h"
+#include "Control.h"
+#include "DxLib.h"
+
+
+using namespace std;
+
+
+// Brainクラス
+Brain::Brain() {
+	m_characterAction_p = NULL;
+}
+
+
+/*
+* キーボード
+*/
+KeyboardBrain::KeyboardBrain(const Camera* camera) {
+	m_camera_p = camera;
+}
+
+void KeyboardBrain::bulletTargetPoint(int& x, int& y) {
+	// マウスの位置
+	int mouseX, mouseY;
+	GetMousePoint(&mouseX, &mouseY);
+
+	// カメラで座標を補正
+	m_camera_p->getMouse(&mouseX, &mouseY);
+
+	x = mouseX;
+	y = mouseY;
+}
+
+// 話しかけたり扉入ったり
+bool KeyboardBrain::actionOrder() {
+	return controlW() == 1;
+}
+
+// 移動（上下左右の入力）
+void KeyboardBrain::moveOrder(int& right, int& left, int& up, int& down) {
+	right = controlD();
+	left = controlA();
+	up = controlW();
+	down = controlS();
+}
+
+// ジャンプ
+int KeyboardBrain::jumpOrder() {
+	return controlSpace();
+}
+
+// しゃがみ
+int KeyboardBrain::squatOrder() {
+	return controlS();
+}
+
+// 近距離攻撃
+int KeyboardBrain::slashOrder() {
+	return rightClick();
+}
+
+// 遠距離攻撃
+int KeyboardBrain::bulletOrder() {
+	return leftClick();
+}
+
+
+/*
+* Normal AI
+*/
+NormalAI::NormalAI() {
+	m_target_p = NULL;
+	m_gx = 0;
+	m_gy = 0;
+	m_rightKey = 0;
+	m_leftKey = 0;
+	m_upKey = 0;
+	m_downKey = 0;
+	m_jumpCnt = 0;
+	m_squatCnt = 0;
+	m_moveCnt = 0;
+}
+
+
+Brain* NormalAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	NormalAI* res = new NormalAI();
+
+	if (m_target_p != NULL) {
+		for (unsigned int i = 0; i < characters.size(); i++) {
+			if (m_target_p->getId() == characters[i]->getId()) {
+				res->setTarget(characters[i]);
+				break;
+			}
+		}
+	}
+	setParam(res);
+	return res;
+}
+
+void NormalAI::setParam(NormalAI* brain) {
+	// 移動用
+	brain->setRightKey(m_rightKey);
+	brain->setLeftKey(m_leftKey);
+	brain->setUpKey(m_upKey);
+	brain->setDownKey(m_downKey);
+	// ジャンプの長さ
+	brain->setJumpCnt(m_jumpCnt);
+	// しゃがむ長さ
+	brain->setSquatCnt(m_squatCnt);
+	// 移動目標
+	brain->setGx(m_gx);
+	brain->setGy(m_gy);
+	brain->setMoveCnt(m_moveCnt);
+}
+
+void NormalAI::setCharacterAction(const CharacterAction* characterAction) {
+	m_characterAction_p = characterAction;
+	// 目標地点は現在地に設定
+	m_gx = m_characterAction_p->getCharacter()->getX();
+	m_gy = m_characterAction_p->getCharacter()->getY();
+}
+
+void NormalAI::bulletTargetPoint(int& x, int& y) {
+	if (m_target_p == NULL) {
+		x = 0;
+		y = 0;
+	}
+	else { // ターゲットに向かって射撃攻撃
+		x = m_target_p->getCenterX() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2);
+		y = m_target_p->getCenterY() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2);
+	}
+}
+
+void NormalAI::moveOrder(int& right, int& left, int& up, int& down) {
+	// 現在地
+	int x = m_characterAction_p->getCharacter()->getX();
+	int y = m_characterAction_p->getCharacter()->getY();
+
+	// (壁につっかえるなどで)移動できてないから諦める
+	//DrawFormatString(800, 50, GetColor(255, 255, 255), "moveCnt = %d, x(%d) -> gx(%d)", m_moveCnt, x, m_gx);
+	if (m_moveCnt >= GIVE_UP_MOVE_CNT) {
+		m_gx = x;
+		m_gy = y;
+	}
+
+	// 目標地点設定
+	bool alreadyGoal = m_gx > x - GX_ERROR && m_gx < x + GX_ERROR;
+	// ダメージを受けたらリセット
+	if (m_characterAction_p->getState() == CHARACTER_STATE::DAMAGE) {
+		m_gx = x, m_gy = y;
+	}
+	else if (alreadyGoal && GetRand(MOVE_RAND) == 0) {
+		if (m_target_p != NULL && abs(x - m_target_p->getCenterX()) < TARGET_DISTANCE) {
+			// targetについていく
+			m_gx = m_target_p->getCenterX() + GetRand(2000) - 1000;
+		}
+		else {
+			// ランダムに設定
+			m_gx = GetRand(200) + 100;
+			if (GetRand(99) < GX_ERROR) { m_gx *= -1; }
+			m_gx += x;
+		}
+	}
+	stickOrder(right, left, up, down);
+}
+
+// スティック操作
+void NormalAI::stickOrder(int& right, int& left, int& up, int& down) {
+	// 現在地
+	int x = m_characterAction_p->getCharacter()->getX();
+	int y = m_characterAction_p->getCharacter()->getY();
+
+	// 目標に向かって走る
+	if (m_gx > x + GX_ERROR) {
+		m_rightKey++;
+		m_leftKey = 0;
+		m_moveCnt++;
+	}
+	else if (m_gx < x - GX_ERROR) {
+		m_rightKey = 0;
+		m_leftKey++;
+		m_moveCnt++;
+	}
+	else {
+		m_rightKey = 0;
+		m_leftKey = 0;
+		m_moveCnt = 0;
+	}
+
+	// 反映
+	right = m_rightKey;
+	left = m_leftKey;
+	up = m_upKey;
+	down = m_downKey;
+}
+
+int NormalAI::jumpOrder() {
+	// ダメージを食らったらリセット
+	if (m_characterAction_p->getState() == CHARACTER_STATE::DAMAGE) {
+		m_jumpCnt = 0;
+		if (GetRand(120) == 0) { return 1; }
+	}
+
+	// ランダムでジャンプ
+	if (m_squatCnt == 0 && GetRand(99) == 0) { m_jumpCnt = GetRand(15) + 5; }
+
+	// 壁にぶつかったからジャンプ
+	if (m_rightKey > 0 && m_characterAction_p->getRightLock()) { m_jumpCnt = 20; }
+	else if (m_leftKey > 0 && m_characterAction_p->getLeftLock()) { m_jumpCnt = 20; }
+
+	if (m_jumpCnt > 0) { m_jumpCnt--; }
+	return m_jumpCnt == 0 ? 0 : 20 - m_jumpCnt;
+}
+
+int NormalAI::squatOrder() {
+	// ダメージを食らったらリセット
+	if (m_characterAction_p->getState() == CHARACTER_STATE::DAMAGE) {
+		m_squatCnt = 0;
+	}
+
+	// 目標地点にいないならしゃがまない
+	int x = m_characterAction_p->getCharacter()->getX();
+	bool alreadyGoal = m_gx > x - GX_ERROR && m_gx < x + GX_ERROR;
+	if (!alreadyGoal) { m_squatCnt = 0; }
+
+	// ランダムでしゃがむ
+	if (alreadyGoal && m_characterAction_p->getGrand() && GetRand(99) == 0) {
+		m_squatCnt = GetRand(120) + 60;
+	}
+
+	if (m_squatCnt > 0) { m_squatCnt--; }
+	return m_squatCnt;
+}
+
+int NormalAI::slashOrder() {
+	if (m_target_p == NULL || m_target_p->getHp() == 0) {
+		return 0;
+	}
+	// 遠距離の敵には斬撃しない
+	if (m_target_p != NULL && abs(m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX()) > 500) {
+		return 0;
+	}
+	// ランダムで斬撃
+	if (GetRand(50) == 0) {
+		return 1;
+	}
+	return 0;
+}
+
+int NormalAI::bulletOrder() {
+	if (m_target_p == NULL || m_target_p->getHp() == 0) {
+		return 0;
+	}
+	int x = m_characterAction_p->getCharacter()->getX();
+	if (abs(x - m_target_p->getCenterX()) > TARGET_DISTANCE) {
+		return 0;
+	}
+	// ランダムで射撃
+	if (GetRand(30) == 0) {
+		return 1;
+	}
+	return 0;
+}
+
+// 攻撃対象を決める(targetのままか、characterに変更するか)
+void NormalAI::searchTarget(const Character* character) {
+	if (GetRand(99) < 50) {
+		int x = m_characterAction_p->getCharacter()->getX();
+		// 距離が遠い
+		if (abs(x - character->getCenterX()) > TARGET_DISTANCE) {
+			return;
+		}
+		// 味方じゃなければ&中立じゃなければ
+		int groupId = character->getGroupId();
+		if (groupId != m_characterAction_p->getCharacter()->getGroupId() && groupId != -1) {
+			m_target_p = character;
+		}
+	}
+}
+
+// 攻撃対象を変更する必要があるならtrueでアピールする。
+bool NormalAI::needSearchTarget() const {
+	if (m_target_p == NULL || m_target_p->getHp() == 0 || GetRand(99) == 0 || m_target_p->getGroupId() == -1) {
+		return true;
+	}
+	return false;
+}
+
+int  NormalAI::getTargetId() const { return m_target_p == NULL ? NULL : m_target_p->getId(); }
+
+
+void ParabolaAI::bulletTargetPoint(int& x, int& y) {
+	if (m_target_p == NULL) {
+		x = 0;
+		y = 0;
+	}
+	else { // ターゲットに向かって射撃攻撃
+		x = m_target_p->getCenterX() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2);
+		y = m_target_p->getCenterY() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2) - 200;
+	}
+}
+
+
+/*
+* キャラについていくNormalAI
+*/
+FollowNormalAI::FollowNormalAI() :
+	NormalAI()
+{
+	m_follow_p = NULL;
+}
+
+Brain* FollowNormalAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	FollowNormalAI* res = new FollowNormalAI();
+	for (unsigned int i = 0; i < characters.size(); i++) {
+		if (m_follow_p->getId() == characters[i]->getId()) {
+			res->setFollow(characters[i]);
+			break;
+		}
+	}
+	for (unsigned int i = 0; i < characters.size(); i++) {
+		if (m_target_p->getId() == characters[i]->getId()) {
+			res->setTarget(characters[i]);
+			break;
+		}
+	}
+	setParam(res);
+	return res;
+}
+
+int FollowNormalAI::getFollowId() const {
+	if (m_follow_p == nullptr) { return -1; }
+	return m_follow_p->getId();
+}
+
+void FollowNormalAI::moveOrder(int& right, int& left, int& up, int& down) {
+	// 現在地
+	int x = m_characterAction_p->getCharacter()->getX();
+	int y = m_characterAction_p->getCharacter()->getY();
+
+	// (壁につっかえるなどで)移動できてないから諦める
+	if (m_moveCnt >= GIVE_UP_MOVE_CNT) {
+		m_gx = x;
+		m_gy = y;
+	}
+
+	// 目標地点設定用パラメータ
+	int followX = m_follow_p->getCenterX();
+	bool alreadyGoal = m_gx > x - GX_ERROR && m_gx < x + GX_ERROR;
+	bool alreadyFollow = m_gx < followX + FOLLOW_X_ERROR && m_gx > followX - FOLLOW_X_ERROR;
+
+	// 目標地点設定
+	if ((alreadyGoal && GetRand(MOVE_RAND) == 0) || !alreadyFollow) {
+		if (m_follow_p != NULL) {
+			// followについていく
+			m_gx = m_follow_p->getCenterX() + GetRand(FOLLOW_X_ERROR * 2) - FOLLOW_X_ERROR;
+		}
+		else {
+			// ランダムに設定
+			m_gx = GetRand(200) + 100;
+			if (GetRand(99) < GX_ERROR) { m_gx *= -1; }
+			m_gx += x;
+		}
+	}
+
+	stickOrder(right, left, up, down);
+}
+
+// 追跡対象を決める(AIクラスでオーバライドする。)
+void FollowNormalAI::searchFollow(const Character* character) {
+	// 味方のみ
+	if (character->getId() != m_characterAction_p->getCharacter()->getId() && character->getGroupId() == m_characterAction_p->getCharacter()->getGroupId()) {
+		m_follow_p = character;
+	}
+}
+
+// 追跡対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
+bool FollowNormalAI::needSearchFollow() const {
+	if (m_follow_p == NULL || m_follow_p->getHp() == 0) {
+		return true;
+	}
+	return false;
+}

--- a/Brain.h
+++ b/Brain.h
@@ -1,0 +1,230 @@
+#ifndef BRAIN_H_INCLUDED
+#define BRAIN_H_INCLUDED
+
+#include <vector>
+
+
+class Character;
+class CharacterAction;
+class Camera;
+
+
+// Controllerに命令するクラス（キーボード＆マウスやＡＩ）
+class Brain {
+protected:
+	// 今のキャラの状態を考慮して射撃の目標座標や次の行動を決めるため必要
+	const CharacterAction* m_characterAction_p;
+
+public:
+	Brain();
+
+	virtual Brain* createCopy(std::vector<Character*> characters, const Camera* camera) = 0;
+
+	virtual void debug(int x, int y, int color) const = 0;
+
+	// 話しかけたり扉入ったり
+	virtual bool actionOrder() { return false; }
+
+	// セッタ
+	virtual void setCharacterAction(const CharacterAction* characterAction) = 0;
+
+	// 遠距離攻撃の目標座標
+	virtual void bulletTargetPoint(int& x, int& y) = 0;
+
+	// 移動（上下左右の入力）
+	virtual void moveOrder(int& right, int& left, int& up, int& down) = 0;
+
+	// ジャンプの制御
+	virtual int jumpOrder() = 0;
+
+	// しゃがみの制御
+	virtual int squatOrder() = 0;
+
+	// 近距離攻撃
+	virtual int slashOrder() = 0;
+
+	// 遠距離攻撃
+	virtual int bulletOrder() = 0;
+
+	// 攻撃対象を決める(AIクラスでオーバライドする。)
+	virtual void searchTarget(const Character* character) { }
+
+	// 攻撃対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
+	virtual bool needSearchTarget() const { return false; }
+
+	// 追跡対象を決める(AIクラスでオーバライドする。)
+	virtual void searchFollow(const Character* character) { }
+
+	// 追跡対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
+	virtual bool needSearchFollow() const { return false; }
+
+	virtual int getTargetId() const { return -1; }
+
+	virtual void setTarget(Character* character) {  }
+};
+
+/*
+* キーボードでキャラの操作を命令するクラス
+*/
+class KeyboardBrain :
+	public Brain
+{
+private:
+	// カメラ
+	const Camera* m_camera_p;
+
+public:
+	KeyboardBrain(const Camera* camera);
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera) { return new KeyboardBrain(camera); }
+	void debug(int x, int y, int color) const;
+	inline void setCharacterAction(const CharacterAction* characterAction) { m_characterAction_p = characterAction; }
+	void bulletTargetPoint(int& x, int& y);
+	bool actionOrder();
+	void moveOrder(int& right, int& left, int& up, int& down);
+	int jumpOrder();
+	int squatOrder();
+	int slashOrder();
+	int bulletOrder();
+};
+
+/*
+* 全く動かないAI
+*/
+class Freeze :
+	public Brain
+{
+public:
+	Freeze() { }
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera) { return new Freeze(); }
+	void debug(int x, int y, int color) const { }
+	bool actionOrder() { return false; }
+	void setCharacterAction(const CharacterAction* characterAction) {  }
+	void bulletTargetPoint(int& x, int& y) {  }
+	void moveOrder(int& right, int& left, int& up, int& down) { right = 0; left = 0; up = 0; down = 0; }
+	int jumpOrder() { return 0; }
+	int squatOrder() { return 0; }
+	int slashOrder() { return 0; }
+	int bulletOrder() { return 0; }
+};
+
+/*
+*  普通に敵と戦うよう命令するＡＩのクラス
+*/
+class NormalAI :
+	public Brain
+{
+private:
+
+	// 攻撃対象を認知する距離
+	const int TARGET_DISTANCE = 2000;
+
+	// 移動用
+	int m_rightKey, m_leftKey, m_upKey, m_downKey;
+
+	// ジャンプの長さ
+	int m_jumpCnt;
+
+	// しゃがむ長さ
+	int m_squatCnt;
+
+protected:
+	// 攻撃対象
+	const Character* m_target_p;
+
+	// 射撃の精度
+	const int BULLET_ERROR = 400;
+
+	// 特に意味のない移動をする確率
+	const int MOVE_RAND = 59;
+
+	// 移動目標
+	int m_gx, m_gy;
+
+	// 移動目標達成とみなす誤差 ±GX_ERROR
+	const int GX_ERROR = 100;
+
+	// 移動時間
+	int m_moveCnt;
+
+	// 移動を諦めるまでの時間
+	const int GIVE_UP_MOVE_CNT = 300;
+
+public:
+	NormalAI();
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+	void setParam(NormalAI* brain);
+
+	void setRightKey(int rightKey) { m_rightKey = rightKey; }
+	void setLeftKey(int leftKey) { m_leftKey = leftKey; }
+	void setUpKey(int upKey) { m_upKey = upKey; }
+	void setDownKey(int downKey) { m_downKey = downKey; }
+	void setJumpCnt(int cnt) { m_jumpCnt = cnt; }
+	void setSquatCnt(int cnt) { m_squatCnt = cnt; }
+	void setGx(int gx) { m_gx = gx; }
+	void setGy(int gy) { m_gy = gy; }
+	void setMoveCnt(int cnt) { m_moveCnt = cnt; }
+	void setTarget(Character* character) { m_target_p = character; }
+
+	void debug(int x, int y, int color) const;
+	void setCharacterAction(const CharacterAction* characterAction);
+	void bulletTargetPoint(int& x, int& y);
+	void moveOrder(int& right, int& left, int& up, int& down);
+	int jumpOrder();
+	int squatOrder();
+	int slashOrder();
+	int bulletOrder();
+
+	// 攻撃対象を決める(targetのままか、characterに変更するか)
+	void searchTarget(const Character* character);
+
+	// 攻撃対象を変更する必要があるならtrueでアピールする。
+	bool needSearchTarget() const;
+
+	int getTargetId() const;
+
+protected:
+	// スティック操作
+	void stickOrder(int& right, int& left, int& up, int& down);
+};
+
+
+class ParabolaAI :
+	public NormalAI
+{
+	void bulletTargetPoint(int& x, int& y);
+};
+
+
+class FollowNormalAI :
+	public NormalAI
+{
+private:
+	// ついていくキャラ
+	const Character* m_follow_p;
+
+	// 追跡対象の近くにいるとみなす誤差 ±GX_ERROR
+	const int FOLLOW_X_ERROR = 500;
+
+public:
+	FollowNormalAI();
+
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+
+	void debug(int x, int y, int color) const;
+
+	int getFollowId() const;
+
+	void setFollow(Character* character) { m_follow_p = character; }
+
+	// 移動の目標地点設定
+	void moveOrder(int& right, int& left, int& up, int& down);
+
+	// 追跡対象を決める(AIクラスでオーバライドする。)
+	void searchFollow(const Character* character);
+
+	// 追跡対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
+	bool needSearchFollow() const;
+};
+
+
+#endif

--- a/Camera.cpp
+++ b/Camera.cpp
@@ -20,6 +20,18 @@ Camera::Camera(int x, int y, double ex, int speed) {
 	m_centerY = GAME_HEIGHT / 2;
 }
 
+Camera::Camera(const Camera* original) {
+	m_x = original->getX();
+	m_y = original->getY();
+	m_gx = original->getGx();
+	m_gy = original->getGy();
+	m_ex = original->getEx();
+	m_speed = original->getSpeed();
+	m_maxSpeed = original->getMaxSpeed();
+	m_centerX = GAME_WIDE / 2;
+	m_centerY = GAME_HEIGHT / 2;
+}
+
 // カメラの移動 目標地点が近いほど鈍感になる
 void Camera::move() {
 	if (m_x < m_gx) {

--- a/Camera.h
+++ b/Camera.h
@@ -26,11 +26,19 @@ private:
 public:
 	Camera();
 	Camera(int x, int y, double ex, int speed=0);
+	Camera(const Camera* original);
 
-	// ゲッタとセッタ
-	inline void getPoint(int* x, int* y) { *x = m_x; *y = m_y; }
-	inline int getX() { return m_x; }
-	inline int getY() { return m_y; }
+	// ゲッタ
+	inline void getPoint(int* x, int* y) const { *x = m_x; *y = m_y; }
+	inline int getX() const { return m_x; }
+	inline int getY() const { return m_y; }
+	inline int getGx() const { return m_gx; }
+	inline int getGy() const { return m_gy; }
+	inline double getEx() const { return m_ex; }
+	inline int getSpeed() const { return m_speed; }
+	inline int getMaxSpeed() const { return m_maxSpeed; }
+
+	// セッタ
 	inline void setPoint(int x, int y) { m_x = x; m_y = y; }
 	inline void setGPoint(int x, int y) { m_gx = x; m_gy = y; }
 	inline void setX(int x) { m_x = x; }
@@ -38,7 +46,6 @@ public:
 	inline void setGx(int x) { m_gx = x; }
 	inline void setGy(int y) { m_gy = y; }
 	inline void setSpeed(int speed) { m_speed = speed; }
-	inline double getEx() const { return m_ex; }
 	inline void setEx(double ex) { m_ex = ex; }
 
 	// カメラの動き

--- a/Character.cpp
+++ b/Character.cpp
@@ -261,6 +261,14 @@ Heart::~Heart() {
 
 }
 
+Character* Heart::createCopy() {
+	Character* res = new Heart(m_characterInfo->name().c_str(), m_hp, m_x, m_y, m_groupId);
+	res->setY(m_y);
+	res->setId(m_id);
+	res->setLeftDirection(m_leftDirection);
+	return res;
+}
+
 // 走り画像をセット
 void Heart::switchRun(int cnt) { 
 	int index = (cnt / RUN_ANIME_SPEED) % (m_graphHandle->getRunHandle()->getSize());
@@ -356,6 +364,14 @@ Siesta::Siesta(const char* name, int hp, int x, int y, int groupId) :
 	Heart(name, hp, x, y, groupId)
 {
 
+}
+
+Character* Siesta::createCopy() {
+	Character* res = new Siesta(m_characterInfo->name().c_str(), m_hp, m_x, m_y, m_groupId);
+	res->setY(m_y);
+	res->setId(m_id);
+	res->setLeftDirection(m_leftDirection);
+	return res;
 }
 
 // 射撃攻撃をする(キャラごとに違う)

--- a/Character.cpp
+++ b/Character.cpp
@@ -135,6 +135,7 @@ Character::Character(int hp, int x, int y, int groupId) {
 	m_attackInfo = NULL;
 	m_graphHandle = NULL;
 	m_faceHandle = NULL;
+	m_duplicationFlag = false;
 }
 
 Character::~Character() {
@@ -143,7 +144,7 @@ Character::~Character() {
 		delete m_characterInfo;
 	}
 	// AttackInfoの削除
-	if (m_attackInfo != NULL) {
+	if (m_attackInfo != NULL && !m_duplicationFlag) {
 		delete m_attackInfo;
 	}
 	// GraphHandleの削除
@@ -156,7 +157,7 @@ Character::~Character() {
 	}
 }
 
-const GraphHandle* Character::getGraphHandle() const {
+GraphHandle* Character::getGraphHandle() const {
 	return m_graphHandle->getHandle();
 }
 
@@ -256,16 +257,33 @@ Heart::Heart(const char* name, int hp, int x, int y, int groupId) :
 	m_y -= getHeight();
 }
 
+Heart::Heart(const char* name, int hp, int x, int y, int groupId, AttackInfo* attackInfo) :
+	Character(hp, x, y, groupId)
+{
+	m_duplicationFlag = true;
+	m_attackInfo = attackInfo;
+	m_characterInfo = new CharacterInfo(name);
+	m_hp = m_characterInfo->maxHp();
+	// 各画像のロード
+	m_graphHandle = new CharacterGraphHandle(name, m_characterInfo->handleEx());
+	m_faceHandle = new FaceGraphHandle(name, 1.0);
+	// とりあえず立ち画像でスタート
+	//switchStand();
+	//m_y -= getHeight();
+}
+
 // デストラクタ
 Heart::~Heart() {
 
 }
 
 Character* Heart::createCopy() {
-	Character* res = new Heart(m_characterInfo->name().c_str(), m_hp, m_x, m_y, m_groupId);
+	Character* res = new Heart(m_characterInfo->name().c_str(), m_hp, m_x, m_y, m_groupId, m_attackInfo);
 	res->setY(m_y);
 	res->setId(m_id);
 	res->setLeftDirection(m_leftDirection);
+	res->setHp(m_hp);
+	res->getCharacterGraphHandle()->setGraph(getGraphHandle());
 	return res;
 }
 
@@ -365,12 +383,19 @@ Siesta::Siesta(const char* name, int hp, int x, int y, int groupId) :
 {
 
 }
+Siesta::Siesta(const char* name, int hp, int x, int y, int groupId, AttackInfo* attackInfo):
+	Heart(name, hp, x, y, groupId, attackInfo)
+{
+
+}
 
 Character* Siesta::createCopy() {
-	Character* res = new Siesta(m_characterInfo->name().c_str(), m_hp, m_x, m_y, m_groupId);
+	Character* res = new Siesta(m_characterInfo->name().c_str(), m_hp, m_x, m_y, m_groupId, m_attackInfo);
 	res->setY(m_y);
 	res->setId(m_id);
 	res->setLeftDirection(m_leftDirection);
+	res->setHp(m_hp);
+	res->getCharacterGraphHandle()->setGraph(getGraphHandle());
 	return res;
 }
 

--- a/Character.h
+++ b/Character.h
@@ -198,6 +198,8 @@ public:
 	Character(int hp, int x, int y, int groupId);
 	~Character();
 
+	virtual Character* createCopy() = 0;
+
 	// デバッグ
 	void debugCharacter(int x, int y, int color) const;
 	virtual void debug(int x, int y, int color) const = 0;
@@ -215,6 +217,7 @@ public:
 	inline void setHp(int hp) { m_hp = (hp > m_characterInfo->maxHp()) ? m_characterInfo->maxHp() : hp; }
 	inline void setX(int x) { m_x = x; }
 	inline void setY(int y) { m_y = y; }
+	inline void setId(int id) { m_id = id; }
 	// キャラの向き変更は、画像の反転も行う
 	void setLeftDirection(bool leftDirection);
 
@@ -309,6 +312,8 @@ public:
 	// デストラクタ
 	~Heart();
 
+	Character* createCopy();
+
 	// デバッグ
 	void debug(int x, int y, int color) const;
 
@@ -339,6 +344,8 @@ class Siesta :
 public:
 	// コンストラクタ
 	Siesta(const char* name, int hp, int x, int y, int groupId);
+
+	Character* createCopy();
 
 	// 射撃攻撃をする(キャラごとに違う)
 	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer);

--- a/Character.h
+++ b/Character.h
@@ -165,6 +165,8 @@ class Character {
 protected:
 	static int characterId;
 
+	bool m_duplicationFlag;
+
 	// ID
 	int m_id;
 
@@ -212,14 +214,21 @@ public:
 	inline int getY() const { return m_y; }
 	inline bool getLeftDirection() const { return m_leftDirection; }
 	FaceGraphHandle* getFaceHandle() const { return m_faceHandle; }
+	inline CharacterGraphHandle* getCharacterGraphHandle() const { return m_graphHandle; }
+	inline AttackInfo* getAttackInfo() const { return m_attackInfo; }
+	inline CharacterInfo* getCharacterInfo() const { return m_characterInfo; }
 
 	// セッタ
 	inline void setHp(int hp) { m_hp = (hp > m_characterInfo->maxHp()) ? m_characterInfo->maxHp() : hp; }
 	inline void setX(int x) { m_x = x; }
 	inline void setY(int y) { m_y = y; }
 	inline void setId(int id) { m_id = id; }
+	inline void setGroupId(int id) { m_groupId = id; }
 	// キャラの向き変更は、画像の反転も行う
 	void setLeftDirection(bool leftDirection);
+	inline void setDuplicationFlag(bool flag) { m_duplicationFlag = flag; }
+	inline void setAttackInfo(AttackInfo* attackInfo) { m_attackInfo = attackInfo; }
+	inline void setCharacterInfo(CharacterInfo* characterInfo) { m_characterInfo = characterInfo; }
 
 	// CharacterInfoからキャラのスペックを取得
 	inline std::string getName() const { return m_characterInfo->name(); }
@@ -241,7 +250,7 @@ public:
 	int getWide() const;
 	int getHeight() const;
 	// 今描画する画像を取得
-	const GraphHandle* getGraphHandle() const;
+	GraphHandle* getGraphHandle() const;
 	void getHandleSize(int& wide, int& height) const;
 
 	// 立ち画像をセット
@@ -308,6 +317,7 @@ private:
 public:
 	// コンストラクタ
 	Heart(const char* name, int hp, int x, int y, int groupId);
+	Heart(const char* name, int hp, int x, int y, int groupId, AttackInfo* attackInfo);
 
 	// デストラクタ
 	~Heart();
@@ -344,6 +354,7 @@ class Siesta :
 public:
 	// コンストラクタ
 	Siesta(const char* name, int hp, int x, int y, int groupId);
+	Siesta(const char* name, int hp, int x, int y, int groupId, AttackInfo* attackInfo);
 
 	Character* createCopy();
 

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -3,6 +3,10 @@
 #include "Sound.h"
 #include "Define.h"
 #include "DxLib.h"
+#include <vector>
+
+
+using namespace std;
 
 
 /*
@@ -15,8 +19,6 @@ CharacterAction::CharacterAction(Character* character, SoundPlayer* soundPlayer_
 	//初期状態
 	m_state = CHARACTER_STATE::STAND;
 	m_grand = false;
-	m_grandRightSlope = false;
-	m_grandRightSlope = false;
 	m_runCnt = -1;
 	m_squat = false;
 	m_preJumpCnt = -1;
@@ -49,6 +51,33 @@ CharacterAction::CharacterAction() :
 	CharacterAction(NULL, NULL)
 {
 
+}
+
+void CharacterAction::setParam(CharacterAction* action) {
+	action->setState(m_state);
+	action->setSimpleGrand(m_grand);
+	action->setGrandLeftSlope(m_grandLeftSlope);
+	action->setGrandRightSlope(m_grandRightSlope);
+	action->setRunCnt(m_runCnt);
+
+	action->setSquat(m_squat);
+	action->setJumpCnt(m_preJumpCnt);
+	action->setMoveRight(m_moveRight);
+	action->setMoveLeft(m_moveLeft);
+	action->setMoveUp(m_moveUp);
+	action->setMoveDown(m_moveDown);
+	action->setVx(m_vx);
+	action->setVy(m_vy);
+	action->setRightLock(m_rightLock);
+	action->setLeftLock(m_leftLock);
+	action->setUpLock(m_upLock);
+	action->setDownLock(m_downLock);
+	action->setBulletCnt(m_bulletCnt);
+	action->setSlashCnt(m_slashCnt);
+	action->setAttackLeftDirection(m_attackLeftDirection);
+	action->setLandCnt(m_landCnt);
+	action->setBoostCnt(m_boostCnt);
+	action->setDamageCnt(m_damageCnt);
 }
 
 void CharacterAction::setState(CHARACTER_STATE state) {
@@ -148,6 +177,18 @@ StickAction::StickAction(Character* character, SoundPlayer* soundPlayer_p):
 	CharacterAction(character, soundPlayer_p)
 {
 
+}
+
+CharacterAction* StickAction::createCopy(vector<Character*> characters) {
+	CharacterAction* res = NULL;
+	for (unsigned int i = 0; i < characters.size(); i++) {
+		if (m_character_p->getId() == characters[i]->getId()) {
+			res = new StickAction(characters[i], m_soundPlayer_p);
+			// コピーする
+			setParam(res);
+		}
+	}
+	return res;
 }
 
 // 行動前の処理

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -1,6 +1,10 @@
 #ifndef CHACACTER_ACTION_H_INCLUDED
 #define CHACACTER_ACTION_H_INCLUDED
 
+
+#include <vector>
+
+
 class Character;
 class Object;
 class SoundPlayer;
@@ -93,6 +97,9 @@ public:
 	CharacterAction();
 	CharacterAction(Character* character, SoundPlayer* soundPlayer_p);
 
+	virtual CharacterAction* createCopy(std::vector<Character*> characters) = 0;
+	void setParam(CharacterAction* action);
+
 	// デバッグ
 	void debugAction(int x, int y, int color) const;
 	virtual void debug(int x, int y, int color) const = 0;
@@ -114,6 +121,7 @@ public:
 
 	// セッタ
 	void setState(CHARACTER_STATE state);
+	inline void setSimpleGrand(bool grand) { m_grand = grand; }
 	void setGrand(bool grand);
 	void setRightLock(bool lock);
 	void setLeftLock(bool lock);
@@ -122,6 +130,20 @@ public:
 	inline void setBoost() { if(!m_grand) m_boostCnt = BOOST_TIME; }
 	inline void setGrandRightSlope(bool grand) { m_grandRightSlope = grand; }
 	inline void setGrandLeftSlope(bool grand) { m_grandLeftSlope = grand; }
+	void setRunCnt(int runCnt) { m_runCnt = runCnt; }
+	void setJumpCnt(int preJumpCnt) { m_preJumpCnt = preJumpCnt; }
+	void setMoveRight(bool moveRight) { m_moveRight = moveRight; }
+	void setMoveLeft(bool moveLeft) { m_moveLeft = moveLeft; }
+	void setMoveUp(bool moveUp) { m_moveUp = moveUp; }
+	void setMoveDown(bool moveDown) { m_moveDown = moveDown; }
+	void setVx(int vx) { m_vx = vx; }
+	void setVy(int vy) { m_vy = vy; }
+	void setBulletCnt(int bulletCnt) { m_bulletCnt = bulletCnt; }
+	void setSlashCnt(int slashCnt) { m_slashCnt = slashCnt; }
+	void setAttackLeftDirection(bool attackLeftDirection) { m_attackLeftDirection = attackLeftDirection; }
+	void setLandCnt(int landCnt) { m_landCnt = landCnt; }
+	void setBoostCnt(int boostCnt) { m_boostCnt = boostCnt; }
+	void setDamageCnt(int damageCnt) { m_damageCnt = damageCnt; }
 
 	// 今ダメージを受けていて動けない
 	inline bool damageFlag() const { return m_state == CHARACTER_STATE::DAMAGE; }
@@ -193,6 +215,8 @@ private:
 
 public:
 	StickAction(Character* character, SoundPlayer* soundPlayer_p);
+
+	CharacterAction* createCopy(std::vector<Character*> characters);
 
 	void debug(int x, int y, int color) const;
 

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -87,10 +87,12 @@ NormalAI::NormalAI() {
 Brain* NormalAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
 	NormalAI* res = new NormalAI();
 
-	for (unsigned int i = 0; i < characters.size(); i++) {
-		if (m_target_p->getId() == characters[i]->getId()) {
-			res->setTarget(characters[i]);
-			break;
+	if (m_target_p != NULL) {
+		for (unsigned int i = 0; i < characters.size(); i++) {
+			if (m_target_p->getId() == characters[i]->getId()) {
+				res->setTarget(characters[i]);
+				break;
+			}
 		}
 	}
 	setParam(res);
@@ -280,11 +282,13 @@ void NormalAI::searchTarget(const Character* character) {
 
 // 攻撃対象を変更する必要があるならtrueでアピールする。
 bool NormalAI::needSearchTarget() const {
-	if (m_target_p == NULL || m_target_p->getHp() == 0 || GetRand(99) == 0) {
+	if (m_target_p == NULL || m_target_p->getHp() == 0 || GetRand(99) == 0 || m_target_p->getGroupId() == -1) {
 		return true;
 	}
 	return false;
 }
+
+int  NormalAI::getTargetId() const { return m_target_p == NULL ? NULL : m_target_p->getId(); }
 
 
 void ParabolaAI::bulletTargetPoint(int& x, int& y) {

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -83,6 +83,36 @@ NormalAI::NormalAI() {
 	m_moveCnt = 0;
 }
 
+
+Brain* NormalAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	NormalAI* res = new NormalAI();
+
+	for (unsigned int i = 0; i < characters.size(); i++) {
+		if (m_target_p->getId() == characters[i]->getId()) {
+			res->setTarget(characters[i]);
+			break;
+		}
+	}
+	setParam(res);
+	return res;
+}
+
+void NormalAI::setParam(NormalAI* brain) {
+	// 移動用
+	brain->setRightKey(m_rightKey);
+	brain->setLeftKey(m_leftKey);
+	brain->setUpKey(m_upKey);
+	brain->setDownKey(m_downKey);
+	// ジャンプの長さ
+	brain->setJumpCnt(m_jumpCnt);
+	// しゃがむ長さ
+	brain->setSquatCnt(m_squatCnt);
+	// 移動目標
+	brain->setGx(m_gx);
+	brain->setGy(m_gy);
+	brain->setMoveCnt(m_moveCnt);
+}
+
 void NormalAI::setCharacterAction(const CharacterAction* characterAction) { 
 	m_characterAction_p = characterAction;
 	// 目標地点は現在地に設定
@@ -278,6 +308,24 @@ FollowNormalAI::FollowNormalAI() :
 	m_follow_p = NULL;
 }
 
+Brain* FollowNormalAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	FollowNormalAI* res = new FollowNormalAI();
+	for (unsigned int i = 0; i < characters.size(); i++) {
+		if (m_follow_p->getId() == characters[i]->getId()) {
+			res->setFollow(characters[i]);
+			break;
+		}
+	}
+	for (unsigned int i = 0; i < characters.size(); i++) {
+		if (m_target_p->getId() == characters[i]->getId()) {
+			res->setTarget(characters[i]);
+			break;
+		}
+	}
+	setParam(res);
+	return res;
+}
+
 int FollowNormalAI::getFollowId() const {
 	if (m_follow_p == nullptr) { return -1; }
 	return m_follow_p->getId();
@@ -436,6 +484,14 @@ NormalController::NormalController(Brain* brain, CharacterAction* characterActio
 	CharacterController(brain, characterAction)
 {
 
+}
+
+CharacterController* NormalController::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	CharacterAction* action = m_characterAction->createCopy(characters);
+	Brain* brain = m_brain->createCopy(characters, camera);
+	brain->setCharacterAction(action);
+	CharacterController* res = new NormalController(brain, action);
+	return res;
 }
 
 void NormalController::control() {

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -3,386 +3,11 @@
 #include "Character.h"
 #include "Camera.h"
 #include "Control.h"
+#include "Brain.h"
+#include "ControllerRecorder.h"
 #include "Define.h"
 #include "DxLib.h"
 #include <algorithm>
-
-
-// Brainクラス
-Brain::Brain() {
-	m_characterAction_p = NULL;
-}
-
-
-/*
-* キーボード
-*/
-KeyboardBrain::KeyboardBrain(const Camera* camera) {
-	m_camera_p = camera;
-}
-
-void KeyboardBrain::bulletTargetPoint(int& x, int& y) {
-	// マウスの位置
-	int mouseX, mouseY;
-	GetMousePoint(&mouseX, &mouseY);
-
-	// カメラで座標を補正
-	m_camera_p->getMouse(&mouseX, &mouseY);
-
-	x = mouseX;
-	y = mouseY;
-}
-
-// 話しかけたり扉入ったり
-bool KeyboardBrain::actionOrder() {
-	return controlW() == 1;
-}
-
-// 移動（上下左右の入力）
-void KeyboardBrain::moveOrder(int& right, int& left, int& up, int& down) {
-	right = controlD();
-	left = controlA();
-	up = controlW();
-	down = controlS();
-}
-
-// ジャンプ
-int KeyboardBrain::jumpOrder() {
-	return controlSpace();
-}
-
-// しゃがみ
-int KeyboardBrain::squatOrder() {
-	return controlS();
-}
-
-// 近距離攻撃
-int KeyboardBrain::slashOrder() {
-	return rightClick();
-}
-
-// 遠距離攻撃
-int KeyboardBrain::bulletOrder() {
-	return leftClick();
-}
-
-
-/*
-* Normal AI
-*/
-NormalAI::NormalAI() {
-	m_target_p = NULL;
-	m_gx = 0;
-	m_gy = 0;
-	m_rightKey = 0;
-	m_leftKey = 0;
-	m_upKey = 0;
-	m_downKey = 0;
-	m_jumpCnt = 0;
-	m_squatCnt = 0;
-	m_moveCnt = 0;
-}
-
-
-Brain* NormalAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
-	NormalAI* res = new NormalAI();
-
-	if (m_target_p != NULL) {
-		for (unsigned int i = 0; i < characters.size(); i++) {
-			if (m_target_p->getId() == characters[i]->getId()) {
-				res->setTarget(characters[i]);
-				break;
-			}
-		}
-	}
-	setParam(res);
-	return res;
-}
-
-void NormalAI::setParam(NormalAI* brain) {
-	// 移動用
-	brain->setRightKey(m_rightKey);
-	brain->setLeftKey(m_leftKey);
-	brain->setUpKey(m_upKey);
-	brain->setDownKey(m_downKey);
-	// ジャンプの長さ
-	brain->setJumpCnt(m_jumpCnt);
-	// しゃがむ長さ
-	brain->setSquatCnt(m_squatCnt);
-	// 移動目標
-	brain->setGx(m_gx);
-	brain->setGy(m_gy);
-	brain->setMoveCnt(m_moveCnt);
-}
-
-void NormalAI::setCharacterAction(const CharacterAction* characterAction) { 
-	m_characterAction_p = characterAction;
-	// 目標地点は現在地に設定
-	m_gx = m_characterAction_p->getCharacter()->getX();
-	m_gy = m_characterAction_p->getCharacter()->getY();
-}
-
-void NormalAI::bulletTargetPoint(int& x, int& y) {
-	if (m_target_p == NULL) {
-		x = 0;
-		y = 0;
-	}
-	else { // ターゲットに向かって射撃攻撃
-		x = m_target_p->getCenterX() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2);
-		y = m_target_p->getCenterY() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2);
-	}
-}
-
-void NormalAI::moveOrder(int& right, int& left, int& up, int& down) {
-	// 現在地
-	int x = m_characterAction_p->getCharacter()->getX();
-	int y = m_characterAction_p->getCharacter()->getY();
-
-	// (壁につっかえるなどで)移動できてないから諦める
-	//DrawFormatString(800, 50, GetColor(255, 255, 255), "moveCnt = %d, x(%d) -> gx(%d)", m_moveCnt, x, m_gx);
-	if (m_moveCnt >= GIVE_UP_MOVE_CNT) {
-		m_gx = x;
-		m_gy = y;
-	}
-
-	// 目標地点設定
-	bool alreadyGoal = m_gx > x - GX_ERROR && m_gx < x + GX_ERROR;
-	// ダメージを受けたらリセット
-	if (m_characterAction_p->getState() == CHARACTER_STATE::DAMAGE) {
-		m_gx = x, m_gy = y;
-	}
-	else if (alreadyGoal && GetRand(MOVE_RAND) == 0) {
-		if (m_target_p != NULL && abs(x - m_target_p->getCenterX()) < TARGET_DISTANCE) {
-			// targetについていく
-			m_gx = m_target_p->getCenterX() + GetRand(2000) - 1000;
-		}
-		else {
-			// ランダムに設定
-			m_gx = GetRand(200) + 100;
-			if (GetRand(99) < GX_ERROR) { m_gx *= -1; }
-			m_gx += x;
-		}
-	}
-	stickOrder(right, left, up, down);
-}
-
-// スティック操作
-void NormalAI::stickOrder(int& right, int& left, int& up, int& down) {
-	// 現在地
-	int x = m_characterAction_p->getCharacter()->getX();
-	int y = m_characterAction_p->getCharacter()->getY();
-
-	// 目標に向かって走る
-	if (m_gx > x + GX_ERROR) {
-		m_rightKey++;
-		m_leftKey = 0;
-		m_moveCnt++;
-	}
-	else if (m_gx < x - GX_ERROR) {
-		m_rightKey = 0;
-		m_leftKey++;
-		m_moveCnt++;
-	}
-	else {
-		m_rightKey = 0;
-		m_leftKey = 0;
-		m_moveCnt = 0;
-	}
-
-	// 反映
-	right = m_rightKey;
-	left = m_leftKey;
-	up = m_upKey;
-	down = m_downKey;
-}
-
-int NormalAI::jumpOrder() {
-	// ダメージを食らったらリセット
-	if (m_characterAction_p->getState() == CHARACTER_STATE::DAMAGE) {
-		m_jumpCnt = 0;
-		if (GetRand(120) == 0) { return 1; }
-	}
-
-	// ランダムでジャンプ
-	if (m_squatCnt == 0 && GetRand(99) == 0) { m_jumpCnt = GetRand(15) + 5; }
-
-	// 壁にぶつかったからジャンプ
-	if (m_rightKey > 0 && m_characterAction_p->getRightLock()) { m_jumpCnt = 20; }
-	else if (m_leftKey > 0 && m_characterAction_p->getLeftLock()) { m_jumpCnt = 20; }
-
-	if (m_jumpCnt > 0) { m_jumpCnt--; }
-	return m_jumpCnt == 0 ? 0 : 20 - m_jumpCnt;
-}
-
-int NormalAI::squatOrder() {
-	// ダメージを食らったらリセット
-	if (m_characterAction_p->getState() == CHARACTER_STATE::DAMAGE) {
-		m_squatCnt = 0;
-	}
-
-	// 目標地点にいないならしゃがまない
-	int x = m_characterAction_p->getCharacter()->getX();
-	bool alreadyGoal = m_gx > x - GX_ERROR && m_gx < x + GX_ERROR;
-	if (!alreadyGoal) { m_squatCnt = 0; }
-
-	// ランダムでしゃがむ
-	if (alreadyGoal && m_characterAction_p->getGrand() && GetRand(99) == 0) { 
-		m_squatCnt = GetRand(120) + 60;
-	}
-
-	if (m_squatCnt > 0) { m_squatCnt--; }
-	return m_squatCnt;
-}
-
-int NormalAI::slashOrder() {
-	if (m_target_p == NULL || m_target_p->getHp() == 0) {
-		return 0;
-	}
-	// 遠距離の敵には斬撃しない
-	if (m_target_p != NULL && abs(m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX()) > 500) {
-		return 0;
-	}
-	// ランダムで斬撃
-	if (GetRand(50) == 0) {
-		return 1;
-	}
-	return 0;
-}
-
-int NormalAI::bulletOrder() {
-	if (m_target_p == NULL || m_target_p->getHp() == 0) { 
-		return 0;
-	}
-	int x = m_characterAction_p->getCharacter()->getX();
-	if (abs(x - m_target_p->getCenterX()) > TARGET_DISTANCE) {
-		return 0;
-	}
-	// ランダムで射撃
-	if (GetRand(30) == 0) { 
-		return 1;
-	}
-	return 0;
-}
-
-// 攻撃対象を決める(targetのままか、characterに変更するか)
-void NormalAI::searchTarget(const Character* character) {
-	if (GetRand(99) < 50) {
-		int x = m_characterAction_p->getCharacter()->getX();
-		// 距離が遠い
-		if (abs(x - character->getCenterX()) > TARGET_DISTANCE) {
-			return;
-		}
-		// 味方じゃなければ&中立じゃなければ
-		int groupId = character->getGroupId();
-		if (groupId != m_characterAction_p->getCharacter()->getGroupId() && groupId != -1) {
-			m_target_p = character;
-		}
-	}
-}
-
-// 攻撃対象を変更する必要があるならtrueでアピールする。
-bool NormalAI::needSearchTarget() const {
-	if (m_target_p == NULL || m_target_p->getHp() == 0 || GetRand(99) == 0 || m_target_p->getGroupId() == -1) {
-		return true;
-	}
-	return false;
-}
-
-int  NormalAI::getTargetId() const { return m_target_p == NULL ? NULL : m_target_p->getId(); }
-
-
-void ParabolaAI::bulletTargetPoint(int& x, int& y) {
-	if (m_target_p == NULL) {
-		x = 0;
-		y = 0;
-	}
-	else { // ターゲットに向かって射撃攻撃
-		x = m_target_p->getCenterX() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2);
-		y = m_target_p->getCenterY() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2) - 200;
-	}
-}
-
-
-/*
-* キャラについていくNormalAI
-*/
-FollowNormalAI::FollowNormalAI() :
-	NormalAI()
-{
-	m_follow_p = NULL;
-}
-
-Brain* FollowNormalAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
-	FollowNormalAI* res = new FollowNormalAI();
-	for (unsigned int i = 0; i < characters.size(); i++) {
-		if (m_follow_p->getId() == characters[i]->getId()) {
-			res->setFollow(characters[i]);
-			break;
-		}
-	}
-	for (unsigned int i = 0; i < characters.size(); i++) {
-		if (m_target_p->getId() == characters[i]->getId()) {
-			res->setTarget(characters[i]);
-			break;
-		}
-	}
-	setParam(res);
-	return res;
-}
-
-int FollowNormalAI::getFollowId() const {
-	if (m_follow_p == nullptr) { return -1; }
-	return m_follow_p->getId();
-}
-
-void FollowNormalAI::moveOrder(int& right, int& left, int& up, int& down) {
-	// 現在地
-	int x = m_characterAction_p->getCharacter()->getX();
-	int y = m_characterAction_p->getCharacter()->getY();
-
-	// (壁につっかえるなどで)移動できてないから諦める
-	if (m_moveCnt >= GIVE_UP_MOVE_CNT) {
-		m_gx = x;
-		m_gy = y;
-	}
-
-	// 目標地点設定用パラメータ
-	int followX = m_follow_p->getCenterX();
-	bool alreadyGoal = m_gx > x - GX_ERROR && m_gx < x + GX_ERROR;
-	bool alreadyFollow = m_gx < followX + FOLLOW_X_ERROR && m_gx > followX - FOLLOW_X_ERROR;
-
-	// 目標地点設定
-	if ((alreadyGoal && GetRand(MOVE_RAND) == 0) || !alreadyFollow) {
-		if (m_follow_p != NULL) {
-			// followについていく
-			m_gx = m_follow_p->getCenterX() + GetRand(FOLLOW_X_ERROR * 2) - FOLLOW_X_ERROR;
-		}
-		else {
-			// ランダムに設定
-			m_gx = GetRand(200) + 100;
-			if (GetRand(99) < GX_ERROR) { m_gx *= -1; }
-			m_gx += x;
-		}
-	}
-
-	stickOrder(right, left, up, down);
-}
-
-// 追跡対象を決める(AIクラスでオーバライドする。)
-void FollowNormalAI::searchFollow(const Character* character) {
-	// 味方のみ
-	if (character->getId() != m_characterAction_p->getCharacter()->getId() && character->getGroupId() == m_characterAction_p->getCharacter()->getGroupId()) {
-		m_follow_p = character;
-	}
-}
-
-// 追跡対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
-bool FollowNormalAI::needSearchFollow() const {
-	if (m_follow_p == NULL || m_follow_p->getHp() == 0) {
-		return true;
-	}
-	return false;
-}
 
 
 /*
@@ -396,6 +21,15 @@ CharacterController::CharacterController(Brain* brain, CharacterAction* characte
 
 	// BrainにActionを注入
 	m_brain->setCharacterAction(m_characterAction);
+
+	// レコーダはデフォルトで使わない
+	m_stickRecorder = NULL;
+	m_jumpRecorder = NULL;
+	m_squatRecorder = NULL;
+	m_slashRecorder = NULL;
+	m_bulletRecorder = NULL;
+
+	m_duplicationFlag = false;
 }
 
 CharacterController::CharacterController() :
@@ -412,7 +46,41 @@ CharacterController::~CharacterController() {
 	if (m_brain != NULL) {
 		delete m_brain;
 	}
+	if (m_stickRecorder != NULL && !m_duplicationFlag) {
+		delete m_stickRecorder;
+		delete m_jumpRecorder;
+		delete m_squatRecorder;
+		delete m_slashRecorder;
+		delete m_bulletRecorder;
+	}
 }
+
+// レコーダを初期化
+void CharacterController::initRecorder() {
+	m_stickRecorder->init();
+	m_jumpRecorder->init();
+	m_squatRecorder->init();
+	m_slashRecorder->init();
+	m_bulletRecorder->init();
+}
+
+// レコードをやめる
+void CharacterController::eraseRecorder() { 
+	if (m_stickRecorder == NULL) { return; }
+	delete m_stickRecorder;
+	delete m_jumpRecorder;
+	delete m_squatRecorder;
+	delete m_slashRecorder;
+	delete m_bulletRecorder;
+	m_stickRecorder = NULL;
+	m_jumpRecorder = NULL;
+	m_squatRecorder = NULL;
+	m_slashRecorder = NULL;
+	m_bulletRecorder = NULL;
+}
+
+// 話しかけたり扉に入ったりするボタンがtrueか
+bool CharacterController::getActionKey() const { return m_brain->actionOrder(); }
 
 void CharacterController::setAction(CharacterAction* action) {
 	delete m_characterAction;
@@ -423,6 +91,27 @@ void CharacterController::setBrain(Brain* brain) {
 	delete m_brain;
 	m_brain = brain;
 	m_brain->setCharacterAction(m_characterAction);
+}
+
+// レコーダのセッタ
+void CharacterController::setStickRecorder(ControllerRecorder* recorder) {
+	m_stickRecorder = recorder;
+}
+void CharacterController::setJumpRecorder(ControllerRecorder* recorder) {
+	m_jumpRecorder = recorder;
+}
+void CharacterController::setSquatRecorder(ControllerRecorder* recorder) {
+	m_squatRecorder = recorder;
+}
+void CharacterController::setSlashRecorder(ControllerRecorder* recorder) {
+	m_slashRecorder = recorder;
+}
+void CharacterController::setBulletRecorder(ControllerRecorder* recorder) {
+	m_bulletRecorder = recorder;
+}
+
+void CharacterController::setTarget(Character* character) { 
+	m_brain->setTarget(character);
 }
 
 // アクションのセッタ
@@ -495,29 +184,104 @@ CharacterController* NormalController::createCopy(std::vector<Character*> charac
 	Brain* brain = m_brain->createCopy(characters, camera);
 	brain->setCharacterAction(action);
 	CharacterController* res = new NormalController(brain, action);
+	// 複製はレコーダをデリートしないためFlagをtrueにする
+	res->setDuplicationFlag(true);
+	res->setStickRecorder(m_stickRecorder);
+	res->setJumpRecorder(m_jumpRecorder);
+	res->setSquatRecorder(m_squatRecorder);
+	res->setSlashRecorder(m_slashRecorder);
+	res->setBulletRecorder(m_bulletRecorder);
 	return res;
 }
 
 void NormalController::control() {
 	// 移動 stickなどの入力状態を更新する
-	int rightStick, leftStick, upStick, downStick;
-	m_brain->moveOrder(rightStick, leftStick, upStick, downStick);
+	int rightStick = 0, leftStick = 0, upStick = 0, downStick = 0;
+	if (m_stickRecorder != NULL) {
+		if (m_stickRecorder->existRecord()) {
+			int input = m_stickRecorder->checkInput();
+			if (((input >> 0) & 1) == 1) { 
+				rightStick = 1;
+			}
+			if (((input >> 1) & 1) == 1) { 
+				leftStick = 1;
+			}
+			if (((input >> 2) & 1) == 1) { upStick = 1; }
+			if (((input >> 3) & 1) == 1) { downStick = 1; }
+		}
+		else {
+			m_brain->moveOrder(rightStick, leftStick, upStick, downStick);
+			int bit = 0;
+			if (rightStick > 0) { bit |= (1 << 0); }
+			if (leftStick > 0) { bit |= (1 << 1); }
+			if (upStick > 0) { bit |= (1 << 2); }
+			if (downStick > 0) { bit |= (1 << 3); }
+			m_stickRecorder->writeRecord(bit);
+		}
+		m_stickRecorder->addTime();
+	}
+	else {
+		m_brain->moveOrder(rightStick, leftStick, upStick, downStick);
+	}
 
 	// stickに応じて移動
 	m_characterAction->move(rightStick, leftStick, upStick, downStick);
 
 	// ジャンプ
-	int jump = m_brain->jumpOrder();
+	int jump = 0;
+	if (m_jumpRecorder != NULL) {
+		if (m_jumpRecorder->existRecord()) {
+			jump = m_jumpRecorder->checkInput();
+		}
+		else {
+			jump = m_brain->jumpOrder();
+			if (jump == 1) {
+				jump;
+			}
+			m_jumpRecorder->writeRecord(jump);
+		}
+		m_jumpRecorder->addTime();
+	}
+	else {
+		jump = m_brain->jumpOrder();
+	}
 	m_characterAction->jump(jump);
 
 	// しゃがみ
-	int squat = m_brain->squatOrder();
+	int squat = 0;
+	if (m_squatRecorder != NULL) {
+		if (m_squatRecorder->existRecord()) {
+			squat = m_squatRecorder->checkInput();
+		}
+		else {
+			squat = m_brain->squatOrder();
+			m_squatRecorder->writeRecord(squat);
+		}
+		m_squatRecorder->addTime();
+	}
+	else {
+		squat = m_brain->squatOrder();
+	}
 	m_characterAction->setSquat(squat);
 }
 
 Object* NormalController::bulletAttack() {
+	int order = 0;
+	if (m_bulletRecorder != NULL) {
+		if (m_bulletRecorder->existRecord()) {
+			order = m_bulletRecorder->checkInput();
+		}
+		else {
+			order = m_brain->bulletOrder();
+			m_bulletRecorder->writeRecord(order);
+		}
+		m_bulletRecorder->addTime();
+	}
+	else {
+		order = m_brain->bulletOrder();
+	}
 	// 遠距離攻撃の命令がされているなら
-	if (m_brain->bulletOrder() > 0) {
+	if (order > 0) {
 		// 攻撃目標
 		int targetX, targetY;
 		m_brain->bulletTargetPoint(targetX, targetY);
@@ -528,8 +292,22 @@ Object* NormalController::bulletAttack() {
 }
 
 Object* NormalController::slashAttack() {
+	int order = 0;
+	if (m_slashRecorder != NULL) {
+		if (m_slashRecorder->existRecord()) {
+			order = m_slashRecorder->checkInput();
+		}
+		else {
+			order = m_brain->slashOrder();
+			m_slashRecorder->writeRecord(order);
+		}
+		m_slashRecorder->addTime();
+	}
+	else {
+		order = m_brain->slashOrder();
+	}
 	// 近距離攻撃の命令がされたか、した後で今が攻撃タイミングなら
-	if (m_brain->slashOrder() == 1 || m_characterAction->getSlashCnt() > 0) {
+	if (order == 1 || m_characterAction->getSlashCnt() > 0) {
 		// 攻撃目標
 		int targetX, targetY;
 		m_brain->bulletTargetPoint(targetX, targetY);

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -1,6 +1,10 @@
 #ifndef CHACACTER_CONTROLLER_H_INCLUDED
 #define CHACACTER_CONTROLLER_H_INCLUDED
 
+
+#include <vector>
+
+
 class Character;
 class CharacterAction;
 class Object;
@@ -15,6 +19,8 @@ protected:
 
 public:
 	Brain();
+
+	virtual Brain* createCopy(std::vector<Character*> characters, const Camera* camera) = 0;
 
 	virtual void debug(int x, int y, int color) const = 0;
 
@@ -67,6 +73,7 @@ private:
 
 public:
 	KeyboardBrain(const Camera* camera);
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera){ return new KeyboardBrain(camera); }
 	void debug(int x, int y, int color) const;
 	inline void setCharacterAction(const CharacterAction* characterAction) { m_characterAction_p = characterAction; }
 	void bulletTargetPoint(int& x, int& y);
@@ -85,7 +92,8 @@ class Freeze :
 	public Brain
 {
 public:
-	Freeze(){ }
+	Freeze() { }
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera) { return new Freeze(); }
 	void debug(int x, int y, int color) const { }
 	bool actionOrder() { return false; }
 	void setCharacterAction(const CharacterAction* characterAction) {  }
@@ -141,6 +149,20 @@ protected:
 
 public:
 	NormalAI();
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+	void setParam(NormalAI* brain);
+
+	void setRightKey(int rightKey) { m_rightKey = rightKey; }
+	void setLeftKey(int leftKey) { m_leftKey = leftKey; }
+	void setUpKey(int upKey) { m_upKey = upKey; }
+	void setDownKey(int downKey) { m_downKey = downKey; }
+	void setJumpCnt(int cnt) { m_jumpCnt = cnt; }
+	void setSquatCnt(int cnt) { m_squatCnt = cnt; }
+	void setGx(int gx) { m_gx = gx; }
+	void setGy(int gy) { m_gy = gy; }
+	void setMoveCnt(int cnt) { m_moveCnt = cnt; }
+	void setTarget(Character* character) { m_target_p = character; }
+
 	void debug(int x, int y, int color) const;
 	void setCharacterAction(const CharacterAction* characterAction);
 	void bulletTargetPoint(int& x, int& y);
@@ -182,9 +204,13 @@ private:
 public:
 	FollowNormalAI();
 
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+
 	void debug(int x, int y, int color) const;
 
 	int getFollowId() const;
+
+	void setFollow(Character* character) { m_follow_p = character; }
 
 	// 移動の目標地点設定
 	void moveOrder(int& right, int& left, int& up, int& down);
@@ -213,6 +239,8 @@ public:
 	CharacterController();
 	CharacterController(Brain* brain, CharacterAction* characterAction);
 	~CharacterController();
+
+	virtual CharacterController* createCopy(std::vector<Character*> characters, const Camera* camera) = 0;
 
 	// デバッグ
 	void debugController(int x, int y, int color) const;
@@ -279,6 +307,8 @@ private:
 	const int JUMP_KEY_LONG = 10;
 public:
 	NormalController(Brain* brain, CharacterAction* characterAction);
+
+	CharacterController* createCopy(std::vector<Character*> characters, const Camera* camera);
 
 	void debug(int x, int y, int color) const;
 

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -9,225 +9,8 @@ class Character;
 class CharacterAction;
 class Object;
 class Camera;
-
-
-// Controllerに命令するクラス（キーボード＆マウスやＡＩ）
-class Brain {
-protected:
-	// 今のキャラの状態を考慮して射撃の目標座標や次の行動を決めるため必要
-	const CharacterAction* m_characterAction_p;
-
-public:
-	Brain();
-
-	virtual Brain* createCopy(std::vector<Character*> characters, const Camera* camera) = 0;
-
-	virtual void debug(int x, int y, int color) const = 0;
-
-	// 話しかけたり扉入ったり
-	virtual bool actionOrder() { return false; }
-
-	// セッタ
-	virtual void setCharacterAction(const CharacterAction* characterAction) = 0;
-	
-	// 遠距離攻撃の目標座標
-	virtual void bulletTargetPoint(int& x, int& y) = 0;
-
-	// 移動（上下左右の入力）
-	virtual void moveOrder(int& right, int& left, int& up, int& down) = 0;
-
-	// ジャンプの制御
-	virtual int jumpOrder() = 0;
-
-	// しゃがみの制御
-	virtual int squatOrder() = 0;
-
-	// 近距離攻撃
-	virtual int slashOrder() = 0;
-
-	// 遠距離攻撃
-	virtual int bulletOrder() = 0;
-
-	// 攻撃対象を決める(AIクラスでオーバライドする。)
-	virtual void searchTarget(const Character* character) { }
-
-	// 攻撃対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
-	virtual bool needSearchTarget() const { return false; }
-
-	// 追跡対象を決める(AIクラスでオーバライドする。)
-	virtual void searchFollow(const Character* character) { }
-
-	// 追跡対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
-	virtual bool needSearchFollow() const { return false; }
-
-	virtual int getTargetId() const { return -1; }
-
-	virtual void setTarget(Character* character) {  }
-};
-
-/*
-* キーボードでキャラの操作を命令するクラス
-*/
-class KeyboardBrain :
-	public Brain
-{
-private:
-	// カメラ
-	const Camera* m_camera_p;
-
-public:
-	KeyboardBrain(const Camera* camera);
-	Brain* createCopy(std::vector<Character*> characters, const Camera* camera){ return new KeyboardBrain(camera); }
-	void debug(int x, int y, int color) const;
-	inline void setCharacterAction(const CharacterAction* characterAction) { m_characterAction_p = characterAction; }
-	void bulletTargetPoint(int& x, int& y);
-	bool actionOrder();
-	void moveOrder(int& right, int& left, int& up, int& down);
-	int jumpOrder();
-	int squatOrder();
-	int slashOrder();
-	int bulletOrder();
-};
-
-/*
-* 全く動かないAI
-*/
-class Freeze :
-	public Brain
-{
-public:
-	Freeze() { }
-	Brain* createCopy(std::vector<Character*> characters, const Camera* camera) { return new Freeze(); }
-	void debug(int x, int y, int color) const { }
-	bool actionOrder() { return false; }
-	void setCharacterAction(const CharacterAction* characterAction) {  }
-	void bulletTargetPoint(int& x, int& y) {  }
-	void moveOrder(int& right, int& left, int& up, int& down) { right = 0; left = 0; up = 0; down = 0; }
-	int jumpOrder() { return 0; }
-	int squatOrder() { return 0; }
-	int slashOrder() { return 0; }
-	int bulletOrder() { return 0; }
-};
-
-/*
-*  普通に敵と戦うよう命令するＡＩのクラス
-*/
-class NormalAI :
-	public Brain
-{
-private:
-
-	// 攻撃対象を認知する距離
-	const int TARGET_DISTANCE = 2000;
-
-	// 移動用
-	int m_rightKey, m_leftKey, m_upKey, m_downKey;
-
-	// ジャンプの長さ
-	int m_jumpCnt;
-
-	// しゃがむ長さ
-	int m_squatCnt;
-
-protected:
-	// 攻撃対象
-	const Character* m_target_p;
-
-	// 射撃の精度
-	const int BULLET_ERROR = 400;
-
-	// 特に意味のない移動をする確率
-	const int MOVE_RAND = 59;
-
-	// 移動目標
-	int m_gx, m_gy;
-
-	// 移動目標達成とみなす誤差 ±GX_ERROR
-	const int GX_ERROR = 100;
-
-	// 移動時間
-	int m_moveCnt;
-
-	// 移動を諦めるまでの時間
-	const int GIVE_UP_MOVE_CNT = 300;
-
-public:
-	NormalAI();
-	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
-	void setParam(NormalAI* brain);
-
-	void setRightKey(int rightKey) { m_rightKey = rightKey; }
-	void setLeftKey(int leftKey) { m_leftKey = leftKey; }
-	void setUpKey(int upKey) { m_upKey = upKey; }
-	void setDownKey(int downKey) { m_downKey = downKey; }
-	void setJumpCnt(int cnt) { m_jumpCnt = cnt; }
-	void setSquatCnt(int cnt) { m_squatCnt = cnt; }
-	void setGx(int gx) { m_gx = gx; }
-	void setGy(int gy) { m_gy = gy; }
-	void setMoveCnt(int cnt) { m_moveCnt = cnt; }
-	void setTarget(Character* character) { m_target_p = character; }
-
-	void debug(int x, int y, int color) const;
-	void setCharacterAction(const CharacterAction* characterAction);
-	void bulletTargetPoint(int& x, int& y);
-	void moveOrder(int& right, int& left, int& up, int& down);
-	int jumpOrder();
-	int squatOrder();
-	int slashOrder();
-	int bulletOrder();
-
-	// 攻撃対象を決める(targetのままか、characterに変更するか)
-	void searchTarget(const Character* character);
-
-	// 攻撃対象を変更する必要があるならtrueでアピールする。
-	bool needSearchTarget() const;
-
-	int getTargetId() const;
-
-protected:
-	// スティック操作
-	void stickOrder(int& right, int& left, int& up, int& down);
-};
-
-
-class ParabolaAI :
-	public NormalAI
-{
-	void bulletTargetPoint(int& x, int& y);
-};
-
-
-class FollowNormalAI :
-	public NormalAI 
-{
-private:
-	// ついていくキャラ
-	const Character* m_follow_p;
-
-	// 追跡対象の近くにいるとみなす誤差 ±GX_ERROR
-	const int FOLLOW_X_ERROR = 500;
-
-public:
-	FollowNormalAI();
-
-	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
-
-	void debug(int x, int y, int color) const;
-
-	int getFollowId() const;
-
-	void setFollow(Character* character) { m_follow_p = character; }
-
-	// 移動の目標地点設定
-	void moveOrder(int& right, int& left, int& up, int& down);
-
-	// 追跡対象を決める(AIクラスでオーバライドする。)
-	void searchFollow(const Character* character);
-
-	// 追跡対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
-	bool needSearchFollow() const;
-};
-
+class Brain;
+class ControllerRecorder;
 
 
 /*
@@ -235,11 +18,21 @@ public:
 */
 class CharacterController {
 protected:
+	// 複製ならtrue Recorderをデリートしないため
+	bool m_duplicationFlag;
+
 	// こいつが操作を命令してくる Controllerがデリートする
 	Brain* m_brain;
 
 	// 操作対象 Controllerがデリートする
 	CharacterAction* m_characterAction;
+
+	// 操作の記録 使わないならNULL
+	ControllerRecorder* m_stickRecorder;
+	ControllerRecorder* m_jumpRecorder;
+	ControllerRecorder* m_squatRecorder;
+	ControllerRecorder* m_slashRecorder;
+	ControllerRecorder* m_bulletRecorder;
 
 public:
 	CharacterController();
@@ -255,14 +48,30 @@ public:
 	// ゲッタ
 	inline const CharacterAction* getAction() const { return m_characterAction; }
 	inline const Brain* getBrain() const { return m_brain; }
+	inline const ControllerRecorder* getStickRecorder() const { return m_stickRecorder; }
+	inline const ControllerRecorder* getJumpRecorder() const { return m_jumpRecorder; }
+	inline const ControllerRecorder* getSquatRecorder() const { return m_squatRecorder; }
+	inline const ControllerRecorder* getSlashRecorder() const { return m_slashRecorder; }
+	inline const ControllerRecorder* getBulletRecorder() const { return m_bulletRecorder; }
 
 	// セッタ
 	void setAction(CharacterAction* action);
 	void setBrain(Brain* brain);
-	void setTarget(Character* character) { m_brain->setTarget(character); }
+	void setStickRecorder(ControllerRecorder* recorder);
+	void setJumpRecorder(ControllerRecorder* recorder);
+	void setSquatRecorder(ControllerRecorder* recorder);
+	void setSlashRecorder(ControllerRecorder* recorder);
+	void setBulletRecorder(ControllerRecorder* recorder);
+	void setTarget(Character* character);
+	void setDuplicationFlag(bool flag) { m_duplicationFlag = flag; }
+
+	// レコーダを初期化
+	void initRecorder();
+	// レコードをやめる
+	void eraseRecorder();
 
 	// 話しかけたり扉に入ったりするボタンがtrueか
-	virtual bool getActionKey() const { return m_brain->actionOrder(); }
+	virtual bool getActionKey() const;
 
 	// アクションのセッタ
 	void setCharacterGrand(bool grand);

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -49,16 +49,20 @@ public:
 	virtual int bulletOrder() = 0;
 
 	// 攻撃対象を決める(AIクラスでオーバライドする。)
-	virtual void searchTarget(const Character* character) { };
+	virtual void searchTarget(const Character* character) { }
 
 	// 攻撃対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
 	virtual bool needSearchTarget() const { return false; }
 
 	// 追跡対象を決める(AIクラスでオーバライドする。)
-	virtual void searchFollow(const Character* character) { };
+	virtual void searchFollow(const Character* character) { }
 
 	// 追跡対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
 	virtual bool needSearchFollow() const { return false; }
+
+	virtual int getTargetId() const { return -1; }
+
+	virtual void setTarget(Character* character) {  }
 };
 
 /*
@@ -178,6 +182,8 @@ public:
 	// 攻撃対象を変更する必要があるならtrueでアピールする。
 	bool needSearchTarget() const;
 
+	int getTargetId() const;
+
 protected:
 	// スティック操作
 	void stickOrder(int& right, int& left, int& up, int& down);
@@ -253,6 +259,7 @@ public:
 	// セッタ
 	void setAction(CharacterAction* action);
 	void setBrain(Brain* brain);
+	void setTarget(Character* character) { m_brain->setTarget(character); }
 
 	// 話しかけたり扉に入ったりするボタンがtrueか
 	virtual bool getActionKey() const { return m_brain->actionOrder(); }

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -34,6 +34,9 @@ protected:
 	ControllerRecorder* m_slashRecorder;
 	ControllerRecorder* m_bulletRecorder;
 
+	// ダメージの記録 変化したらそれ以降のレコードを削除する
+	ControllerRecorder* m_damageRecorder;
+
 public:
 	CharacterController();
 	CharacterController(Brain* brain, CharacterAction* characterAction);
@@ -53,6 +56,7 @@ public:
 	inline const ControllerRecorder* getSquatRecorder() const { return m_squatRecorder; }
 	inline const ControllerRecorder* getSlashRecorder() const { return m_slashRecorder; }
 	inline const ControllerRecorder* getBulletRecorder() const { return m_bulletRecorder; }
+	inline const ControllerRecorder* getDamageRecorder() const { return m_damageRecorder; }
 
 	// セッタ
 	void setAction(CharacterAction* action);
@@ -62,6 +66,7 @@ public:
 	void setSquatRecorder(ControllerRecorder* recorder);
 	void setSlashRecorder(ControllerRecorder* recorder);
 	void setBulletRecorder(ControllerRecorder* recorder);
+	void setDamageRecorder(ControllerRecorder* recorder);
 	void setTarget(Character* character);
 	void setDuplicationFlag(bool flag) { m_duplicationFlag = flag; }
 

--- a/Control.cpp
+++ b/Control.cpp
@@ -69,9 +69,14 @@ int controlD() {
 	return Key[KEY_INPUT_D];
 }
 
+// Fキー（スキル発動）
+int controlF() {
+	return Key[KEY_INPUT_F];
+}
+
 //デバッグモード起動用
 int controlDebug() {
-	if (Key[KEY_INPUT_F] == 1) { // Fキーが押されていたら
+	if (Key[KEY_INPUT_P] == 1) { // Pキーが押されていたら
 		return TRUE;
 	}
 	return FALSE;

--- a/Control.h
+++ b/Control.h
@@ -22,6 +22,9 @@ int controlA();
 // Dキー（右キー）
 int controlD();
 
+// Fキー（スキル発動）
+int controlF();
+
 //FPS表示のオンオフ
 int controlDebug();
 

--- a/ControllerRecorder.cpp
+++ b/ControllerRecorder.cpp
@@ -12,6 +12,7 @@ ControllerRecord::ControllerRecord(int startTime, int input) {
 	m_startTime = startTime;
 	m_timeLength = 1;
 	m_input = input;
+	m_gx = 0; m_gy = 0;
 }
 
 
@@ -108,4 +109,18 @@ void ControllerRecorder::discardRecord() {
 	if (m_records.size() > 0) {
 		m_records.back()->setEndTime(m_time);
 	}
+}
+
+// UŒ‚–Ú•W‚ðÝ’è
+void ControllerRecorder::setGoal(int gx, int gy) {
+	if (!existRecord()) { return; }
+	m_records.back()->setGx(gx);
+	m_records.back()->setGy(gy);
+}
+
+// UŒ‚–Ú•W‚ðŽæ“¾
+void ControllerRecorder::getGoal(int& gx, int& gy) {
+	if (!existRecord()) { return; }
+	gx = m_records[m_index]->getGx();
+	gy = m_records[m_index]->getGy();
 }

--- a/ControllerRecorder.cpp
+++ b/ControllerRecorder.cpp
@@ -1,0 +1,111 @@
+#include "ControllerRecorder.h"
+#include <algorithm>
+
+
+using namespace std;
+
+
+/*
+* レコード
+*/
+ControllerRecord::ControllerRecord(int startTime, int input) {
+	m_startTime = startTime;
+	m_timeLength = 1;
+	m_input = input;
+}
+
+
+// 終了時刻をセット（終了時刻ちょうどでは入力なし）
+void ControllerRecord::setEndTime(int time) {
+	if (time > m_startTime) {
+		m_timeLength = time - m_startTime;
+	}
+	else {
+		m_startTime = time;
+		m_timeLength = 0;
+	}
+}
+
+
+
+/*
+* レコーダー
+*/
+ControllerRecorder::ControllerRecorder(int startTime) {
+	m_time = startTime;
+	m_index = 0;
+	if (m_time > 0) {
+		ControllerRecord* r = new ControllerRecord(0, false);
+		r->setEndTime(startTime);
+		m_records.push_back(r);
+		m_index++;
+	}
+}
+
+
+// デストラクタはレコードを全削除
+ControllerRecorder::~ControllerRecorder() {
+	for (unsigned int i = 0; i < m_records.size(); i++) {
+		delete m_records[i];
+	}
+}
+
+
+// 時間を進める
+void ControllerRecorder::addTime() {
+	m_time++;
+	//if (m_records.back()->getEndTime() <= m_time) {
+	//	m_index = (int)m_records.size();
+	//}
+	if (m_records.size() > 0 && m_index < m_records.size() && m_records[m_index]->getEndTime() <= m_time) {
+		m_index = min((int)m_records.size() + 1, m_index + 1);
+	}
+}
+
+
+// 時間を最初に戻す
+void ControllerRecorder::init() {
+	m_time = 0;
+	m_index = 0;
+}
+
+
+// レコードの存在チェック
+bool ControllerRecorder::existRecord() {
+	if (m_records.size() == 0) {
+		return false;
+	}
+	// 最新レコードの終了時刻と現在時刻を比較
+	return m_records.back()->getEndTime() > m_time;
+}
+
+
+// 入力を取得
+int ControllerRecorder::checkInput() {
+	if (!existRecord()) { return false; }
+	return m_records[m_index]->checkInput(m_time);
+}
+
+
+// 操作のレコードを追記or追加する（1F分）
+void ControllerRecorder::writeRecord(int input) {
+	if (m_records.size() != 0 && m_records.back()->getInput() == input) {
+		m_records.back()->addTime();
+	}
+	else {
+		m_records.push_back(new ControllerRecord(m_time, input));
+		m_index++;
+	}
+}
+
+
+// m_time以降のレコードを削除する
+void ControllerRecorder::discardRecord() {
+	while (m_records.size() > 0 && m_records.back()->getStartTime() > m_time) {
+		delete m_records.back();
+		m_records.pop_back();
+	}
+	if (m_records.size() > 0) {
+		m_records.back()->setEndTime(m_time);
+	}
+}

--- a/ControllerRecorder.h
+++ b/ControllerRecorder.h
@@ -1,0 +1,98 @@
+#ifndef CONTROLLER_RECORDER_H_INCLUDED
+#define CONTROLLER_RECORDER_H_INCLUDED
+
+
+#include <vector>
+
+
+class CharacterController;
+
+
+
+/*
+* 操作の記録（レコード）
+*/
+class ControllerRecord {
+private:
+
+	// 入力
+	int m_input;
+
+	// 入力開始の時刻
+	int m_startTime;
+
+	// 入力された時間の長さ（例えば1Fだけの入力なら1）
+	int m_timeLength;
+
+public:
+	ControllerRecord(int startTime, int input);
+
+	// ゲッタ
+	int getInput() { return m_input; }
+	int getStartTime() { return m_startTime; }
+	int getTimeLength() { return m_timeLength; }
+
+	// 入力の終了時刻（終了時刻ちょうどでは入力なし）
+	int getEndTime() { return m_startTime + m_timeLength; }
+
+	// ある時刻での入力チェック
+	int checkInput(int time) { 
+		if (m_startTime <= time && time < m_startTime + m_timeLength) {
+			return m_input;
+		}
+		return 0;
+	}
+
+	// 時間を加算
+	void addTime() { m_timeLength++; }
+
+	// 終了時刻をセット（終了時刻ちょうどでは入力なし）
+	void setEndTime(int time);
+};
+
+
+
+/*
+* CharacterControllerによる操作を記録するクラス。
+* 過去の動きの再現に使える。
+*/
+class ControllerRecorder {
+private:
+
+	// これ以降はレコードがないことを表すRecordの時間
+	const int END_RECORD_TIME = -1;
+
+	// 体内時計
+	int m_time;
+
+	// 現在見ているvectorのインデックス
+	int m_index;
+
+	// レコード（記録）
+	std::vector<ControllerRecord*> m_records;
+
+public:
+	ControllerRecorder(int startTime);
+	~ControllerRecorder();
+
+	// 時間を最初に戻す
+	void init();
+
+	// 時間を進める
+	void addTime();
+
+	// レコードの存在チェック
+	bool existRecord();
+
+	// 入力を取得
+	int checkInput();
+
+	// 操作のレコードを追記or追加する（1F分）
+	void writeRecord(int input);
+
+	// time以降のレコードを削除する
+	void discardRecord();
+};
+
+
+#endif

--- a/ControllerRecorder.h
+++ b/ControllerRecorder.h
@@ -24,6 +24,9 @@ private:
 	// 入力された時間の長さ（例えば1Fだけの入力なら1）
 	int m_timeLength;
 
+	// 攻撃用
+	int m_gx, m_gy;
+
 public:
 	ControllerRecord(int startTime, int input);
 
@@ -31,6 +34,12 @@ public:
 	int getInput() { return m_input; }
 	int getStartTime() { return m_startTime; }
 	int getTimeLength() { return m_timeLength; }
+	int getGx() { return m_gx; }
+	int getGy() { return m_gy; }
+
+	// セッタ
+	void setGx(int gx) { m_gx = gx; }
+	void setGy(int gy) { m_gy = gy; }
 
 	// 入力の終了時刻（終了時刻ちょうどでは入力なし）
 	int getEndTime() { return m_startTime + m_timeLength; }
@@ -92,6 +101,12 @@ public:
 
 	// time以降のレコードを削除する
 	void discardRecord();
+
+	// 攻撃目標を設定
+	void setGoal(int gx, int gy);
+
+	// 攻撃目標を取得
+	void getGoal(int& gx, int& gy);
 };
 
 

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -4,6 +4,7 @@
 #include "CharacterController.h"
 #include "Object.h"
 #include "Camera.h"
+#include "Brain.h"
 #include "Define.h"
 #include "DxLib.h"
 

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -10,6 +10,7 @@
 #include "Text.h"
 #include "Event.h"
 #include "Story.h"
+#include "Brain.h"
 #include "DxLib.h"
 
 /*

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -37,11 +37,6 @@ void debugObjects(int x, int y, int color, std::vector<Object*> objects) {
 void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, anime=%d", m_characters.size(), m_characterControllers.size(), m_animations.size());
-	if (m_conversation_p != NULL) {
-		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "cnt=%d, now=%d, text:%s", m_conversation_p->getCnt(), m_conversation_p->getTextNow(), m_conversation_p->getText().c_str());
-		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "size=%d, fullText:%s", m_conversation_p->getTextSize(), m_conversation_p->getFullText().c_str());
-		m_conversation_p->getGraph()->draw(GAME_WIDE-500, 500, 1.0);
-	}
 	//m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 }
 

--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -153,12 +153,14 @@
   <ItemGroup>
     <ClCompile Include="Animation.cpp" />
     <ClCompile Include="AnimationDrawer.cpp" />
+    <ClCompile Include="Brain.cpp" />
     <ClCompile Include="Camera.cpp" />
     <ClCompile Include="Character.cpp" />
     <ClCompile Include="CharacterAction.cpp" />
     <ClCompile Include="CharacterDrawer.cpp" />
     <ClCompile Include="CharacterController.cpp" />
     <ClCompile Include="Control.cpp" />
+    <ClCompile Include="ControllerRecorder.cpp" />
     <ClCompile Include="CsvReader.cpp" />
     <ClCompile Include="Debug.cpp" />
     <ClCompile Include="Event.cpp" />
@@ -178,12 +180,14 @@
   <ItemGroup>
     <ClInclude Include="Animation.h" />
     <ClInclude Include="AnimationDrawer.h" />
+    <ClInclude Include="Brain.h" />
     <ClInclude Include="Camera.h" />
     <ClInclude Include="Character.h" />
     <ClInclude Include="CharacterAction.h" />
     <ClInclude Include="CharacterDrawer.h" />
     <ClInclude Include="CharacterController.h" />
     <ClInclude Include="Control.h" />
+    <ClInclude Include="ControllerRecorder.h" />
     <ClInclude Include="CsvReader.h" />
     <ClInclude Include="Define.h" />
     <ClInclude Include="Event.h" />

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -102,6 +102,12 @@
     <ClCompile Include="TextDrawer.cpp">
       <Filter>ソース ファイル\ui</Filter>
     </ClCompile>
+    <ClCompile Include="Brain.cpp">
+      <Filter>ソース ファイル\api</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerRecorder.cpp">
+      <Filter>ソース ファイル\api</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">
@@ -169,6 +175,12 @@
     </ClInclude>
     <ClInclude Include="TextDrawer.h">
       <Filter>ヘッダー ファイル\ui</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerRecorder.h">
+      <Filter>ヘッダー ファイル\api</Filter>
+    </ClInclude>
+    <ClInclude Include="Brain.h">
+      <Filter>ヘッダー ファイル\api</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Event.cpp
+++ b/Event.cpp
@@ -5,6 +5,7 @@
 #include "CharacterController.h"
 #include "Character.h"
 #include "Text.h"
+#include "Brain.h"
 #include <sstream>
 
 using namespace std;

--- a/Event.cpp
+++ b/Event.cpp
@@ -55,6 +55,10 @@ Event::Event(int eventNum, World* world, SoundPlayer* soundPlayer) {
 
 }
 
+bool Event::skillAble() {
+	return m_eventElement[m_nowElement]->skillAble();
+}
+
 // Fire�̍쐬
 void Event::createFire(vector<string> param, World* world, SoundPlayer* soundPlayer) {
 	string param0 = param[0];

--- a/Event.h
+++ b/Event.h
@@ -47,6 +47,9 @@ protected:
 public:
 	EventElement(World* world);
 	virtual EVENT_RESULT play() = 0;
+
+	// ハートのスキル発動が可能かどうか
+	virtual bool skillAble() = 0;
 };
 
 
@@ -78,6 +81,9 @@ public:
 
 	// イベント進行
 	EVENT_RESULT play();
+
+	// 今ハートのスキル発動可能かどうか
+	bool skillAble();
 
 private:
 	void createFire(std::vector<std::string> param, World* world, SoundPlayer* soundPlayer);
@@ -131,6 +137,9 @@ public:
 	ChangeBrainEvent(World* world, std::vector<std::string> param);
 
 	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
 };
 
 // 特定のキャラのHPが0になるまで戦う
@@ -146,6 +155,9 @@ public:
 	DeadCharacterEvent(World* world, std::vector<std::string> param);
 
 	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return true; }
 };
 
 // 会話イベント
@@ -161,6 +173,9 @@ public:
 	~TalkEvent();
 
 	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
 };
 
 #endif

--- a/Game.cpp
+++ b/Game.cpp
@@ -7,6 +7,8 @@
 #include "Character.h"
 #include "CharacterAction.h"
 #include "CharacterController.h"
+#include "Brain.h"
+#include "ControllerRecorder.h"
 #include "DxLib.h"
 
 /*
@@ -100,9 +102,9 @@ bool Game::play() {
 	}
 
 	// スキル発動 Fキーかつスキル未発動状態かつ発動可能なイベント中（もしくはイベント中でない）かつエリア移動中でない
-	if (controlF() == 1 && m_skill == NULL && m_story->skillAble() && m_world->getBrightValue() == 255) {
+	if (controlF() == 1 && m_skill == NULL && m_story->skillAble() && m_world->getBrightValue() == 255 && m_world->getCharacterWithName("ハート")->getHp() > 0) {
 		m_world->setSkillFlag(true);
-		m_skill = new HeartSkill(2, m_world);
+		m_skill = new HeartSkill(3, m_world);
 	}
 	
 	// スキル発動中
@@ -153,6 +155,7 @@ HeartSkill::HeartSkill(int loopNum, World* world) {
 	Character* original = m_world_p->getCharacterWithId(m_world_p->getPlayerId());
 	original->setGroupId(-1);
 	m_world_p->setBrainWithId(m_world_p->getPlayerId(), new Freeze());
+	m_world_p->createRecorder();
 
 	// 最初の複製
 	m_duplicationWorld = createDuplicationWorld(m_world_p);
@@ -164,6 +167,7 @@ bool HeartSkill::play() {
 		// 次のループへ
 		m_cnt = 0;
 		m_loopNow++;
+		m_world_p->initRecorder();
 
 		if (m_loopNow < m_loopNum) {
 			// duplicationWorldを新たに作り、worldと以前のduplicationWorldの操作記録をコピーする
@@ -186,6 +190,7 @@ bool HeartSkill::play() {
 			// スキル終了
 			for (unsigned int i = 0; i < m_duplicationId.size(); i++) {
 				m_world_p->popCharacter(m_duplicationId[i]);
+				m_world_p->eraseRecorder();
 			}
 			return true;
 		}
@@ -223,11 +228,18 @@ void HeartSkill::createDuplicationHeart() {
 	// Character* duplicationHeart = original->createCopy();
 	duplicationHeart->setX(duplicationHeart->getX() + GetRand(200));
 	duplicationHeart->setHp(original->getHp());
+	duplicationHeart->setLeftDirection(original->getLeftDirection());
 
 	// push
 	m_duplicationId.push_back(duplicationHeart->getId());
 	CharacterAction* action = new StickAction(duplicationHeart, m_world_p->getSoundPlayer());
 	Brain* brain = new KeyboardBrain(m_world_p->getCamera());
-	m_world_p->pushCharacter(duplicationHeart, new NormalController(brain, action));
+	NormalController* controller = new NormalController(brain, action);
+	controller->setStickRecorder(new ControllerRecorder(0));
+	controller->setJumpRecorder(new ControllerRecorder(0));
+	controller->setSquatRecorder(new ControllerRecorder(0));
+	controller->setSlashRecorder(new ControllerRecorder(0));
+	controller->setBulletRecorder(new ControllerRecorder(0));
+	m_world_p->pushCharacter(duplicationHeart, controller);
 	m_world_p->setFocusId(duplicationHeart->getId());
 }

--- a/Game.cpp
+++ b/Game.cpp
@@ -104,7 +104,7 @@ bool Game::play() {
 	// スキル発動 Fキーかつスキル未発動状態かつ発動可能なイベント中（もしくはイベント中でない）かつエリア移動中でない
 	if (controlF() == 1 && m_skill == NULL && m_story->skillAble() && m_world->getBrightValue() == 255 && m_world->getCharacterWithName("ハート")->getHp() > 0) {
 		m_world->setSkillFlag(true);
-		m_skill = new HeartSkill(3, m_world);
+		m_skill = new HeartSkill(3, m_world, m_soundPlayer);
 	}
 	
 	// スキル発動中
@@ -145,7 +145,7 @@ bool Game::play() {
 /*
 * ハートのスキル
 */
-HeartSkill::HeartSkill(int loopNum, World* world) {
+HeartSkill::HeartSkill(int loopNum, World* world, SoundPlayer* soundPlayer) {
 	m_loopNum = loopNum;
 	m_loopNow = 0;
 	m_world_p = world;
@@ -159,6 +159,15 @@ HeartSkill::HeartSkill(int loopNum, World* world) {
 
 	// 最初の複製
 	m_duplicationWorld = createDuplicationWorld(m_world_p);
+
+	// 効果音
+	m_soundPlayer_p = soundPlayer;
+	m_sound = LoadSoundMem("sound/battle/skill.wav");
+	m_soundPlayer_p->pushSoundQueue(m_sound);
+}
+
+HeartSkill::~HeartSkill() {
+	DeleteSoundMem(m_sound);
 }
 
 bool HeartSkill::play() {
@@ -168,6 +177,7 @@ bool HeartSkill::play() {
 		m_cnt = 0;
 		m_loopNow++;
 		m_world_p->initRecorder();
+		m_soundPlayer_p->pushSoundQueue(m_sound);
 
 		if (m_loopNow < m_loopNum) {
 			// duplicationWorldを新たに作り、worldと以前のduplicationWorldの操作記録をコピーする
@@ -240,6 +250,7 @@ void HeartSkill::createDuplicationHeart() {
 	controller->setSquatRecorder(new ControllerRecorder(0));
 	controller->setSlashRecorder(new ControllerRecorder(0));
 	controller->setBulletRecorder(new ControllerRecorder(0));
+	//controller->setDamageRecorder(new ControllerRecorder(0));
 	m_world_p->pushCharacter(duplicationHeart, controller);
 	m_world_p->setFocusId(duplicationHeart->getId());
 }

--- a/Game.h
+++ b/Game.h
@@ -85,8 +85,15 @@ private:
 	// 複製のキャラID スキル終了時に消すため
 	std::vector<int> m_duplicationId;
 
+	// サウンドプレイヤー
+	SoundPlayer* m_soundPlayer_p;
+
+	// 効果音
+	int m_sound;
+
 public:
-	HeartSkill(int loopNum, World* world);
+	HeartSkill(int loopNum, World* world, SoundPlayer* soundPlayer);
+	~HeartSkill();
 
 	// ゲッタ
 	inline int getLoopNum() const { return m_loopNum; }

--- a/Game.h
+++ b/Game.h
@@ -6,6 +6,7 @@
 class SoundPlayer;
 class World;
 class Story;
+class Character;
 
 
 // キャラのセーブデータ
@@ -102,6 +103,8 @@ private:
 
 	// 操作記録をコピーする
 	void copyRecord(const World* from, World* to);
+
+	void createDuplicationHeart();
 };
 
 

--- a/Game.h
+++ b/Game.h
@@ -81,6 +81,9 @@ private:
 	// DUPLICATION_TIMEまでカウントする
 	int m_cnt;
 
+	// 複製のキャラID スキル終了時に消すため
+	std::vector<int> m_duplicationId;
+
 public:
 	HeartSkill(int loopNum, World* world);
 

--- a/Game.h
+++ b/Game.h
@@ -60,6 +60,48 @@ public:
 };
 
 
+// ハートのスキル
+class HeartSkill {
+private:
+	// 複製の数
+	int m_loopNum;
+
+	// 今何ループ目か
+	int m_loopNow;
+
+	// 元の世界
+	World* m_world_p;
+
+	// 複製
+	World* m_duplicationWorld;
+
+	// 何秒間か
+	const int DUPLICATION_TIME = 600;
+
+	// DUPLICATION_TIMEまでカウントする
+	int m_cnt;
+
+public:
+	HeartSkill(int loopNum, World* world);
+
+	// ゲッタ
+	inline int getLoopNum() const { return m_loopNum; }
+	inline int getLoopNow() const { return m_loopNow; }
+	inline World* getWorld() const { return m_loopNow < m_loopNum ? m_duplicationWorld : m_world_p; }
+	inline double getCnt() const { return ((double)DUPLICATION_TIME / 60.0) - ((double)m_cnt / 60.0); }
+
+	// スキル進行中
+	bool play();
+
+private:
+	// 世界のコピーを作る コピーの変更はオリジナルに影響しない
+	World* createDuplicationWorld(const World* world);
+
+	// 操作記録をコピーする
+	void copyRecord(const World* from, World* to);
+};
+
+
 class Game {
 private:
 	GameData* m_gameData;
@@ -73,12 +115,16 @@ private:
 	// ストーリー
 	Story* m_story;
 
+	// スキル
+	HeartSkill* m_skill;
+
 public:
 	Game();
 	~Game();
 
 	// ゲッタ
 	World* getWorld() const { return m_world; }
+	HeartSkill* getSkill() const { return m_skill; }
 
 	// デバッグ
 	void debug(int x, int y, int color) const;

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -2,20 +2,49 @@
 #include "Game.h"
 #include "World.h"
 #include "WorldDrawer.h"
+#include "Define.h"
+#include "DxLib.h"
+#include <string>
+#include <sstream>
+
+
+using namespace std;
 
 
 GameDrawer::GameDrawer(const Game* game) {
 	m_game = game;
 
 	m_worldDrawer = new WorldDrawer(NULL);
+
+	m_skillHandle = CreateFontToHandle(NULL, SKILL_SIZE, 10);
 }
 
 GameDrawer::~GameDrawer() {
 	delete m_worldDrawer;
+	DeleteFontToHandle(m_skillHandle);
 }
 
 void GameDrawer::draw() {
 	// ¢ŠE‚ð•`‰æ
-	m_worldDrawer->setWorld(m_game->getWorld());
+	HeartSkill* skill = m_game->getSkill();
+	if (skill != NULL) {
+		m_worldDrawer->setWorld(skill->getWorld());
+	}
+	else {
+		m_worldDrawer->setWorld(m_game->getWorld());
+	}
 	m_worldDrawer->draw();
+
+	// ƒXƒLƒ‹‚ÌŽžŠÔ“™‚ð•`‰æ
+	if (skill != NULL) {
+		int num = skill->getLoopNum();
+		int now = skill->getLoopNow();
+		if (now < num) {
+			ostringstream oss;
+			int cnt1 = (int)skill->getCnt();
+			int cnt2 = (int)((skill->getCnt() * 10) - cnt1 * 10);
+			oss << now + 1 << "/" << num << "F" << cnt1 << "." << cnt2;
+			DrawStringToHandle(700, 50, oss.str().c_str(), BLACK, m_skillHandle);
+		}
+	}
 }

--- a/GameDrawer.h
+++ b/GameDrawer.h
@@ -10,6 +10,10 @@ private:
 
 	WorldDrawer* m_worldDrawer;
 
+	// スキルの情報のフォント
+	const int SKILL_SIZE = 100;
+	int m_skillHandle;
+
 public:
 	GameDrawer(const Game* game);
 

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -183,9 +183,13 @@ void CharacterGraphHandle::setGraphSize() {
 }
 
 // ‰æ‘œ‚ðƒZƒbƒg‚·‚é ‘¶Ý‚µ‚È‚¢‚È‚ç‚»‚Ì‚Ü‚Ü
-void CharacterGraphHandle::setGraph(GraphHandles* graphHandles, int index) {
+void CharacterGraphHandle::setGraph(const GraphHandles* graphHandles, int index) {
 	if (index >= graphHandles->getSize() || index < 0) { return; }
 	m_graphHandle = graphHandles == NULL ? m_graphHandle : graphHandles->getGraphHandle(index);
+	setGraphSize();
+}
+void CharacterGraphHandle::setGraph(GraphHandle* graphHandle) {
+	m_graphHandle = graphHandle;
 	setGraphSize();
 }
 

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -27,7 +27,7 @@ public:
 	~GraphHandle();
 
 	// ゲッタ
-	inline int getHandle() { return m_handle; }
+	inline int getHandle() const { return m_handle; }
 	inline double getEx() const { return m_ex; }
 
 	// セッタ
@@ -60,7 +60,7 @@ public:
 	// ゲッタ
 	inline GraphHandle* getGraphHandle(int i = 0) const { return m_handles[i]; }
 	inline int getHandle(int i) { return m_handles[i]->getHandle(); }
-	inline int getSize() { return m_handleSum; }
+	inline int getSize() const { return m_handleSum; }
 
 	// セッタ
 	void setEx(double ex);
@@ -147,7 +147,7 @@ public:
 	~CharacterGraphHandle();
 
 	// 表示する画像を返す
-	inline GraphHandle* getHandle() const { return m_graphHandle; }
+	inline GraphHandle* getHandle() { return m_graphHandle; }
 	inline int getWide() const { return m_wide; }
 	inline int getHeight() const { return m_height; }
 
@@ -174,7 +174,8 @@ public:
 	void setGraphSize();
 
 	// 画像をセット、存在しない画像ならそのまま　サイズも決定
-	void setGraph(GraphHandles* graphHandles, int index);
+	void setGraph(const GraphHandles* graphHandles, int index);
+	void setGraph(GraphHandle* graphHandle);
 
 	// 立ち画像をセット
 	void switchStand(int index = 0);

--- a/Object.cpp
+++ b/Object.cpp
@@ -792,6 +792,7 @@ void BulletObject::setBulletParam(BulletObject* object) {
 	object->setGy(m_gy);
 	object->setD(m_d);
 	object->setDamage(m_damage);
+	object->setEffectHandles(m_effectHandles_p);
 }
 Object* ParabolaBullet::createCopy() {
 	ParabolaBullet* res = new ParabolaBullet(m_x1, m_y1, m_handle, m_gx, m_gy);
@@ -814,6 +815,7 @@ void SlashObject::setSlashParam(SlashObject* object) {
 	object->setCnt(m_cnt);
 	object->setSlashImpactX(m_slashImpactX);
 	object->setSlashImpactY(m_slashImpactY);
+	object->setEffectHandles(m_effectHandles_p);
 }
 Object* DoorObject::createCopy() {
 	DoorObject* res = new DoorObject(m_x1, m_y1, m_x2, m_y2, m_fileName, m_areaNum);

--- a/Object.h
+++ b/Object.h
@@ -42,6 +42,9 @@ public:
 	Object();
 	Object(int x1, int y1, int x2, int y2, int hp = -1);
 
+	virtual Object* createCopy() = 0;
+	void setParam(Object* object);
+
 	void debugObject(int x, int y, int color) const;
 	virtual void debug(int x, int y, int color) const = 0;
 
@@ -60,6 +63,14 @@ public:
 
 	// セッタ
 	inline void setDeleteFlag(bool deleteFlag) { m_deleteFlag = deleteFlag; }
+	void setX1(int x1) { m_x1 = x1; }
+	void setY1(int y1) { m_y1 = y1; }
+	void setX2(int x2) { m_x2 = x2; }
+	void setY2(int y2) { m_y2 = y2; }
+	void setHp(int hp) { m_hp = hp; }
+	void setDamageCnt(int damageCnt) { m_damageCnt = damageCnt; }
+	void setEffectHandles(GraphHandles* effectHandles_p) { m_effectHandles_p = effectHandles_p; }
+	void setSoundHandle(int soundHandle_p) { m_soundHandle_p = soundHandle_p; }
 
 	// HPを減らす
 	void decreaseHp(int damageValue);
@@ -118,6 +129,8 @@ private:
 public:
 	BoxObject(int x1, int y1, int x2, int y2, int color, int hp = -1);
 
+	Object* createCopy();
+
 	void debug(int x, int y, int color) const;
 
 	// オブジェクト描画（画像がないときに使う）
@@ -154,6 +167,8 @@ private:
 	int getY(int x) const;
 public:
 	TriangleObject(int x1, int y1, int x2, int y2, int color, bool leftDown, int hp = -1);
+
+	Object* createCopy();
 
 	void debug(int x, int y, int color) const;
 
@@ -213,6 +228,10 @@ protected:
 public:
 	// x, y, gx, gyは弾の中心座標
 	BulletObject(int x, int y, int color, int gx, int gy, AttackInfo* attackInfo);
+	BulletObject(int x, int y, int color, int gx, int gy);
+
+	Object* createCopy();
+	void setBulletParam(BulletObject* obejct);
 
 	void debug(int x, int y, int color) const;
 
@@ -226,6 +245,16 @@ public:
 	// キャラクターIDをセット
 	inline void setCharacterId(int id) { m_characterId = id; }
 	inline void setGroupId(int id) { m_groupId = id; }
+	inline void setColor(int color) { m_color = color; }
+	inline void setRx(int rx) { m_rx = rx; }
+	inline void setRy(int ry) { m_ry = ry; }
+	inline void setV(int v) { m_v = v; }
+	inline void setVx(int vx) { m_vx = vx; }
+	inline void setVy(int vy) { m_vy = vy; }
+	inline void setGx(int gx) { m_gx = gx; }
+	inline void setGy(int gy) { m_gy = gy; }
+	inline void setD(int d) { m_d = d; }
+	inline void setDamage(int damage) { m_damage = damage; }
 
 	// 攻撃力 攻撃オブジェクト用
 	inline int getDamage() const { return m_damage; }
@@ -255,6 +284,11 @@ private:
 	const int G = 2;
 public:
 	ParabolaBullet(int x, int y, GraphHandle* handle, int gx, int gy, AttackInfo* attackInfo);
+	ParabolaBullet(int x, int y, GraphHandle* handle, int gx, int gy);
+
+	Object* createCopy();
+
+	inline void setGraphHandle(GraphHandle* handle) { m_handle = handle; }
 
 	// 動くオブジェクト用 毎フレーム行う
 	void action();
@@ -302,8 +336,14 @@ public:
 	// 座標、画像、生存時間、AttackInfo
 	SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo);
 
+	SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum);
+
 	// 大きさを指定しない場合。画像からサイズ取得。生存時間、AttackInfo
 	SlashObject(int x, int y, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo);
+
+	Object* createCopy();
+
+	void setSlashParam(SlashObject* object);
 
 	void debug(int x, int y, int color) const;
 
@@ -316,6 +356,11 @@ public:
 	// セッタ
 	inline void setCharacterId(int id) { m_characterId = id; }
 	inline void setGroupId(int id) { m_groupId = id; }
+	inline void setDamage(int damage) { m_damage = damage; }
+	inline void setGraphHandle(GraphHandle* handle) { m_handle = handle; }
+	inline void setCnt(int cnt) { m_cnt = cnt; }
+	inline void setSlashImpactX(int slashImpactX) { m_slashImpactX = slashImpactX; }
+	inline void setSlashImpactY(int slashImpactY) { m_slashImpactY = slashImpactY; }
 
 	// 攻撃力 攻撃オブジェクト用
 	inline int getDamage() const { return m_damage; }
@@ -340,6 +385,9 @@ class DoorObject :
 	public Object 
 {
 private:
+	// ファイルネームを保存しておく
+	const char* m_fileName;
+
 	// 画像
 	GraphHandle* m_graph;
 
@@ -353,12 +401,17 @@ public:
 	DoorObject(int x1, int y1, int x2, int y2, const char* fileName, int areaNum);
 	~DoorObject();
 
+	Object* createCopy();
+
 	void debug(int x, int y, int color) const;
 
 	// ゲッタ
 	GraphHandle* getHandle() const { return m_graph; }
 	inline int getAreaNum() const { return m_areaNum; }
 	inline std::string getText() const { return m_text; }
+
+	// セッタ
+	inline void setText(std::string text) { m_text = text; }
 
 	// キャラとの当たり判定
 	virtual bool atari(CharacterController* characterController);

--- a/Story.cpp
+++ b/Story.cpp
@@ -75,3 +75,11 @@ bool Story::play() {
 	}
 	return false;
 }
+
+// ハートのスキル発動が可能かどうか
+bool Story::skillAble() {
+	if (m_nowEvent == NULL) {
+		return true;
+	}
+	return m_nowEvent->skillAble();
+}

--- a/Story.h
+++ b/Story.h
@@ -33,6 +33,9 @@ public:
 	void debug(int x, int y, int color);
 
 	bool play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble();
 };
 
 

--- a/Text.h
+++ b/Text.h
@@ -23,7 +23,7 @@ private:
 	unsigned int m_textSpeed;
 
 	// テキストを飛ばせるようになるまでの時間
-	const unsigned int MOVE_FINAL_ABLE = 30;
+	const unsigned int MOVE_FINAL_ABLE = 10;
 
 	// ファイルポインタ
 	int m_fp;

--- a/World.cpp
+++ b/World.cpp
@@ -204,19 +204,40 @@ void World::pushCharacter(Character* character, CharacterController* controller)
 
 void World::popCharacter(int id) {
 	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
+		if (m_characterControllers[i]->getAction()->getCharacter()->getName() == "ハート") {
+			continue;
+		}
 		if (m_characterControllers[i]->getAction()->getCharacter()->getId() == id) {
 			delete m_characterControllers[i];
 			m_characterControllers[i] = m_characterControllers.back();
 			m_characterControllers.pop_back();
+			i--;
 		}
 	}
 	for (unsigned int i = 0; i < m_characters.size(); i++) {
+		if (m_characters[i]->getName() == "ハート") {
+			continue;
+		}
 		if (m_characters[i]->getId() == id) {
+			for (unsigned int j = 0; j < m_characterControllers.size(); j++) {
+				if (m_characterControllers[j]->getBrain()->getTargetId() == id) {
+					m_characterControllers[j]->setTarget(NULL);
+				}
+			}
+			//m_characters[i]->setHp(0);
 			delete m_characters[i];
 			m_characters[i] = m_characters.back();
 			m_characters.pop_back();
+			i--;
 		}
 	}
+	//// 攻撃エフェクト削除
+	//for (unsigned i = 0; i < m_animations.size(); i++) {
+	//	delete m_animations[i];
+	//	m_animations[i] = m_animations.back();
+	//	m_animations.pop_back();
+	//	i--;
+	//}
 }
 
 
@@ -472,7 +493,9 @@ void World::controlCharacter() {
 		if (slashAttack != NULL) { m_attackObjects.push_back(slashAttack); }
 
 		// 反映
-		controller->action();
+		if (!m_duplicationFlag || m_characterControllers[i]->getAction()->getCharacter()->getId() != m_playerId) {
+			controller->action();
+		}
 
 		// オブジェクトとの貫通判定
 		penetrationCharacterAndObject(controller, m_stageObjects);
@@ -563,6 +586,23 @@ Character* World::getCharacterWithName(string characterName) const {
 		}
 	}
 	return NULL;
+}
+
+Character* World::getCharacterWithId(int id) const {
+	for (unsigned int i = 0; i < m_characters.size(); i++) {
+		if (m_characters[i]->getId() == id) {
+			return m_characters[i];
+		}
+	}
+	return NULL;
+}
+
+void World::setBrainWithId(int id, Brain* brain) {
+	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
+		if (m_characterControllers[i]->getAction()->getCharacter()->getId() == id) {
+			m_characterControllers[i]->setBrain(brain);
+		}
+	}
 }
 
 CharacterController* World::getControllerWithName(string characterName) const {

--- a/World.cpp
+++ b/World.cpp
@@ -78,6 +78,9 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) {
 	// 会話イベント
 	m_conversation_p = NULL;
 
+	// スキル発動中
+	m_skillFlag = false;
+
 	// 主人公のスタート地点
 	m_areaNum = toAreaNum;
 
@@ -330,6 +333,10 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 
 // キャラクターと扉オブジェクトの当たり判定
 void World::atariCharacterAndDoor(CharacterController* controller, vector<Object*>& objects) {
+
+	// スキル発動中は扉は入れない
+	if (m_skillFlag) { return; }
+
 	// 壁や床オブジェクトの処理 (当たり判定と動き)
 	for (unsigned int i = 0; i < objects.size(); i++) {
 		// 当たり判定をここで行う
@@ -340,6 +347,7 @@ void World::atariCharacterAndDoor(CharacterController* controller, vector<Object
 			m_brightValue--;
 		}
 	}
+
 }
 
 // キャラクターの動き

--- a/World.cpp
+++ b/World.cpp
@@ -10,6 +10,8 @@
 #include "Control.h"
 #include "Define.h"
 #include "Text.h"
+#include "Brain.h"
+#include "ControllerRecorder.h"
 #include "DxLib.h"
 #include <algorithm>
 
@@ -231,13 +233,35 @@ void World::popCharacter(int id) {
 			i--;
 		}
 	}
-	//// 攻撃エフェクト削除
-	//for (unsigned i = 0; i < m_animations.size(); i++) {
-	//	delete m_animations[i];
-	//	m_animations[i] = m_animations.back();
-	//	m_animations.pop_back();
-	//	i--;
-	//}
+}
+
+
+// レコーダを作成し使用を開始
+void World::createRecorder() {
+	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
+		if (m_characterControllers[i]->getAction()->getCharacter()->getName() == "ハート") { continue; }
+		m_characterControllers[i]->setStickRecorder(new ControllerRecorder(0));
+		m_characterControllers[i]->setJumpRecorder(new ControllerRecorder(0));
+		m_characterControllers[i]->setSquatRecorder(new ControllerRecorder(0));
+		m_characterControllers[i]->setSlashRecorder(new ControllerRecorder(0));
+		m_characterControllers[i]->setBulletRecorder(new ControllerRecorder(0));
+	}
+}
+
+// レコーダの時間を最初に戻す
+void World::initRecorder() {
+	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
+		if (m_characterControllers[i]->getAction()->getCharacter()->getName() == "ハート") { continue; }
+		m_characterControllers[i]->initRecorder();
+	}
+}
+
+// レコーダの使用をやめて削除する
+void World::eraseRecorder() {
+	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
+		if (m_characterControllers[i]->getAction()->getCharacter()->getName() == "ハート") { continue; }
+		m_characterControllers[i]->eraseRecorder();
+	}
 }
 
 
@@ -482,7 +506,9 @@ void World::controlCharacter() {
 		}
 
 		// 操作
-		controller->control();
+		if (!m_duplicationFlag || m_characterControllers[i]->getAction()->getCharacter()->getId() != m_playerId) {
+			controller->control();
+		}
 
 		// 射撃攻撃
 		Object* bulletAttack = controller->bulletAttack();

--- a/World.cpp
+++ b/World.cpp
@@ -245,6 +245,7 @@ void World::createRecorder() {
 		m_characterControllers[i]->setSquatRecorder(new ControllerRecorder(0));
 		m_characterControllers[i]->setSlashRecorder(new ControllerRecorder(0));
 		m_characterControllers[i]->setBulletRecorder(new ControllerRecorder(0));
+		m_characterControllers[i]->setDamageRecorder(new ControllerRecorder(0));
 	}
 }
 

--- a/World.h
+++ b/World.h
@@ -16,6 +16,9 @@ class Conversation;
 
 class World {
 private:
+	// 複製ならtrue 背景をデリートしないため
+	bool m_duplicationFlag;
+
 	// サウンドプレイヤー
 	SoundPlayer* m_soundPlayer_p;
 
@@ -66,14 +69,24 @@ public:
 	World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer);
 	~World();
 
+	World(const World* original);
+
 	// ゲッタ
+	inline int getFocusId() const { return m_focusId; }
+	inline int getPlayerId() const { return m_playerId; }
 	inline int getBrightValue() const { return m_brightValue; }
 	inline int getAreaNum() const { return m_areaNum; }
 	inline const Camera* getCamera() const { return m_camera; }
+	std::vector<CharacterController*> getCharacterControllers() const;
 	std::vector<const CharacterAction*> getActions() const;
+	std::vector<Character*> getCharacters() const;
+	std::vector<Object*> getStageObjects() const;
+	std::vector<Object*> getDoorObjects() const;
+	std::vector<Object*> getAttackObjects() const;
+	std::vector<Animation*> getAnimations() const;
 	std::vector<const Object*> getFrontObjects() const;
 	std::vector<const Object*> getBackObjects() const;
-	std::vector<const Animation*> getAnimations() const;
+	std::vector<const Animation*> getConstAnimations() const;
 	inline const int getBackGroundGraph() const { return m_backGroundGraph; }
 	inline const int getBackGroundColor() const { return m_backGroundColor; }
 	inline const Conversation* getConversation() const { return m_conversation_p; }
@@ -103,6 +116,8 @@ public:
 	Character* getCharacterWithName(std::string characterName) const;
 	CharacterController* getControllerWithName(std::string characterName) const;
 	inline void setConversation(Conversation* conversation){ m_conversation_p = conversation; }
+	void pushCharacter(Character* character, CharacterController* controller);
+	void popCharacter(int id);
 
 private:
 	// キャラクターとオブジェクトの当たり判定

--- a/World.h
+++ b/World.h
@@ -22,6 +22,9 @@ private:
 	// 会話イベント EventElementクラスからもらう
 	Conversation* m_conversation_p;
 
+	// スキル発動中はエリア間の移動できない
+	bool m_skillFlag;
+
 	// 画面の明るさ
 	int m_brightValue;
 
@@ -74,6 +77,10 @@ public:
 	inline const int getBackGroundGraph() const { return m_backGroundGraph; }
 	inline const int getBackGroundColor() const { return m_backGroundColor; }
 	inline const Conversation* getConversation() const { return m_conversation_p; }
+	inline SoundPlayer* getSoundPlayer() const { return m_soundPlayer_p; }
+
+	// セッタ
+	inline void setSkillFlag(bool skillFlag) { m_skillFlag = skillFlag; }
 
 	//デバッグ
 	void debug(int x, int y, int color) const;

--- a/World.h
+++ b/World.h
@@ -13,6 +13,7 @@ class Camera;
 class Animation;
 class SoundPlayer;
 class Conversation;
+class Brain;
 
 class World {
 private:
@@ -94,6 +95,7 @@ public:
 
 	// セッタ
 	inline void setSkillFlag(bool skillFlag) { m_skillFlag = skillFlag; }
+	inline void setFocusId(int id) { m_focusId = id; }
 
 	//デバッグ
 	void debug(int x, int y, int color) const;
@@ -115,6 +117,8 @@ public:
 	*/
 	Character* getCharacterWithName(std::string characterName) const;
 	CharacterController* getControllerWithName(std::string characterName) const;
+	Character* getCharacterWithId(int id) const;
+	void setBrainWithId(int id, Brain* brain);
 	inline void setConversation(Conversation* conversation){ m_conversation_p = conversation; }
 	void pushCharacter(Character* character, CharacterController* controller);
 	void popCharacter(int id);

--- a/World.h
+++ b/World.h
@@ -122,6 +122,9 @@ public:
 	inline void setConversation(Conversation* conversation){ m_conversation_p = conversation; }
 	void pushCharacter(Character* character, CharacterController* controller);
 	void popCharacter(int id);
+	void createRecorder();
+	void initRecorder();
+	void eraseRecorder();
 
 private:
 	// キャラクターとオブジェクトの当たり判定

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -110,7 +110,7 @@ void WorldDrawer::draw() {
 	}
 
 	// 各Animationを描画
-	vector<const Animation*> animations = m_world->getAnimations();
+	vector<const Animation*> animations = m_world->getConstAnimations();
 	size = animations.size();
 	for (unsigned int i = 0; i < size; i++) {
 		// AnimationをDrawerにセット


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
[Wikiのこのページを参照](https://github.com/kuriuminoki/DuplicationHeart/wiki/%E4%B8%BB%E4%BA%BA%E5%85%AC%E3%81%AE%E3%82%B9%E3%82%AD%E3%83%AB%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)


# やったこと
Worldクラスのコピーを作れるようにした。WorldをコピーするということはCharacterなどのメンバもすべてコピーできるようにする必要があるため、その処理も実装した。ゲッタやセッタを多く定義した。
具体的なやり方としては、コピー元が持つ関数createCopy()を呼び出し、その戻り値をコピー先へ代入する。

Characterクラスに関しては、コピーされたインスタンスはコピー元とAttackInfoを共有する。なぜなら、共有しなければコピーをデリートしたときに攻撃のエフェクトデータも削除されて、Worldに残った攻撃やエフェクトの情報が抜け落ちて実行時エラーとなるからである。コピーはdeleteされたときに共有しているAttackInfoを消さない。(duplicationFlagがtrueなら消さない。)

スキルのアルゴリズムはおおむねWikiに書いてある通りに実装した。
しかし、ControllerRecorderクラスの設計は変更。queueでなくvectorを使って入力を記録する。
この方が計算が速い実装ができる。
また、当初の予定ではWorldクラスが管理する時間の情報をControllerに渡してその時間を元にレコーダを取り扱うつもりだったが、各Recorderが時間を個別に管理することにした。この方がクラス間の依存が弱まり分かりやすくなる。

Brain.cpp、Brain.hを新たに作成してBrainクラスとControllerクラスの実装を分けた。（Controllerのファイルが大きくなって読みにくかったため）

敵はダメージの受けるタイミングが前のループと違うと、それ以降のレコードを破棄してレコーディングしなおす。

ループの開始時に効果音が鳴る。

射撃や斬撃攻撃については攻撃目標をレコードに入れておき、読み込み時に攻撃目標の座標を取り出し攻撃する。

# やらないこと
#49 

# できるようになること(ユーザ目線)
スキルを使えるようになる。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。

# 懸念点
重い＆メモリリーク不安 今のところ60fpsで動くが果たして。
↓試したけどNULL == nullptrは成り立つから取り急ぎ対処の必要はない。
#49 NULL == nullptrが成り立たないかもしれない問題が発覚。でも成り立つか関係なくnullptrで統一した方がよさそう？
↓削除時にAnimationの描画で実行時エラーになるバグ、どうやって直したか忘れてしまった。
スキル終了後、複製のハートをどのように消すか問題
