### PR TITLE
Api: キャラの状態を保存する

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -334,7 +334,9 @@ bool NormalAI::needSearchTarget() const {
 	return false;
 }
 
-int  NormalAI::getTargetId() const { return m_target_p == NULL ? NULL : m_target_p->getId(); }
+int  NormalAI::getTargetId() const { return m_target_p == nullptr ? -1 : m_target_p->getId(); }
+
+const char*  NormalAI::getTargetName() const { return m_target_p == nullptr ? "" : m_target_p->getName().c_str(); }
 
 
 void ParabolaAI::bulletTargetPoint(int& x, int& y) {
@@ -449,10 +451,9 @@ Brain* FollowNormalAI::createCopy(std::vector<Character*> characters, const Came
 	return res;
 }
 
-int FollowNormalAI::getFollowId() const {
-	if (m_follow_p == nullptr) { return -1; }
-	return m_follow_p->getId();
-}
+int FollowNormalAI::getFollowId() const { return m_follow_p == nullptr ? -1 : m_follow_p->getId(); }
+
+const char* FollowNormalAI::getFollowName() const { return m_follow_p == nullptr ? "" : m_follow_p->getName().c_str(); }
 
 void FollowNormalAI::moveOrder(int& right, int& left, int& up, int& down) {
 	// åªç›ín

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -453,7 +453,10 @@ Brain* FollowNormalAI::createCopy(std::vector<Character*> characters, const Came
 
 int FollowNormalAI::getFollowId() const { return m_follow_p == nullptr ? -1 : m_follow_p->getId(); }
 
-const char* FollowNormalAI::getFollowName() const { return m_follow_p == nullptr ? "" : m_follow_p->getName().c_str(); }
+const char* FollowNormalAI::getFollowName() const { return m_follow_p == nullptr ? "ハート" : m_follow_p->getName().c_str(); }
+const Character* FollowNormalAI::getFollow() const {
+	return m_follow_p;
+}
 
 void FollowNormalAI::moveOrder(int& right, int& left, int& up, int& down) {
 	// 現在地

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -22,7 +22,7 @@ const char* FollowParabolaAI::BRAIN_NAME = "FollowParabolaAI";
 
 // ƒNƒ‰ƒX–¼‚©‚çBrain‚ğì¬‚·‚éŠÖ”
 Brain* createBrain(const string brainName, const Camera* camera_p) {
-	Brain* brain = NULL;
+	Brain* brain = nullptr;
 	if (brainName == KeyboardBrain::BRAIN_NAME) {
 		brain = new KeyboardBrain(camera_p);
 	}

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -11,6 +11,40 @@
 using namespace std;
 
 
+// クラス名
+const char* Brain::BRAIN_NAME = "Brain";
+const char* KeyboardBrain::BRAIN_NAME = "KeyboardBrain";
+const char* Freeze::BRAIN_NAME = "Freeze";
+const char* NormalAI::BRAIN_NAME = "NormalAI";
+const char* ParabolaAI::BRAIN_NAME = "ParabolaAI";
+const char* FollowNormalAI::BRAIN_NAME = "FollowNormalAI";
+const char* FollowParabolaAI::BRAIN_NAME = "FollowParabolaAI";
+
+// クラス名からBrainを作成する関数
+Brain* createBrain(const string brainName, const Camera* camera_p) {
+	Brain* brain = NULL;
+	if (brainName == KeyboardBrain::BRAIN_NAME) {
+		brain = new KeyboardBrain(camera_p);
+	}
+	else if (brainName == NormalAI::BRAIN_NAME) {
+		brain = new NormalAI();
+	}
+	else if (brainName == ParabolaAI::BRAIN_NAME) {
+		brain = new ParabolaAI();
+	}
+	else if (brainName == FollowNormalAI::BRAIN_NAME) {
+		brain = new FollowNormalAI();
+	}
+	else if (brainName == FollowParabolaAI::BRAIN_NAME) {
+		brain = new FollowParabolaAI();
+	}
+	else if (brainName == Freeze::BRAIN_NAME) {
+		brain = new Freeze();
+	}
+	return brain;
+}
+
+
 // Brainクラス
 Brain::Brain() {
 	m_characterAction_p = NULL;
@@ -327,7 +361,7 @@ void ParabolaAI::bulletTargetPoint(int& x, int& y) {
 			else {
 				x = (int)(m_characterAction_p->getCharacter()->getCenterX() - v * cos(r));
 			}
-			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r)) - GetRand(100);
+			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r)) + 50 - GetRand(100);
 		}
 		else {
 			// 射程外なら45度で投げる
@@ -367,7 +401,7 @@ void FollowParabolaAI::bulletTargetPoint(int& x, int& y) {
 			else {
 				x = (int)(m_characterAction_p->getCharacter()->getCenterX() - v * cos(r));
 			}
-			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r)) - GetRand(100);
+			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r)) + 50 - GetRand(100);
 		}
 		else {
 			// 射程外なら45度で投げる

--- a/Brain.h
+++ b/Brain.h
@@ -2,6 +2,7 @@
 #define BRAIN_H_INCLUDED
 
 #include <vector>
+#include <string>
 
 
 class Character;
@@ -16,6 +17,9 @@ protected:
 	const CharacterAction* m_characterAction_p;
 
 public:
+	static const char* BRAIN_NAME;
+	virtual const char* getBrainName() { return this->BRAIN_NAME; }
+
 	Brain();
 
 	virtual Brain* createCopy(std::vector<Character*> characters, const Camera* camera) = 0;
@@ -64,6 +68,10 @@ public:
 };
 
 
