### PR TITLE
Api: ドアの状態を保存する

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -348,22 +348,23 @@ void ParabolaAI::bulletTargetPoint(int& x, int& y) {
 		const int G = -ParabolaBullet::G;
 		int dx = m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX();
 		int gx = abs(dx);
-		int dy = -(m_target_p->getCenterY() - m_characterAction_p->getCharacter()->getCenterY());
+		int gy = -(m_target_p->getCenterY() - m_characterAction_p->getCharacter()->getCenterY());
 		int v = m_characterAction_p->getCharacter()->getAttackInfo()->bulletSpeed();
 		double A = (G * gx * gx) / (2 * v * v);
 		double a = gx / A;
-		double b = 1 - (dy / A);
-		double route = a * a / 4 - b;
-		if (route >= 0) {
-			double t = -sqrt(route) - (a / 2);
-			double r = atan(t);
+		double b = 1 - (gy / A);
+		double routeInside = a * a / 4 - b;
+		if (routeInside >= 0) {
+			double route = sqrt(routeInside);
+			if (GetRand(99) < 50) { route *= -1; }
+			double r = atan(route - (a / 2));
 			if (dx > 0) {
 				x = (int)(m_characterAction_p->getCharacter()->getCenterX() + v * cos(r));
 			}
 			else {
 				x = (int)(m_characterAction_p->getCharacter()->getCenterX() - v * cos(r));
 			}
-			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r)) + 50 - GetRand(100);
+			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r));
 		}
 		else {
 			// 射程外なら45度で投げる
@@ -374,7 +375,7 @@ void ParabolaAI::bulletTargetPoint(int& x, int& y) {
 			else {
 				x = (int)(m_characterAction_p->getCharacter()->getCenterX() - v * cos(r));
 			}
-			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r)) + 50 - GetRand(100);
+			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r));
 		}
 	}
 }
@@ -388,22 +389,23 @@ void FollowParabolaAI::bulletTargetPoint(int& x, int& y) {
 		const int G = -ParabolaBullet::G;
 		int dx = m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX();
 		int gx = abs(dx);
-		int dy = -(m_target_p->getCenterY() - m_characterAction_p->getCharacter()->getCenterY());
+		int gy = -(m_target_p->getCenterY() - m_characterAction_p->getCharacter()->getCenterY());
 		int v = m_characterAction_p->getCharacter()->getAttackInfo()->bulletSpeed();
 		double A = (G * gx * gx) / (2 * v * v);
 		double a = gx / A;
-		double b = 1 - (dy / A);
-		double route = a * a / 4 - b;
-		if (route >= 0) {
-			double t = -sqrt(route) - (a / 2);
-			double r = atan(t);
+		double b = 1 - (gy / A);
+		double routeInside = a * a / 4 - b;
+		if (routeInside >= 0) {
+			double route = sqrt(routeInside);
+			if (GetRand(99) < 50) { route *= -1; }
+			double r = atan(route - (a / 2));
 			if (dx > 0) {
 				x = (int)(m_characterAction_p->getCharacter()->getCenterX() + v * cos(r));
 			}
 			else {
 				x = (int)(m_characterAction_p->getCharacter()->getCenterX() - v * cos(r));
 			}
-			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r)) + 50 - GetRand(100);
+			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r));
 		}
 		else {
 			// 射程外なら45度で投げる
@@ -414,7 +416,7 @@ void FollowParabolaAI::bulletTargetPoint(int& x, int& y) {
 			else {
 				x = (int)(m_characterAction_p->getCharacter()->getCenterX() - v * cos(r));
 			}
-			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r)) + 50 - GetRand(100);
+			y = (int)(m_characterAction_p->getCharacter()->getCenterY() - v * sin(r));
 		}
 	}
 }

--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -247,7 +247,7 @@ AreaReader::AreaReader(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer)
 		loadBackGround(data[i]);
 	}
 
-	setPlayer();
+	// 追跡対象をプレイヤーにする
 	setFollow();
 }
 
@@ -323,21 +323,6 @@ void AreaReader::loadBackGround(std::map<std::string, std::string> dataMap) {
 	}
 	// 背景色
 	m_backGroundColor = str2color(color);
-}
-
-// プレイヤーの初期位置を、前いたエリアを元に設定
-void AreaReader::setPlayer() {
-	for (int i = 0; i < m_characters.size(); i++) {
-		if (m_playerId == m_characters[i]->getId()) {
-			for (int j = 0; j < m_doorObjects.size(); j++) {
-				if (m_doorObjects[j]->getAreaNum() == m_fromAreaNum) {
-					m_characters[i]->setX(m_doorObjects[j]->getX1());
-					m_characters[i]->setY(m_doorObjects[j]->getY2() - m_characters[i]->getHeight());
-				}
-			}
-			break;
-		}
-	}
 }
 
 // follow対象をプレイヤーにする

--- a/CsvReader.h
+++ b/CsvReader.h
@@ -144,9 +144,7 @@ public:
 private:
 	void loadBGM(std::map<std::string, std::string> dataMap);
 	void loadCharacter(std::map<std::string, std::string> dataMap);
-	void loadObject(std::map<std::string, std::string> dataMap);
 	void loadBackGround(std::map<std::string, std::string> dataMap);
-	void setPlayer();
 	void setFollow();
 };
 

--- a/Game.h
+++ b/Game.h
@@ -84,6 +84,41 @@ public:
 };
 
 
