### PR TITLE
Api: ParabolaAIの改善と槍の描画バグ修正

### DIFF
--- a/Brain.h
+++ b/Brain.h
@@ -232,5 +232,14 @@ public:
 	bool needSearchFollow() const;
 };
 
+/*
+* ParabolaBullet‚ðŽg‚¤AI
+*/
+class FollowParabolaAI :
+	public FollowNormalAI
+{
+	void bulletTargetPoint(int& x, int& y);
+};
+
 
 #endif

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -311,16 +311,19 @@ void AreaReader::loadCharacter(std::map<std::string, std::string> dataMap) {
 
 	// BrainÇçÏê¨
 	Brain* brain = NULL;
-	if (brainName == "keyboard") {
+	if (brainName == "Keyboard") {
 		brain = new KeyboardBrain(m_camera_p);
 	}
-	else if (brainName == "normalAI") {
+	else if (brainName == "NormalAI") {
 		brain = new NormalAI();
 	}
-	else if (brainName == "followNormalAI") {
+	else if (brainName == "FollowNormalAI") {
 		brain = new FollowNormalAI();
 	}
-	else if (brainName == "freeze") {
+	else if (brainName == "FollowParabolaAI") {
+		brain = new FollowParabolaAI();
+	}
+	else if (brainName == "Freeze") {
 		brain = new Freeze();
 	}
 

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -38,7 +38,7 @@ void debugObjects(int x, int y, int color, std::vector<Object*> objects) {
 void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, anime=%d", m_characters.size(), m_characterControllers.size(), m_animations.size());
-	//m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+	debugObjects(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, m_attackObjects);
 }
 
 
@@ -163,6 +163,13 @@ void TriangleObject::debug(int x, int y, int color) const {
 void BulletObject::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**BulletObject**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "(gx,gy)=(%d,%d), groupId=%d", m_gx, m_gy, m_groupId);
+	debugObject(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+	// DrawOval(m_x1 + m_rx, m_y1 + m_ry, m_rx, m_ry, m_color, TRUE);
+}
+
+void ParabolaBullet::debug(int x, int y, int color) const {
+	DrawFormatString(x, y, color, "**ParabolaObject**");
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "(gx,gy)=(%d,%d), r=%f", m_gx, m_gy, m_handle->getAngle());
 	debugObject(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	// DrawOval(m_x1 + m_rx, m_y1 + m_ry, m_rx, m_ry, m_color, TRUE);
 }

--- a/Event.cpp
+++ b/Event.cpp
@@ -225,6 +225,12 @@ EVENT_RESULT ChangeBrainEvent::play() {
 		Character* follow = m_world_p->getCharacterWithName(m_param[3]);
 		brain->searchFollow(follow);
 	}
+	else if (m_brainName == "FollowParabolaAI") {
+		brain = new FollowParabolaAI();
+		m_controller_p->setBrain(brain);
+		Character* follow = m_world_p->getCharacterWithName(m_param[3]);
+		brain->searchFollow(follow);
+	}
 	return EVENT_RESULT::SUCCESS;
 }
 void ChangeBrainEvent::setWorld(World* world) {

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -29,6 +29,7 @@ public:
 	// ゲッタ
 	inline int getHandle() const { return m_handle; }
 	inline double getEx() const { return m_ex; }
+	inline double getAngle() const { return m_angle; }
 
 	// セッタ
 	inline void setEx(double ex) { m_ex = ex; }

--- a/Object.cpp
+++ b/Object.cpp
@@ -604,8 +604,14 @@ void ParabolaBullet::action() {
 	m_vy += G;
 	m_y1 += m_vy;
 	m_y2 += m_vy;
+}
+
+// ‰æ‘œƒnƒ“ƒhƒ‹‚ğ•Ô‚·
+GraphHandle* ParabolaBullet::getHandle() const { 
 	double r = atan2((double)m_vy, (double)m_vx);
+	if (m_vy == 0) { r = 0; }
 	m_handle->setAngle(r);
+	return m_handle;
 }
 
 

--- a/Object.cpp
+++ b/Object.cpp
@@ -604,7 +604,7 @@ void ParabolaBullet::action() {
 	m_vy += G;
 	m_y1 += m_vy;
 	m_y2 += m_vy;
-	double r = std::atan2((double)m_vy, (double)m_vx);
+	double r = atan2((double)m_vy, (double)m_vx);
 	m_handle->setAngle(r);
 }
 

--- a/Object.h
+++ b/Object.h
@@ -297,7 +297,7 @@ public:
 	void action();
 
 	// ‰æ‘œƒnƒ“ƒhƒ‹‚ğ•Ô‚·
-	GraphHandle* getHandle() const { return m_handle; }
+	GraphHandle* getHandle() const;
 
 	// ‰æ‘œ‚Ì‘å‚«‚³‚ğ©“®’²ß‚·‚é
 	bool extendGraph() const { return false; }

--- a/Object.h
+++ b/Object.h
@@ -281,12 +281,15 @@ class ParabolaBullet :
 {
 private:
 	GraphHandle* m_handle;
-	const int G = 2;
 public:
+	static const int G = 2;
+
 	ParabolaBullet(int x, int y, GraphHandle* handle, int gx, int gy, AttackInfo* attackInfo);
 	ParabolaBullet(int x, int y, GraphHandle* handle, int gx, int gy);
 
 	Object* createCopy();
+
+	void debug(int x, int y, int color) const;
 
 	inline void setGraphHandle(GraphHandle* handle) { m_handle = handle; }
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
ParabolaBulletで戦うAIの改善。
斜方投射の物理計算で射撃を賢く相手に当てる。
シエスタのヤリの描画が時々おかしいので直す。

# やったこと
[参考](http://www.sousakuba.com/Programming/algo_dandoukeisan2.html)
そのままやるとおそらく符号の取り扱いでバグが起きるため、Y座標に関しては上方向を正とみなして計算した後、最後に符号を逆転する。X座標に関してはいったん正の方向に攻撃するつもりで計算して、敵が左にいるなら最後に符号を逆転する。

描画のバグの原因は各Bulletが画像ハンドルを共有していたこと。すべての弾の向きが進行方向に関係なく統一されてしまう。getHandle時に向きを設定するように変更。画像ハンドルを共有すること自体は変更なし。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
シエスタが頼もしくなる（はず）。

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。実際にシエスタを操作してバグの修正も確認した。

# 懸念点