+// クラス名からBrainを作成する関数
+Brain* createBrain(const std::string brainName, const Camera* camera_p);
+
+
 /*
 * キーボードでキャラの操作を命令するクラス
 */
@@ -75,6 +83,8 @@ private:
 	const Camera* m_camera_p;
 
 public:
+	static const char* BRAIN_NAME;
+	const char* getBrainName() { return this->BRAIN_NAME; }
 	KeyboardBrain(const Camera* camera);
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera) { return new KeyboardBrain(camera); }
 	void debug(int x, int y, int color) const;
@@ -96,6 +106,8 @@ class Freeze :
 	public Brain
 {
 public:
+	static const char* BRAIN_NAME;
+	const char* getBrainName() { return this->BRAIN_NAME; }
 	Freeze() { }
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera) { return new Freeze(); }
 	void debug(int x, int y, int color) const { }
@@ -153,6 +165,8 @@ protected:
 	const int GIVE_UP_MOVE_CNT = 300;
 
 public:
+	static const char* BRAIN_NAME;
+	const char* getBrainName() { return this->BRAIN_NAME; }
 	NormalAI();
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
 	void setParam(NormalAI* brain);
@@ -197,6 +211,9 @@ protected:
 class ParabolaAI :
 	public NormalAI
 {
+public:
+	static const char* BRAIN_NAME;
+	const char* getBrainName() { return this->BRAIN_NAME; }
 	void bulletTargetPoint(int& x, int& y);
 };
 
@@ -212,6 +229,8 @@ private:
 	const int FOLLOW_X_ERROR = 500;
 
 public:
+	static const char* BRAIN_NAME;
+	const char* getBrainName() { return this->BRAIN_NAME; }
 	FollowNormalAI();
 
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
@@ -238,6 +257,9 @@ public:
 class FollowParabolaAI :
 	public FollowNormalAI
 {
+public:
+	static const char* BRAIN_NAME;
+	const char* getBrainName() { return this->BRAIN_NAME; }
 	void bulletTargetPoint(int& x, int& y);
 };
 

--- a/Brain.h
+++ b/Brain.h
@@ -18,7 +18,7 @@ protected:
 
 public:
 	static const char* BRAIN_NAME;
-	virtual const char* getBrainName() { return this->BRAIN_NAME; }
+	virtual const char* getBrainName() const { return this->BRAIN_NAME; }
 
 	Brain();
 
@@ -62,7 +62,11 @@ public:
 	// 追跡対象を変更する必要があるならtrueでアピールする(AIクラスでオーバライドする)。
 	virtual bool needSearchFollow() const { return false; }
 
+	// 攻撃対象や追跡対象の情報を取得
 	virtual int getTargetId() const { return -1; }
+	virtual const char* getTargetName() const { return ""; }
+	virtual int getFollowId() const { return -1; }
+	virtual const char* getFollowName() const { return ""; }
 
 	virtual void setTarget(Character* character) {  }
 };
@@ -84,7 +88,7 @@ private:
 
 public:
 	static const char* BRAIN_NAME;
-	const char* getBrainName() { return this->BRAIN_NAME; }
+	const char* getBrainName() const { return this->BRAIN_NAME; }
 	KeyboardBrain(const Camera* camera);
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera) { return new KeyboardBrain(camera); }
 	void debug(int x, int y, int color) const;
@@ -107,7 +111,7 @@ class Freeze :
 {
 public:
 	static const char* BRAIN_NAME;
-	const char* getBrainName() { return this->BRAIN_NAME; }
+	const char* getBrainName() const { return this->BRAIN_NAME; }
 	Freeze() { }
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera) { return new Freeze(); }
 	void debug(int x, int y, int color) const { }
@@ -166,7 +170,7 @@ protected:
 
 public:
 	static const char* BRAIN_NAME;
-	const char* getBrainName() { return this->BRAIN_NAME; }
+	const char* getBrainName() const { return this->BRAIN_NAME; }
 	NormalAI();
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
 	void setParam(NormalAI* brain);
@@ -197,7 +201,9 @@ public:
 	// 攻撃対象を変更する必要があるならtrueでアピールする。
 	bool needSearchTarget() const;
 
+	// 攻撃対象の情報を取得（オーバーライド）
 	int getTargetId() const;
+	const char* getTargetName() const;
 
 protected:
 	// スティック操作
