### PR TITLE
Api: デモに必要なストーリー進行処理を追加

### DIFF
--- a/Brain.h
+++ b/Brain.h
@@ -63,6 +63,7 @@ public:
 	virtual void setTarget(Character* character) {  }
 };
 
+
 /*
 * キーボードでキャラの操作を命令するクラス
 */
@@ -87,6 +88,7 @@ public:
 	int bulletOrder();
 };
 
+
 /*
 * 全く動かないAI
 */
@@ -106,6 +108,7 @@ public:
 	int slashOrder() { return 0; }
 	int bulletOrder() { return 0; }
 };
+
 
 /*
 *  普通に敵と戦うよう命令するＡＩのクラス
@@ -188,6 +191,9 @@ protected:
 };
 
 
+/*
+* ParabolaBulletを使うAI
+*/
 class ParabolaAI :
 	public NormalAI
 {

--- a/CsvReader.h
+++ b/CsvReader.h
@@ -7,6 +7,9 @@
 #include <sstream>
 
 
+int str2color(std::string colorName);
+
+
 class CsvReader {
 private:
 	/*

--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Object.cpp" />
     <ClCompile Include="ObjectDrawer.cpp" />
+    <ClCompile Include="ObjectLoader.cpp" />
     <ClCompile Include="Sound.cpp" />
     <ClCompile Include="Story.cpp" />
     <ClCompile Include="Text.cpp" />
@@ -196,6 +197,7 @@
     <ClInclude Include="GraphHandle.h" />
     <ClInclude Include="Object.h" />
     <ClInclude Include="ObjectDrawer.h" />
+    <ClInclude Include="ObjectLoader.h" />
     <ClInclude Include="Sound.h" />
     <ClInclude Include="Story.h" />
     <ClInclude Include="Text.h" />

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClCompile Include="ControllerRecorder.cpp">
       <Filter>ソース ファイル\api</Filter>
     </ClCompile>
+    <ClCompile Include="ObjectLoader.cpp">
+      <Filter>ソース ファイル\api</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">
@@ -180,6 +183,9 @@
       <Filter>ヘッダー ファイル\api</Filter>
     </ClInclude>
     <ClInclude Include="Brain.h">
+      <Filter>ヘッダー ファイル\api</Filter>
+    </ClInclude>
+    <ClInclude Include="ObjectLoader.h">
       <Filter>ヘッダー ファイル\api</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Event.cpp
+++ b/Event.cpp
@@ -3,6 +3,7 @@
 #include "Sound.h"
 #include "CsvReader.h"
 #include "CharacterController.h"
+#include "CharacterAction.h"
 #include "Character.h"
 #include "Text.h"
 #include "Brain.h"
@@ -38,6 +39,9 @@ Event::Event(int eventNum, World* world, SoundPlayer* soundPlayer) {
 	m_eventNum = eventNum;
 	m_nowElement = 0;
 
+	m_world_p = world;
+	m_soundPlayer = soundPlayer;
+
 	ostringstream oss;
 	oss << "data/event/event" << eventNum << ".csv";
 	CsvReader2 csvReader2(oss.str().c_str());
@@ -48,16 +52,22 @@ Event::Event(int eventNum, World* world, SoundPlayer* soundPlayer) {
 		createFire(mapParam2vector(fireData[i]), world, soundPlayer);
 	}
 
-	// イベントの内容
-	vector<map<string, string> > elementsData = csvReader2.getDomainData("ELEMENT:");
-	for (unsigned int i = 0; i < elementsData.size(); i++) {
-		createElement(mapParam2vector(elementsData[i]), world, soundPlayer);
-	}
-
 }
 
 bool Event::skillAble() {
+	if (m_eventElement.size() == 0) { return true; }
 	return m_eventElement[m_nowElement]->skillAble();
+}
+
+// Worldを設定しなおす
+void Event::setWorld(World* world) {
+	m_world_p = world;
+	for (unsigned int i = 0; i < m_eventFire.size(); i++) {
+		m_eventFire[i]->setWorld(m_world_p);
+	}
+	for (unsigned int i = 0; i < m_eventElement.size(); i++) {
+		m_eventElement[i]->setWorld(m_world_p);
+	}
 }
 
 // Fireの作成
@@ -80,8 +90,14 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	if (param0 == "ChangeBrain") {
 		element = new ChangeBrainEvent(world, param);
 	}
+	else if (param0 == "ChangeGroup") {
+		element = new ChangeGroupEvent(world, param);
+	}
 	else if (param0 == "DeadCharacter") {
 		element = new DeadCharacterEvent(world, param);
+	}
+	else if (param0 == "DeadGroup") {
+		element = new DeadGroupEvent(world, param);
 	}
 	else if (param0 == "Talk") {
 		element = new TalkEvent(world, soundPlayer, param);
@@ -104,6 +120,15 @@ bool Event::fire() {
 		if (!m_eventFire[i]->fire()) {
 			return false;
 		}
+	}
+	ostringstream oss;
+	oss << "data/event/event" << m_eventNum << ".csv";
+	CsvReader2 csvReader2(oss.str().c_str());
+	// イベントの内容
+	vector<map<string, string> > elementsData = csvReader2.getDomainData("ELEMENT:");
+	// 発火して初めてイベントを作る
+	for (unsigned int i = 0; i < elementsData.size(); i++) {
+		createElement(mapParam2vector(elementsData[i]), m_world_p, m_soundPlayer);
 	}
 	return true;
 }
@@ -142,6 +167,7 @@ EventFire::EventFire(World* world) {
 CharacterPointFire::CharacterPointFire(World* world, std::vector<std::string> param) :
 	EventFire(world)
 {
+	m_param = param;
 	m_character_p = m_world_p->getCharacterWithName(param[1]);
 	m_areaNum = stoi(param[2]);
 	m_x = stoi(param[3]);
@@ -159,6 +185,10 @@ bool CharacterPointFire::fire() {
 	}
 	return false;
 }
+void CharacterPointFire::setWorld(World* world) {
+	EventFire::setWorld(world);
+	m_character_p = m_world_p->getCharacterWithName(m_param[1]);
+}
 
 
 
@@ -171,25 +201,53 @@ EventElement::EventElement(World* world) {
 
 
 // キャラのBrainを変更する
-ChangeBrainEvent::ChangeBrainEvent(World* world, std::vector<string> param) :
+ChangeBrainEvent::ChangeBrainEvent(World* world, vector<string> param) :
 	EventElement(world)
 {
 	m_brainName = param[1];
 	m_controller_p = m_world_p->getControllerWithName(param[2]);
+	m_param = param;
 }
 EVENT_RESULT ChangeBrainEvent::play() {
 	// 対象のキャラのBrainを変更する
 	Brain* brain = NULL;
 	if (m_brainName == "NormalAI") {
 		brain = new NormalAI();
+		m_controller_p->setBrain(brain);
 	}
 	else if (m_brainName == "ParabolaAI") {
 		brain = new ParabolaAI();
-	}
-	if (brain != NULL) {
 		m_controller_p->setBrain(brain);
 	}
+	else if (m_brainName == "FollowNormalAI") {
+		brain = new FollowNormalAI();
+		m_controller_p->setBrain(brain);
+		Character* follow = m_world_p->getCharacterWithName(m_param[3]);
+		brain->searchFollow(follow);
+	}
 	return EVENT_RESULT::SUCCESS;
+}
+void ChangeBrainEvent::setWorld(World* world) {
+	EventElement::setWorld(world);
+	m_controller_p = m_world_p->getControllerWithName(m_param[2]);
+}
+
+// キャラのGroupIDを変更する
+ChangeGroupEvent::ChangeGroupEvent(World* world, std::vector<string> param) :
+	EventElement(world)
+{
+	m_param = param;
+	m_groupId = stoi(param[1]);
+	m_character_p = m_world_p->getCharacterWithName(param[2]);
+}
+EVENT_RESULT ChangeGroupEvent::play() {
+	// 対象のキャラのBrainを変更する
+	m_character_p->setGroupId(m_groupId);
+	return EVENT_RESULT::SUCCESS;
+}
+void ChangeGroupEvent::setWorld(World* world) {
+	EventElement::setWorld(world);
+	m_character_p = m_world_p->getCharacterWithName(m_param[2]);
 }
 
 // 特定のキャラのHPが0になるまで戦う
@@ -205,6 +263,27 @@ EVENT_RESULT DeadCharacterEvent::play() {
 		return EVENT_RESULT::SUCCESS;
 	}
 	return EVENT_RESULT::NOW;
+}
+void DeadCharacterEvent::setWorld(World* world) {
+	EventElement::setWorld(world);
+	m_character_p = m_world_p->getCharacterWithName(m_param[1]);
+}
+
+// 特定のグループが全滅するまで戦う
+DeadGroupEvent::DeadGroupEvent(World* world, std::vector<std::string> param) :
+	EventElement(world)
+{
+	m_groupId = stoi(param[1]);
+}
+EVENT_RESULT DeadGroupEvent::play() {
+	m_world_p->battle();
+	vector<const CharacterAction*> actions = m_world_p->getActions();
+	for (unsigned int i = 0; i < actions.size(); i++) {
+		if (actions[i]->getCharacter()->getGroupId() == m_groupId && actions[i]->getCharacter()->getHp() > 0) {
+			return EVENT_RESULT::NOW;
+		}
+	}
+	return EVENT_RESULT::SUCCESS;
 }
 
 

--- a/Event.h
+++ b/Event.h
@@ -32,6 +32,8 @@ public:
 	EventFire(World* world);
 
 	virtual bool fire() = 0;
+
+	virtual void setWorld(World* world) { m_world_p = world; }
 };
 
 
@@ -50,6 +52,8 @@ public:
 
 	// ハートのスキル発動が可能かどうか
 	virtual bool skillAble() = 0;
+
+	virtual void setWorld(World* world) { m_world_p = world; }
 };
 
 
@@ -59,6 +63,10 @@ public:
 */
 class Event {
 private:
+
+	// 発火後にこれを使ってElement生成
+	World* m_world_p;
+	SoundPlayer* m_soundPlayer;
 
 	// イベント番号
 	int m_eventNum;
@@ -85,6 +93,9 @@ public:
 	// 今ハートのスキル発動可能かどうか
 	bool skillAble();
 
+	// Worldを設定しなおす
+	void setWorld(World* world);
+
 private:
 	void createFire(std::vector<std::string> param, World* world, SoundPlayer* soundPlayer);
 	void createElement(std::vector<std::string> param, World* world, SoundPlayer* soundPlayer);
@@ -99,7 +110,10 @@ class CharacterPointFire :
 	public	EventFire
 {
 private:
-	// キャラの名前
+	// パラメータ
+	std::vector<std::string> m_param;
+
+	// キャラ
 	Character* m_character_p;
 
 	// エリア番号
@@ -115,6 +129,9 @@ public:
 	CharacterPointFire(World* world, std::vector<std::string> param);
 
 	bool fire();
+
+	// 世界を設定しなおす
+	void setWorld(World* world);
 };
 
 
@@ -126,6 +143,9 @@ class ChangeBrainEvent :
 	public EventElement
 {
 private:
+
+	// パラメータ
+	std::vector<std::string> m_param;
 
 	// Brainのクラス名
 	std::string m_brainName;
@@ -140,6 +160,35 @@ public:
 
 	// ハートのスキル発動が可能かどうか
 	bool skillAble() { return false; }
+
+	// 世界を設定しなおす
+	void setWorld(World* world);
+};
+
+// キャラのGroupIDを変える
+class ChangeGroupEvent :
+	public EventElement
+{
+private:
+
+	// パラメータ
+	std::vector<std::string> m_param;
+
+	int m_groupId;
+
+	// 対象のキャラ
+	Character* m_character_p;
+
+public:
+	ChangeGroupEvent(World* world, std::vector<std::string> param);
+
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
+	// 世界を設定しなおす
+	void setWorld(World* world);
 };
 
 // 特定のキャラのHPが0になるまで戦う
@@ -148,11 +197,35 @@ class DeadCharacterEvent :
 {
 private:
 
+	// パラメータ
+	std::vector<std::string> m_param;
+
 	// 対象のキャラ
 	Character* m_character_p;
 
 public:
 	DeadCharacterEvent(World* world, std::vector<std::string> param);
+
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return true; }
+
+	// 世界を設定しなおす
+	void setWorld(World* world);
+};
+
+// 特定のグループが全滅するまで戦う
+class DeadGroupEvent :
+	public EventElement
+{
+private:
+
+	// 対象のグループ
+	int m_groupId;
+
+public:
+	DeadGroupEvent(World* world, std::vector<std::string> param);
 
 	EVENT_RESULT play();
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -97,14 +97,22 @@ Game::~Game() {
 bool Game::play() {
 
 	// これ以上ストーリーを進ませない（テスト用）
-	if (m_gameData->getStoryNum() == 3) {
+	if (m_gameData->getStoryNum() == 5) {
+		m_world->battle();
+		m_soundPlayer->play();
 		return false;
 	}
 
 	// スキル発動 Fキーかつスキル未発動状態かつ発動可能なイベント中（もしくはイベント中でない）かつエリア移動中でない
-	if (controlF() == 1 && m_skill == NULL && m_story->skillAble() && m_world->getBrightValue() == 255 && m_world->getCharacterWithName("ハート")->getHp() > 0) {
-		m_world->setSkillFlag(true);
-		m_skill = new HeartSkill(3, m_world, m_soundPlayer);
+	if (m_gameData->getStoryNum() >= 4) { // ストーリーの最初は発動できない
+		if (controlF() == 1 && m_skill == NULL) { // Fキーで発動、ただしスキル身発動時
+			if (m_story->skillAble() && m_world->getBrightValue() == 255) { // 特定のイベント時やエリア移動中はダメ
+				if (m_world->getCharacterWithName("ハート")->getHp() > 0) {
+					m_world->setSkillFlag(true);
+					m_skill = new HeartSkill(3, m_world, m_soundPlayer);
+				}
+			}
+		}
 	}
 	
 	// スキル発動中

--- a/Game.cpp
+++ b/Game.cpp
@@ -27,8 +27,9 @@ CharacterData::CharacterData(const char* name) {
 GameData::GameData() {
 	m_saveFilePath = "data/save/savedata1.dat";
 
-	m_areaNum = 0;
-	m_storyNum = 0;
+	m_areaNum = 1;
+	m_storyNum = 1;
+	m_soundVolume = 50;
 
 	// 主要キャラを設定
 	m_characterData.push_back("ハート");
@@ -72,11 +73,10 @@ Game::Game() {
 
 	// サウンドプレイヤー
 	m_soundPlayer = new SoundPlayer();
-	m_soundPlayer->setVolume(50);
+	m_soundPlayer->setVolume(m_gameData->getSoundVolume());
 
 	// 世界
-	int startAreaNum = 0;
-	m_world = new World(-1, startAreaNum, m_soundPlayer);
+	m_world = new World(-1, m_gameData->getAreaNum(), m_soundPlayer);
 
 	// データを世界に反映
 	m_gameData->asignWorld(m_world);
@@ -97,7 +97,7 @@ Game::~Game() {
 bool Game::play() {
 
 	// これ以上ストーリーを進ませない（テスト用）
-	if (m_gameData->getStoryNum() == 1) {
+	if (m_gameData->getStoryNum() == 3) {
 		return false;
 	}
 
@@ -122,6 +122,7 @@ bool Game::play() {
 		m_gameData->setStoryNum(m_gameData->getStoryNum() + 1);
 		delete m_story;
 		m_story = new Story(m_gameData->getStoryNum(), m_world, m_soundPlayer);
+		m_world->addObject(m_story->getObjectLoader());
 	}
 
 	// 音
@@ -136,6 +137,8 @@ bool Game::play() {
 		m_world = new World(m_gameData->getAreaNum(), nextAreaNum, m_soundPlayer);
 		m_gameData->asignWorld(m_world);
 		m_gameData->setAreaNum(nextAreaNum);
+		m_world->addObject(m_story->getObjectLoader());
+		m_story->setWorld(m_world);
 		return true;
 	}
 	return false;

--- a/Game.h
+++ b/Game.h
@@ -41,6 +41,9 @@ private:
 	// 今やっているストーリー
 	int m_storyNum;
 
+	// 音量
+	int m_soundVolume;
+
 public:
 	GameData();
 	GameData(const char* saveFilePath);
@@ -48,10 +51,12 @@ public:
 	// ゲッタ
 	inline int getAreaNum() const { return m_areaNum; }
 	inline int getStoryNum() const { return m_storyNum; }
+	inline int getSoundVolume() const { return m_soundVolume; }
 
 	// セッタ
 	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }
 	inline void setStoryNum(int storyNum) { m_storyNum = storyNum; }
+	inline void setSoundVolume(int soundVolume) { m_soundVolume = soundVolume; }
 
 	// 自身のデータをWorldにデータ反映させる
 	void asignWorld(World* world);

--- a/ObjectLoader.cpp
+++ b/ObjectLoader.cpp
@@ -1,0 +1,58 @@
+#include "ObjectLoader.h"
+#include "Object.h"
+#include "CsvReader.h"
+
+
+using namespace std;
+
+
+// csvファイルから読み込んだOBJECT:ドメインからオブジェクトを作成
+ObjectLoader::ObjectLoader() {
+
+}
+
+void ObjectLoader::addObject(map<string, string> dataMap) {
+	int areaNum = -1;
+	if (dataMap.find("area") != dataMap.end()) {
+		areaNum = stoi(dataMap["area"]);
+	}
+	m_objects[areaNum].push_back(dataMap);
+}
+
+// 特定のエリアの追加オブジェクトのvectorを取得
+pair<vector<Object*>, vector<Object*> > ObjectLoader::getObjects(int areaNum) {
+
+	pair<vector<Object*>, vector<Object*> > res;
+	for (unsigned int i = 0; i < m_objects[areaNum].size(); i++) {
+		string name = m_objects[areaNum][i]["name"];
+		int x1 = stoi(m_objects[areaNum][i]["x1"]);
+		int y1 = stoi(m_objects[areaNum][i]["y1"]);
+		int x2 = stoi(m_objects[areaNum][i]["x2"]);
+		int y2 = stoi(m_objects[areaNum][i]["y2"]);
+		string graph = m_objects[areaNum][i]["graph"];
+		string color = m_objects[areaNum][i]["color"];
+		int hp = stoi(m_objects[areaNum][i]["hp"]);
+		string other = m_objects[areaNum][i]["other"];
+
+		int colorHandle = str2color(color);
+		Object* object = NULL;
+		if (name == "Box") {
+			object = new BoxObject(x1, y1, x2, y2, colorHandle, hp);
+		}
+		else if (name == "Triangle") {
+			bool leftDown = false;
+			if (other == "leftDown") { leftDown = true; }
+			object = new TriangleObject(x1, y1, x2, y2, colorHandle, leftDown, hp);
+		}
+		if (object != NULL) { res.first.push_back(object); }
+
+		// 扉オブジェクトは別に分ける
+		if (name == "Door") {
+			graph = "picture/stageMaterial/" + graph;
+			res.second.push_back(new DoorObject(x1, y1, x2, y2, graph.c_str(), stoi(other)));
+		}
+	}
+	
+	return res;
+
+}

--- a/ObjectLoader.h
+++ b/ObjectLoader.h
@@ -1,0 +1,29 @@
+#ifndef OBJECT_LOADER_H_INCLUDED
+#define OBJECT_LOADER_H_INCLUDED
+
+
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+
+
+class Object;
+
+
+class ObjectLoader {
+private:
+	std::map<int, std::vector<std::map<std::string, std::string> > > m_objects;
+
+public:
+	// csvファイルから読み込んだOBJECT:ドメインからオブジェクトを作成
+	ObjectLoader();
+
+	void addObject(std::map<std::string, std::string> dataMap);
+
+	// 特定のエリアの追加オブジェクトのvectorを取得
+	std::pair<std::vector<Object*>, std::vector<Object*> > getObjects(int areaNum = -1);
+};
+
+
+#endif

--- a/Story.cpp
+++ b/Story.cpp
@@ -92,3 +92,14 @@ bool Story::skillAble() {
 	}
 	return m_nowEvent->skillAble();
 }
+
+// ƒZƒbƒ^
+void Story::setWorld(World* world) {
+	m_world_p = world;
+	for (unsigned int i = 0; i < m_mustEvent.size(); i++) {
+		m_mustEvent[i]->setWorld(m_world_p);
+	}
+	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
+		m_mustEvent[i]->setWorld(m_world_p);
+	}
+}

--- a/Story.cpp
+++ b/Story.cpp
@@ -3,6 +3,7 @@
 #include "CsvReader.h"
 #include "World.h"
 #include "Sound.h"
+#include "ObjectLoader.h"
 #include <sstream>
 
 using namespace std;
@@ -26,6 +27,13 @@ Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer) {
 		if (mustFlag) { m_mustEvent.push_back(eventOne); }
 		else { m_subEvent.push_back(eventOne); }
 	}
+
+	// オブジェクトを用意
+	vector<map<string, string> > objectData = csvReader2.getDomainData("OBJECT:");
+	m_objectLoader = new ObjectLoader;
+	for (unsigned int i = 0; i < objectData.size(); i++) {
+		m_objectLoader->addObject(objectData[i]);
+	}
 }
 
 Story::~Story() {
@@ -35,6 +43,7 @@ Story::~Story() {
 	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
 		delete m_subEvent[i];
 	}
+	delete m_objectLoader;
 }
 
 bool Story::play() {

--- a/Story.h
+++ b/Story.h
@@ -45,7 +45,7 @@ public:
 	ObjectLoader* getObjectLoader() { return m_objectLoader; }
 
 	// ƒZƒbƒ^
-	void setWorld(World* world) { m_world_p = world; }
+	void setWorld(World* world);
 };
 
 

--- a/Story.h
+++ b/Story.h
@@ -6,6 +6,7 @@
 class Event;
 class World;
 class SoundPlayer;
+class ObjectLoader;
 
 // ストーリ－
 class Story {
@@ -26,6 +27,9 @@ private:
 	// クリア任意イベント
 	std::vector<Event*> m_subEvent;
 
+	// オブジェクトのデータ
+	ObjectLoader* m_objectLoader;
+
 public:
 	Story(int storyNum, World* world, SoundPlayer* soundPlayer);
 	~Story();
@@ -36,6 +40,12 @@ public:
 
 	// ハートのスキル発動が可能かどうか
 	bool skillAble();
+
+	// ゲッタ
+	ObjectLoader* getObjectLoader() { return m_objectLoader; }
+
+	// セッタ
+	void setWorld(World* world) { m_world_p = world; }
 };
 
 

--- a/Text.cpp
+++ b/Text.cpp
@@ -15,6 +15,7 @@ using namespace std;
 
 Conversation::Conversation(int textNum, World* world, SoundPlayer* soundPlayer) {
 
+	m_finishCnt = 0;
 	m_finishFlag = false;
 	m_world_p = world;
 	m_soundPlayer_p = soundPlayer;
@@ -64,13 +65,23 @@ int Conversation::getTextSize() const {
 
 bool Conversation::play() {
 
+	// 終了処理
+	if (m_finishCnt > 0) {
+		m_finishCnt++;
+		if (m_finishCnt == FINISH_COUNT) {
+			m_finishFlag = true;
+			return true;
+		}
+		return false;
+	}
+
 	// プレイヤーからのアクション（スペースキー入力）
 	if (controlSpace() == 1 || leftClick() == 1) {
 		if (m_textNow == m_text.size()) {
 			// 全ての会話が終わった
 			if (FileRead_eof(m_fp) != 0) {
-				m_finishFlag = true;
-				return true;
+				m_finishCnt++;
+				return false;
 			}
 			// 次のテキストへ移る
 			setNextText();

--- a/Text.h
+++ b/Text.h
@@ -15,6 +15,10 @@ class GraphHandles;
 class Conversation {
 private:
 
+	// 終了時、少しだけ待機時間
+	const int FINISH_COUNT = 30;
+	int m_finishCnt;
+
 	// イベント終了したか
 	bool m_finishFlag;
 
@@ -63,6 +67,7 @@ public:
 	int getTextSize() const;
 	GraphHandle* getGraph() const;
 	inline 	std::string getSpeakerName() const { return m_speakerName; }
+	inline int getFinishCnt() const { return m_finishCnt; }
 	inline bool getFinishFlag() const { return m_finishFlag; }
 	inline int getTextNow() const { return m_textNow; }
 	inline int getCnt() const { return m_cnt; }

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -45,6 +45,14 @@ void ConversationDrawer::draw() {
 	// 上端
 	static const int Y1 = 551;
 
+	// 会話終了時
+	int finishCnt = m_conversation->getFinishCnt() * 8;
+	if (finishCnt > 0) {
+		// フキダシ
+		DrawExtendGraph(EDGE, Y1 + finishCnt, GAME_WIDE - EDGE, GAME_HEIGHT - EDGE - finishCnt, m_frameHandle, TRUE);
+		return;
+	}
+
 	// フキダシ
 	DrawExtendGraph(EDGE, Y1, GAME_WIDE - EDGE, GAME_HEIGHT - EDGE, m_frameHandle, TRUE);
 

--- a/World.cpp
+++ b/World.cpp
@@ -12,6 +12,7 @@
 #include "Text.h"
 #include "Brain.h"
 #include "ControllerRecorder.h"
+#include "ObjectLoader.h"
 #include "DxLib.h"
 #include <algorithm>
 
@@ -178,6 +179,15 @@ World::World(const World* original) {
 	}
 	m_backGroundGraph = original->getBackGroundGraph();
 	m_backGroundColor = original->getBackGroundColor();
+}
+
+// ストーリーやイベントによる追加オブジェクト
+void World::addObject(ObjectLoader* objectLoader) {
+	pair<vector<Object*>, vector<Object*> > p = objectLoader->getObjects(m_areaNum);
+	// 壁や床
+	m_stageObjects.insert(m_stageObjects.end(), p.first.begin(), p.first.end());
+	// ドア
+	m_doorObjects.insert(m_doorObjects.end(), p.second.begin(), p.second.end());
 }
 
 std::vector<CharacterController*> World::getCharacterControllers() const {

--- a/World.h
+++ b/World.h
@@ -1,8 +1,10 @@
 #ifndef WORLD_H_INCLUDED
 #define WORLD_H_INCLUDE
 
+
 #include <vector>
 #include <string>
+
 
 class CharacterController;
 class CharacterAction;
@@ -14,6 +16,8 @@ class Animation;
 class SoundPlayer;
 class Conversation;
 class Brain;
+class ObjectLoader;
+
 
 class World {
 private:
@@ -96,6 +100,9 @@ public:
 	// セッタ
 	inline void setSkillFlag(bool skillFlag) { m_skillFlag = skillFlag; }
 	inline void setFocusId(int id) { m_focusId = id; }
+
+	// ストーリーやイベントによる追加オブジェクト
+	void addObject(ObjectLoader* objectLoader);
 
 	//デバッグ
 	void debug(int x, int y, int color) const;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
体験版の流れ（予定）：
- ゲームを起動すると、最初のステージに主人公と非敵対キャラが１人いる。
- キャラに話しかけて操作方法の説明を受ける。
- 扉から次のステージへ移動すると、敵がいる。
- 扉から次のステージへ移動すると、キャラがいる為話しかけると味方になってついてくる。
- 扉から次のステージへ移動すると、敵がいる。
- 扉から次のステージへ移動すると、キャラがいる為話しかけるとスキルの発動方法を教えてくれる。
- 扉から次のステージへ移動すると、敵がいる。
- おわり

# やったこと
ObjectLoaderクラスを作成した。このクラスを使ってエリア移動時のオブジェクトロードや、ストーリーによるオブジェクトの追加が行われる。

バグを修正。エリア移動時にWorldが作り直され、Storyオブジェクトが持つWorldが使えなくなることが原因で、エリア移動時にストーリーが進まなくなっていた。Story、Event、EventElement、EventFireクラスにsetWorld関数を追加して対処した。

テキストイベント終了時、直後に戦闘フェーズへ移行するため最後の操作が影響してしまう問題に対処。テキストイベント終了時は0.5秒間のインターバルを設ける。インターバル時間中はテキストのフキダシが閉じるアニメが流れる。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
概要の通り体験版を遊べる。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。
フィードバックもらいましょ

# 懸念点
遠くの敵は動かない。これがレコーダに保存されてしまうのがちょっと気になる。