+class DoorData {
+private:
+
+	// 座標
+	int m_x1, m_y1, m_x2, m_y2;
+
+	// どこからどこへのドアか
+	int m_from, m_to;
+
+	// 画像のファイル名
+	const char* m_fileName;
+
+public:
+	DoorData(int x1, int y1, int x2, int y2, int from, int to, const char* fileName);
+
+	// ゲッタ
+	inline int x1() const { return m_x1; }
+	inline int y1() const { return m_y1; }
+	inline int x2() const { return m_x2; }
+	inline int y2() const { return m_y2; }
+	inline int from() const { return m_from; }
+	inline int to() const { return m_to; }
+	inline const char* fileName() const { return m_fileName; }
+
+	// セッタ
+	inline void setX1(int x1) { m_x1 = x1; }
+	inline void setY1(int y1) { m_y1 = y1; }
+	inline void setX2(int x2) { m_x2 = x2; }
+	inline void setY2(int y2) { m_y2 = y2; }
+	inline void setFrom(int from) { m_from = from; }
+	inline void setTo(int to) { m_to = to; }
+	inline void setFileName(const char* fileName) { m_fileName = fileName; }
+};
+
+
 // セーブデータ
 class GameData {
 private:
@@ -91,7 +126,10 @@ private:
 	const char* m_saveFilePath;
 
 	// キャラのデータ
-	std::vector<CharacterData> m_characterData;
+	std::vector<CharacterData*> m_characterData;
+
+	// ドアのデータ
+	std::vector<DoorData*> m_doorData;
 
 	// 今いるエリア
 	int m_areaNum;
@@ -105,6 +143,7 @@ private:
 public:
 	GameData();
 	GameData(const char* saveFilePath);
+	~GameData();
 
 	// ゲッタ
 	inline int getAreaNum() const { return m_areaNum; }

--- a/Object.cpp
+++ b/Object.cpp
@@ -824,7 +824,7 @@ void SlashObject::setSlashParam(SlashObject* object) {
 	object->setEffectHandles(m_effectHandles_p);
 }
 Object* DoorObject::createCopy() {
-	DoorObject* res = new DoorObject(m_x1, m_y1, m_x2, m_y2, m_fileName, m_areaNum);
+	DoorObject* res = new DoorObject(m_x1, m_y1, m_x2, m_y2, m_fileName.c_str(), m_areaNum);
 	setParam(res);
 	res->setText(m_text);
 	return res;

--- a/Object.h
+++ b/Object.h
@@ -60,6 +60,7 @@ public:
 	inline int getSoundHandle() const { return m_soundHandle_p; }
 	inline int getHp() const { return m_hp; }
 	inline int getDamageCnt() const { return m_damageCnt; }
+	virtual const char* getFileName() const { return ""; }
 
 	// セッタ
 	inline void setDeleteFlag(bool deleteFlag) { m_deleteFlag = deleteFlag; }
@@ -389,7 +390,7 @@ class DoorObject :
 {
 private:
 	// ファイルネームを保存しておく
-	const char* m_fileName;
+	std::string m_fileName;
 
 	// 画像
 	GraphHandle* m_graph;
@@ -412,6 +413,7 @@ public:
 	GraphHandle* getHandle() const { return m_graph; }
 	inline int getAreaNum() const { return m_areaNum; }
 	inline std::string getText() const { return m_text; }
+	const char* getFileName() const { return m_fileName.c_str(); }
 
 	// セッタ
 	inline void setText(std::string text) { m_text = text; }

--- a/World.h
+++ b/World.h
@@ -18,6 +18,7 @@ class Conversation;
 class Brain;
 class ObjectLoader;
 class CharacterData;
+class DoorData;
 
 
 class World {
@@ -115,10 +116,19 @@ public:
 	void talk();
 
 	// キャラの状態を変更する いないなら作成する
-	void asignedCharacterData(const char* name, CharacterData& data);
+	void asignedCharacterData(const char* name, CharacterData* data);
 
 	// キャラの状態を教える
-	void asignCharacterData(const char* name, CharacterData& data, int fromAreaNum);
+	void asignCharacterData(const char* name, CharacterData* data, int fromAreaNum);
+
+	// Doorの状態を変更する いないなら作成する
+	void asignedDoorData(DoorData* data);
+
+	// Doorの状態を教える
+	void asignDoorData(std::vector<DoorData*>& data, int fromAreaNum);
+
+	// プレイヤーとその仲間をドアの前に移動
+	void setPlayerOnDoor(int from);
 
 	/*
 	* イベント用
@@ -166,8 +176,8 @@ private:
 	void atariAttackAndAttack();
 
 	// キャラのセーブデータを自身に反映させる
-	void asignedCharacter(Character* character, CharacterData& data);
-	CharacterController* createControllerWithData(const Character* character, CharacterData& data);
+	void asignedCharacter(Character* character, CharacterData* data);
+	CharacterController* createControllerWithData(const Character* character, CharacterData* data);
 };
 
 #endif


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
ストーリーの進行等で追加されたドアオブジェクトを、エリア間を移動しても残り続けるようにする。

# やったこと
DoorDataクラスを定義し、配列としてGameDataオブジェクトが保持する。World::asignDoorとWorld::asignedDoorでWorldとやりとりする（基本的にCharacterと同じ処理 #54  ）。

また、エリア間を移動したときにプレイヤーの位置がドアの位置にセットされる処理が不十分で、追加されたドアは認識されていなかったので、処理を変更。今まではAreaLoaderクラスがこの処理を行っていたが、これは追加ドアを保持していないため、すべてのドアを保持するWorldクラスに任せることにした。

ついでに、プレイヤーを追跡する味方（シエスタなど）はエリア移動時にプレイヤーと同じ位置にセットされるようにした。

おまけ：ParabolaBulletを撃つAIを改善

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
ObjectはcsvファイルのObject:ドメインから情報を取得するためにObjctLoaderクラスを使っているが、Characterはクラスを使わず取得している。今後、StoryやEventも同様の処理を行えるよう、CharacterLoaderクラスを新たに作るべき。