@@ -213,7 +219,7 @@ class ParabolaAI :
 {
 public:
 	static const char* BRAIN_NAME;
-	const char* getBrainName() { return this->BRAIN_NAME; }
+	const char* getBrainName() const { return this->BRAIN_NAME; }
 	void bulletTargetPoint(int& x, int& y);
 };
 
@@ -230,15 +236,18 @@ private:
 
 public:
 	static const char* BRAIN_NAME;
-	const char* getBrainName() { return this->BRAIN_NAME; }
+	const char* getBrainName() const { return this->BRAIN_NAME; }
 	FollowNormalAI();
 
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
 
 	void debug(int x, int y, int color) const;
 
+	// 追跡対象の情報を取得（オーバーライド）
 	int getFollowId() const;
+	const char* getFollowName() const;
 
+	// 追跡対象をセット
 	void setFollow(Character* character) { m_follow_p = character; }
 
 	// 移動の目標地点設定
@@ -259,7 +268,7 @@ class FollowParabolaAI :
 {
 public:
 	static const char* BRAIN_NAME;
-	const char* getBrainName() { return this->BRAIN_NAME; }
+	const char* getBrainName() const { return this->BRAIN_NAME; }
 	void bulletTargetPoint(int& x, int& y);
 };
 

--- a/Brain.h
+++ b/Brain.h
@@ -67,6 +67,7 @@ public:
 	virtual const char* getTargetName() const { return ""; }
 	virtual int getFollowId() const { return -1; }
 	virtual const char* getFollowName() const { return ""; }
+	virtual const Character* getFollow() const { return nullptr; }
 
 	virtual void setTarget(Character* character) {  }
 };
@@ -227,7 +228,7 @@ public:
 class FollowNormalAI :
 	public NormalAI
 {
-private:
+protected:
 	// ついていくキャラ
 	const Character* m_follow_p;
 
@@ -246,6 +247,7 @@ public:
 	// 追跡対象の情報を取得（オーバーライド）
 	int getFollowId() const;
 	const char* getFollowName() const;
+	const Character* getFollow() const;
 
 	// 追跡対象をセット
 	void setFollow(Character* character) { m_follow_p = character; }

--- a/Character.cpp
+++ b/Character.cpp
@@ -11,6 +11,25 @@
 using namespace std;
 
 
+Character* createCharacter(const char* characterName, int hp, int x, int y, int groupId) {
+	Character* character = NULL;
+	string name = characterName;
+	if (name == "テスト") {
+		character = new Heart(name.c_str(), hp, x, y, groupId);
+	}
+	else if (name == "ハート") {
+		character = new Heart(name.c_str(), hp, x, y, groupId);
+	}
+	else if (name == "シエスタ") {
+		character = new Siesta(name.c_str(), hp, x, y, groupId);
+	}
+	else {
+		character = new Heart(name.c_str(), hp, x, y, groupId);
+	}
+	return character;
+}
+
+
 CharacterInfo::CharacterInfo() :
 	CharacterInfo("test")
 {

--- a/Character.h
+++ b/Character.h
@@ -301,6 +301,9 @@ public:
 };
 
 
+Character* createCharacter(const char* characterName, int hp = 100, int x = 0, int y = 0, int groupId = 0);
+
+
 /*
 * ハート（主人公）
 */

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -3,10 +3,23 @@
 #include "Sound.h"
 #include "Define.h"
 #include "DxLib.h"
-#include <vector>
 
 
 using namespace std;
+
+
+// クラス名
+const char* CharacterAction::ACTION_NAME = "CharacterAction";
+const char* StickAction::ACTION_NAME = "StickAction";
+
+// クラス名からCharacterActionを作成する関数
+CharacterAction* createAction(const string actionName, Character* character, SoundPlayer* soundPlayer_p) {
+	CharacterAction* action = nullptr;
+	if (actionName == StickAction::ACTION_NAME) {
+		action = new StickAction(character, soundPlayer_p);
+	}
+	return action;
+}
 
 
 /*

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -3,6 +3,7 @@
 
 
 #include <vector>
+#include <string>
 
 
 class Character;
@@ -94,6 +95,9 @@ protected:
 	int m_damageCnt;
 
 public:
+	static const char* ACTION_NAME;
+	virtual const char* getActionName() { return this->ACTION_NAME; }
+
 	CharacterAction();
 	CharacterAction(Character* character, SoundPlayer* soundPlayer_p);
 
@@ -196,6 +200,10 @@ protected:
 };
 
 
+// ƒNƒ‰ƒX–¼‚©‚çCharacterAction‚ðì¬‚·‚éŠÖ”
+CharacterAction* createAction(const std::string actionName, Character* character, SoundPlayer* soundPlayer_p);
+
+
 /*
 * ‹ó‚ð”ò‚Î‚È‚¢•’Ê‚Ì–_lŠÔ
 */
@@ -214,6 +222,9 @@ private:
 	void switchHandle();
 
 public:
+	static const char* ACTION_NAME;
+	const char* getActionName() { return this->ACTION_NAME; }
+
 	StickAction(Character* character, SoundPlayer* soundPlayer_p);
 
 	CharacterAction* createCopy(std::vector<Character*> characters);

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -96,7 +96,7 @@ protected:
 
 public:
 	static const char* ACTION_NAME;
-	virtual const char* getActionName() { return this->ACTION_NAME; }
+	virtual const char* getActionName() const { return this->ACTION_NAME; }
 
 	CharacterAction();
 	CharacterAction(Character* character, SoundPlayer* soundPlayer_p);
@@ -223,7 +223,7 @@ private:
 
 public:
 	static const char* ACTION_NAME;
-	const char* getActionName() { return this->ACTION_NAME; }
+	const char* getActionName() const { return this->ACTION_NAME; }
 
 	StickAction(Character* character, SoundPlayer* soundPlayer_p);
 

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -122,6 +122,7 @@ public:
 	bool getLeftLock() const { return m_leftLock; }
 	bool getUpLock() const { return m_upLock; }
 	bool getDownLock() const { return m_downLock; }
+	const SoundPlayer* getSoundPlayer() const { return m_soundPlayer_p; }
 
 	// ƒZƒbƒ^
 	void setState(CHARACTER_STATE state);

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -10,6 +10,23 @@
 #include <algorithm>
 
 
+using namespace std;
+
+
+// クラス名
+const char* CharacterController::CONTROLLER_NAME = "CharacterController";
+const char* NormalController::CONTROLLER_NAME = "NormalController";
+
+// クラス名からコントローラを作成する関数
+CharacterController* createController(const string controllerName, Brain* brain, CharacterAction* action) {
+	CharacterController* controller = nullptr;
+	if (controllerName == NormalController::CONTROLLER_NAME) {
+		controller = new NormalController(brain, action);
+	}
+	return controller;
+}
+
+
 /*
 * コントローラ
 */

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -40,7 +40,7 @@ protected:
 
 public:
 	static const char* CONTROLLER_NAME;
-	virtual const char* getControllerName() { return this->CONTROLLER_NAME; }
+	virtual const char* getControllerName() const { return this->CONTROLLER_NAME; }
 
 	CharacterController();
 	CharacterController(Brain* brain, CharacterAction* characterAction);
@@ -136,7 +136,7 @@ private:
 	const int JUMP_KEY_LONG = 10;
 public:
 	static const char* CONTROLLER_NAME;
-	const char* getControllerName() { return this->CONTROLLER_NAME; }
+	const char* getControllerName() const { return this->CONTROLLER_NAME; }
 
 	NormalController(Brain* brain, CharacterAction* characterAction);
 

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -3,6 +3,7 @@
 
 
 #include <vector>
+#include <string>
 
 
 class Character;
@@ -38,6 +39,9 @@ protected:
 	ControllerRecorder* m_damageRecorder;
 
 public:
+	static const char* CONTROLLER_NAME;
+	virtual const char* getControllerName() { return this->CONTROLLER_NAME; }
+
 	CharacterController();
 	CharacterController(Brain* brain, CharacterAction* characterAction);
 	~CharacterController();
@@ -117,6 +121,10 @@ public:
 	virtual void damage(int vx, int vy, int damageValue) = 0;
 };
 
+
+CharacterController* createController(const std::string controllerName, Brain* brain, CharacterAction* action);
+
+
 /*
 * 普通のコントローラ
 */
@@ -127,6 +135,9 @@ private:
 	// ジャンプキーを長押しする最大時間
 	const int JUMP_KEY_LONG = 10;
 public:
+	static const char* CONTROLLER_NAME;
+	const char* getControllerName() { return this->CONTROLLER_NAME; }
+
 	NormalController(Brain* brain, CharacterAction* characterAction);
 
 	CharacterController* createCopy(std::vector<Character*> characters, const Camera* camera);

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -273,19 +273,7 @@ void AreaReader::loadCharacter(std::map<std::string, std::string> dataMap) {
 	bool playerFlag = (bool)stoi(dataMap["player"]);
 
 	// キャラを作成
-	Character* character = NULL;
-	if (name == "テスト") {
-		character = new Heart(name.c_str(), 100, x, y, groupId);
-	}
-	else if (name == "ハート") {
-		character = new Heart(name.c_str(), 100, x, y, groupId);
-	}
-	else if (name == "シエスタ") {
-		character = new Siesta(name.c_str(), 100, x, y, groupId);
-	}
-	else {
-		character = new Heart(name.c_str(), 100, x, y, groupId);
-	}
+	Character* character = createCharacter(name.c_str(), 100, x, y, groupId);
 
 	// カメラをセット
 	if (cameraFlag && m_camera_p == NULL && character != NULL) {

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -310,11 +310,9 @@ void AreaReader::loadCharacter(std::map<std::string, std::string> dataMap) {
 	if (brain == NULL) { return; }
 
 	// コントローラを作成
-	CharacterController* controller = NULL;
-	if (controllerName == "normal") {
-		controller = new NormalController(brain, action);
-	}
+	CharacterController* controller = createController(controllerName, brain, action);
 
+	// 完成したキャラとコントローラを保存
 	if (character != NULL && controller != NULL) { 
 		m_characters.push_back(character);
 		m_characterControllers.push_back(controller);

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -310,22 +310,7 @@ void AreaReader::loadCharacter(std::map<std::string, std::string> dataMap) {
 	if (action == NULL) { return; }
 
 	// BrainÇçÏê¨
-	Brain* brain = NULL;
-	if (brainName == "Keyboard") {
-		brain = new KeyboardBrain(m_camera_p);
-	}
-	else if (brainName == "NormalAI") {
-		brain = new NormalAI();
-	}
-	else if (brainName == "FollowNormalAI") {
-		brain = new FollowNormalAI();
-	}
-	else if (brainName == "FollowParabolaAI") {
-		brain = new FollowParabolaAI();
-	}
-	else if (brainName == "Freeze") {
-		brain = new Freeze();
-	}
+	Brain* brain = createBrain(brainName, m_camera_p);
 
 	if (brain == NULL) { return; }
 

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -301,17 +301,12 @@ void AreaReader::loadCharacter(std::map<std::string, std::string> dataMap) {
 	}
 
 	// アクションを作成
-	CharacterAction* action = NULL;
 	SoundPlayer* soundPlayer = sound ? m_soundPlayer_p : NULL;
-	if (actionName == "stick") {
-		action = new StickAction(character, soundPlayer);
-	}
-
+	CharacterAction* action = createAction(actionName, character, soundPlayer);
 	if (action == NULL) { return; }
 
 	// Brainを作成
 	Brain* brain = createBrain(brainName, m_camera_p);
-
 	if (brain == NULL) { return; }
 
 	// コントローラを作成

--- a/Event.cpp
+++ b/Event.cpp
@@ -209,28 +209,21 @@ ChangeBrainEvent::ChangeBrainEvent(World* world, vector<string> param) :
 	m_param = param;
 }
 EVENT_RESULT ChangeBrainEvent::play() {
+
 	// 対象のキャラのBrainを変更する
-	Brain* brain = NULL;
-	if (m_brainName == "NormalAI") {
-		brain = new NormalAI();
-		m_controller_p->setBrain(brain);
-	}
-	else if (m_brainName == "ParabolaAI") {
-		brain = new ParabolaAI();
-		m_controller_p->setBrain(brain);
-	}
-	else if (m_brainName == "FollowNormalAI") {
-		brain = new FollowNormalAI();
-		m_controller_p->setBrain(brain);
+	Brain* brain = createBrain(m_brainName, m_world_p->getCamera());
+	m_controller_p->setBrain(brain);
+
+	// 追跡対象が必要なBrainは追跡対象を設定
+	if (brain->getBrainName() == FollowNormalAI::BRAIN_NAME) {
 		Character* follow = m_world_p->getCharacterWithName(m_param[3]);
 		brain->searchFollow(follow);
 	}
-	else if (m_brainName == "FollowParabolaAI") {
-		brain = new FollowParabolaAI();
-		m_controller_p->setBrain(brain);
+	else if (brain->getBrainName() == FollowParabolaAI::BRAIN_NAME) {
 		Character* follow = m_world_p->getCharacterWithName(m_param[3]);
 		brain->searchFollow(follow);
 	}
+
 	return EVENT_RESULT::SUCCESS;
 }
 void ChangeBrainEvent::setWorld(World* world) {

--- a/Event.cpp
+++ b/Event.cpp
@@ -257,6 +257,9 @@ DeadCharacterEvent::DeadCharacterEvent(World* world, std::vector<std::string> pa
 }
 EVENT_RESULT DeadCharacterEvent::play() {
 	m_world_p->battle();
+	if (m_character_p == nullptr) {
+		return EVENT_RESULT::NOW;
+	}
 	// 対象のキャラのHPをチェックする
 	if (m_character_p->getHp() == 0) {
 		return EVENT_RESULT::SUCCESS;
@@ -273,9 +276,13 @@ DeadGroupEvent::DeadGroupEvent(World* world, std::vector<std::string> param) :
 	EventElement(world)
 {
 	m_groupId = stoi(param[1]);
+	m_areaNum = stoi(param[2]);
 }
 EVENT_RESULT DeadGroupEvent::play() {
 	m_world_p->battle();
+	if (m_world_p->getAreaNum() != m_areaNum || m_world_p->getBrightValue() < 255) {
+		return EVENT_RESULT::NOW;
+	}
 	vector<const CharacterAction*> actions = m_world_p->getActions();
 	for (unsigned int i = 0; i < actions.size(); i++) {
 		if (actions[i]->getCharacter()->getGroupId() == m_groupId && actions[i]->getCharacter()->getHp() > 0) {

--- a/Event.h
+++ b/Event.h
@@ -224,6 +224,9 @@ private:
 	// 対象のグループ
 	int m_groupId;
 
+	// エリア番号
+	int m_areaNum;
+
 public:
 	DeadGroupEvent(World* world, std::vector<std::string> param);
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -17,6 +17,7 @@
 CharacterData::CharacterData(const char* name) {
 	m_name = name;
 	m_hp = -1;
+	// id=-1はデータなしを意味する
 	m_id = -1;
 	m_groupId = -1;
 	m_areaNum = -1;
@@ -25,6 +26,7 @@ CharacterData::CharacterData(const char* name) {
 	m_targetName = "";
 	m_followName = "";
 	m_actionName = "";
+	m_soundFlag = false;
 	m_controllerName = "";
 }
 
@@ -38,10 +40,11 @@ GameData::GameData() {
 
 	m_areaNum = 1;
 	m_storyNum = 1;
-	m_soundVolume = 50;
+	m_soundVolume = 10;
 
 	// 主要キャラを設定
 	m_characterData.push_back("ハート");
+	m_characterData.push_back("シエスタ");
 
 }
 
@@ -66,7 +69,7 @@ void GameData::asignWorld(World* world) {
 void GameData::asignedWorld(World* world) {
 	size_t size = m_characterData.size();
 	for (unsigned int i = 0; i < size; i++) {
-		world->asignCharacterData(m_characterData[i].name(), m_characterData[i]);
+		world->asignCharacterData(m_characterData[i].name(), m_characterData[i], m_areaNum);
 	}
 }
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -21,10 +21,9 @@ CharacterData::CharacterData(const char* name) {
 	m_groupId = -1;
 	m_areaNum = -1;
 	m_x, m_y = -1;
-	m_brainName = Brain::BRAIN_NAME;
-	m_brainName = KeyboardBrain::BRAIN_NAME;
-	m_target_name = "";
-	m_follow_name = "";
+	m_brainName = "";
+	m_targetName = "";
+	m_followName = "";
 	m_actionName = "";
 	m_controllerName = "";
 }
@@ -59,9 +58,7 @@ GameData::GameData(const char* saveFilePath):
 void GameData::asignWorld(World* world) {
 	size_t size = m_characterData.size();
 	for (unsigned int i = 0; i < size; i++) {
-		int hp = m_characterData[i].hp();
-		if (hp == -1) { continue; }
-		world->asignedCharacterData(m_characterData[i].name(), hp);
+		world->asignedCharacterData(m_characterData[i].name(), m_characterData[i]);
 	}
 }
 
@@ -69,9 +66,7 @@ void GameData::asignWorld(World* world) {
 void GameData::asignedWorld(World* world) {
 	size_t size = m_characterData.size();
 	for (unsigned int i = 0; i < size; i++) {
-		int hp = 0;
-		world->asignCharacterData(m_characterData[i].name(), hp);
-		m_characterData[i].setHp(hp);
+		world->asignCharacterData(m_characterData[i].name(), m_characterData[i]);
 	}
 }
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -17,6 +17,16 @@
 CharacterData::CharacterData(const char* name) {
 	m_name = name;
 	m_hp = -1;
+	m_id = -1;
+	m_groupId = -1;
+	m_areaNum = -1;
+	m_x, m_y = -1;
+	m_brainName = Brain::BRAIN_NAME;
+	m_brainName = KeyboardBrain::BRAIN_NAME;
+	m_target_name = "";
+	m_follow_name = "";
+	m_actionName = "";
+	m_controllerName = "";
 }
 
 
@@ -45,6 +55,7 @@ GameData::GameData(const char* saveFilePath):
 
 }
 
+// 自身のデータをWorldにデータ反映させる
 void GameData::asignWorld(World* world) {
 	size_t size = m_characterData.size();
 	for (unsigned int i = 0; i < size; i++) {
@@ -54,6 +65,7 @@ void GameData::asignWorld(World* world) {
 	}
 }
 
+// Worldのデータを自身に反映させる
 void GameData::asignedWorld(World* world) {
 	size_t size = m_characterData.size();
 	for (unsigned int i = 0; i < size; i++) {

--- a/Game.h
+++ b/Game.h
@@ -36,10 +36,10 @@ private:
 	std::string m_brainName;
 
 	// 攻撃対象の名前 いないなら空文字
-	std::string m_target_name;
+	std::string m_targetName;
 
 	// 追跡対象の名前 いないなら空文字
-	std::string m_follow_name;
+	std::string m_followName;
 
 	// CharacterActionのクラス名
 	std::string m_actionName;
@@ -53,9 +53,29 @@ public:
 	// ゲッタ
 	inline const char* name() const { return m_name; }
 	inline int hp() const { return m_hp; }
+	inline int id() const { return m_id; }
+	inline int groupId() const { return m_groupId; }
+	inline int areaNum() const { return m_areaNum; }
+	inline int x() const { return m_x; }
+	inline int y() const { return m_y; }
+	inline std::string brainName() const { return m_brainName; }
+	inline std::string targetName() const { return m_targetName; }
+	inline std::string followName() const { return m_followName; }
+	inline std::string actionName() const { return m_actionName; }
+	inline std::string controllerName() const { return m_controllerName; }
 
 	// セッタ
 	inline void setHp(int hp) { m_hp = hp; }
+	inline void setId(int id) { m_id = id; }
+	inline void setGroupId(int groupId) { m_groupId = groupId; }
+	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }
+	inline void setX(int x) { m_x = x; }
+	inline void setY(int y) { m_y = y; }
+	inline void setBrainName(const char* brainName) { m_brainName = brainName; }
+	inline void setTargetName(const char* targetName) { m_targetName = targetName; }
+	inline void setFollowName(const char* followName) { m_followName = followName; }
+	inline void setActionName(const char* actionName) { m_actionName = actionName; }
+	inline void setControllerName(const char* controllerName) { m_controllerName = controllerName; }
 };
 
 

--- a/Game.h
+++ b/Game.h
@@ -44,6 +44,9 @@ private:
 	// CharacterActionのクラス名
 	std::string m_actionName;
 
+	// 効果音ありか
+	bool m_soundFlag;
+
 	// CharacterControllerのクラス名
 	std::string m_controllerName;
 
@@ -62,6 +65,7 @@ public:
 	inline std::string targetName() const { return m_targetName; }
 	inline std::string followName() const { return m_followName; }
 	inline std::string actionName() const { return m_actionName; }
+	inline bool soundFlag() const { return m_soundFlag; }
 	inline std::string controllerName() const { return m_controllerName; }
 
 	// セッタ
@@ -75,6 +79,7 @@ public:
 	inline void setTargetName(const char* targetName) { m_targetName = targetName; }
 	inline void setFollowName(const char* followName) { m_followName = followName; }
 	inline void setActionName(const char* actionName) { m_actionName = actionName; }
+	inline void setSoundFlag(bool soundFlag) { m_soundFlag = soundFlag; }
 	inline void setControllerName(const char* controllerName) { m_controllerName = controllerName; }
 };
 

--- a/Game.h
+++ b/Game.h
@@ -2,6 +2,7 @@
 #define GAME_H_INCLUDED
 
 #include <vector>
+#include <string>
 
 class SoundPlayer;
 class World;
@@ -12,8 +13,40 @@ class Character;
 // キャラのセーブデータ
 class CharacterData {
 private:
+
+	// 名前
 	const char* m_name;
+
+	// HP
 	int m_hp;
+
+	// ID
+	int m_id;
+
+	// GroupID
+	int m_groupId;
+
+	// どこのエリアにいるか
+	int m_areaNum;
+
+	// 座標
+	int m_x, m_y;
+
+	// Brainのクラス名
+	std::string m_brainName;
+
+	// 攻撃対象の名前 いないなら空文字
+	std::string m_target_name;
+
+	// 追跡対象の名前 いないなら空文字
+	std::string m_follow_name;
+
+	// CharacterActionのクラス名
+	std::string m_actionName;
+
+	// CharacterControllerのクラス名
+	std::string m_controllerName;
+
 public:
 	CharacterData(const char* name);
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -6,7 +6,7 @@
 
 
 // フルスクリーンならFALSE
-static int WINDOW = FALSE;
+static int WINDOW = TRUE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = FALSE;
 

--- a/Story.cpp
+++ b/Story.cpp
@@ -96,10 +96,13 @@ bool Story::skillAble() {
 // ƒZƒbƒ^
 void Story::setWorld(World* world) {
 	m_world_p = world;
+	if (m_nowEvent != NULL) {
+		m_nowEvent->setWorld(m_world_p);
+	}
 	for (unsigned int i = 0; i < m_mustEvent.size(); i++) {
 		m_mustEvent[i]->setWorld(m_world_p);
 	}
 	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
-		m_mustEvent[i]->setWorld(m_world_p);
+		m_subEvent[i]->setWorld(m_world_p);
 	}
 }

--- a/World.cpp
+++ b/World.cpp
@@ -13,6 +13,7 @@
 #include "Brain.h"
 #include "ControllerRecorder.h"
 #include "ObjectLoader.h"
+#include "Game.h"
 #include "DxLib.h"
 #include <algorithm>
 
@@ -276,23 +277,50 @@ void World::eraseRecorder() {
 }
 
 
-// キャラの状態を変更する
-void World::asignedCharacterData(const char* name, int hp) {
+// キャラの状態を変更する いないなら作成する
+void World::asignedCharacterData(const char* name, CharacterData& data) {
+	if (data.areaNum() != m_areaNum) { return; }
 	size_t size = m_characters.size();
+	// キャラの設定
 	for (unsigned i = 0; i < size; i++) {
 		if (name == m_characters[i]->getName()) {
-			m_characters[i]->setHp(hp);
+			m_characters[i]->setHp(data.hp());
+			//m_characters[i]->setId(data.id());
+			m_characters[i]->setGroupId(data.groupId());
+			//m_characters[i]->setX(data.x());
+			//m_characters[i]->setY(data.y());
+		}
+	}
+	// コントローラ、アクション、Brainの設定
+	size = m_characterControllers.size();
+	for (unsigned int i = 0; i < size; i++) {
+		if (name == m_characterControllers[i]->getAction()->getCharacter()->getName()) {
+			// いろいろ設定
+			//if (m_characterControllers[i]->getControllerName() != data.controllerName()) {
+			//	delete m_characterControllers[i];
+			//}
 		}
 	}
 }
 
 // キャラの状態を教える
-void World::asignCharacterData(const char* name, int& hp) {
-	size_t size = m_characters.size();
+void World::asignCharacterData(const char* name, CharacterData& data) {
+	size_t size = m_characterControllers.size();
 	for (unsigned i = 0; i < size; i++) {
-		if (name == m_characters[i]->getName()) {
-			hp = m_characters[i]->getHp();
-			return;
+		if (name == m_characterControllers[i]->getAction()->getCharacter()->getName()) {
+			const Character* c = m_characterControllers[i]->getAction()->getCharacter();
+			data.setHp(c->getHp());
+			data.setId(c->getId());
+			data.setGroupId(c->getGroupId());
+			data.setAreaNum(m_areaNum);
+			data.setX(c->getX());
+			data.setY(c->getY());
+			data.setBrainName(m_characterControllers[i]->getBrain()->getBrainName());
+			data.setTargetName(m_characterControllers[i]->getBrain()->getTargetName());
+			data.setFollowName(m_characterControllers[i]->getBrain()->getFollowName());
+			data.setActionName(m_characterControllers[i]->getAction()->getActionName());
+			data.setControllerName(m_characterControllers[i]->getControllerName());
+			break;
 		}
 	}
 }

--- a/World.h
+++ b/World.h
@@ -17,6 +17,7 @@ class SoundPlayer;
 class Conversation;
 class Brain;
 class ObjectLoader;
+class CharacterData;
 
 
 class World {
@@ -113,11 +114,11 @@ public:
 	// キャラに会話させる
 	void talk();
 
-	// キャラの状態を変更
-	void asignedCharacterData(const char* name, int hp);
+	// キャラの状態を変更する いないなら作成する
+	void asignedCharacterData(const char* name, CharacterData& data);
 
 	// キャラの状態を教える
-	void asignCharacterData(const char* name, int& hp);
+	void asignCharacterData(const char* name, CharacterData& data);
 
 	/*
 	* イベント用

--- a/World.h
+++ b/World.h
@@ -118,7 +118,7 @@ public:
 	void asignedCharacterData(const char* name, CharacterData& data);
 
 	// キャラの状態を教える
-	void asignCharacterData(const char* name, CharacterData& data);
+	void asignCharacterData(const char* name, CharacterData& data, int fromAreaNum);
 
 	/*
 	* イベント用
@@ -164,6 +164,10 @@ private:
 
 	// 攻撃<->攻撃の当たり判定
 	void atariAttackAndAttack();
+
+	// キャラのセーブデータを自身に反映させる
+	void asignedCharacter(Character* character, CharacterData& data);
+	CharacterController* createControllerWithData(const Character* character, CharacterData& data);
 };
 
 #endif


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
現状、イベントでキャラが仲間になってもエリアを移動すると初期化されてしまう。
GameDataクラスにBrainやAction、Controllerなど、エリア移動やゲームロード時に必要となるキャラの情報を追加する。

# やったこと
Brainとその派生クラス全てにstatic const char* BRAIN_NAMEを追加。クラス名::BRAIN_NAMEやgetBrainName()でアクセス可能。
それに伴い、CSVReaderなどでクラス名からBrainを作成するコードが簡単になった。csvファイルに記述するBrainの名前はクラス名と一致させるルールで。
CharacterActionとCharacterControllerもBrainと同様の変更。

GameDataにBrain、Action、Controlelrのクラス名を保存するように。

WorldクラスのasignCharacterData、asignedCharacterData関数を修正し、キャラの状態をWorldに適用できるようにした。

エリアを移動すると、元居たエリアの重要キャラは設定が保存され、そのエリアに戻ると再生される。CharacterDataオブジェクトのareaNumフィールドさえ書き換えれば、他のエリアに移動させることもできる。
CharacterDataのareaNumが今いるエリアと一致したなら、Worldに現時点で存在しなくても新たにキャラが作られる。既に存在するなら、設定の上書きのみ行う。

また、GroupDeadElementの問題を見つけたため修正した。具体的には、異なるエリアの敵でも指定されたgroupIdの敵を全滅させるとイベントクリアになってしまうため、エリアまで決められるようにした。

# やらないこと
これらの対処はしない
- エリア移動の際、（ストーリーで追加されたドアで移動すると？）主人公のスタート地点がおかしくなる。
- シエスタなど、主人公の仲間はエリア移動の際座標が主人公の位置にセットされるようにしたい。

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
たまに実行時エラー起きる？Worldオブジェクトが壊れることがある。（フィールドが非常に大きな値になっているのがデバッグモードで確認できた。）エリアの移動時に数回起きたが、再現性がない。
#55 

キャラの扱いがかなり複雑になってきた。story、event、GameDataどれをいじってもWorldに変更を加えられる。ルールを決めるなど、工夫が必要