### PR TITLE
story.csvでキャラの追加を可能にする&エリア移動時のキャラの生成方法を変更

### DIFF
--- a/CharacterLoader.cpp
+++ b/CharacterLoader.cpp
@@ -2,6 +2,7 @@
 #include "Character.h"
 #include "CharacterAction.h"
 #include "CharacterController.h"
+#include "Game.h"
 #include "Brain.h"
 #include "CsvReader.h"
 #include "Sound.h"
@@ -80,4 +81,27 @@ pair<vector<Character*>, vector<CharacterController*> > CharacterLoader::getChar
 	}
 
 	return res;
+}
+
+// キャラのエリアと座標をセーブする
+void CharacterLoader::saveCharacterData(CharacterData* characterData) {
+	for (auto it = m_characters.begin(); it != m_characters.end(); it++) {
+		int areaNum = it->first;
+		vector<map<string, string> > characters = it->second;
+		for (unsigned int i = 0; i < characters.size(); i++) {
+			if (characters[i]["name"] == characterData->name()) {
+				characterData->setInitFlag(false);
+				characterData->setAreaNum(areaNum);
+				characterData->setX(stoi(characters[i]["x"]));
+				characterData->setY(stoi(characters[i]["y"]));
+				characterData->setSoundFlag((bool)stoi(characters[i]["sound"]));
+				characterData->setGroupId(stoi(characters[i]["groupId"]));
+				characterData->setActionName(characters[i]["action"].c_str());
+				characterData->setBrainName(characters[i]["brain"].c_str());
+				characterData->setControllerName(characters[i]["controller"].c_str());
+				characterData->setActionName(characters[i]["action"].c_str());
+				return;
+			}
+		}
+	}
 }

--- a/CharacterLoader.h
+++ b/CharacterLoader.h
@@ -12,6 +12,7 @@ class Character;
 class CharacterController;
 class Camera;
 class SoundPlayer;
+class CharacterData;
 
 
 class CharacterLoader {
@@ -35,6 +36,9 @@ public:
 
 	// 特定のエリアの追加キャラのvectorを取得<Character, Controller>
 	std::pair<std::vector<Character*>, std::vector<CharacterController*> > getCharacters(Camera* camera_p, SoundPlayer* soundPlayer_p, int areaNum = -1);
+
+	// キャラのエリアと座標をセーブする
+	void saveCharacterData(CharacterData* characterData);
 };
 
 

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -39,6 +39,7 @@ void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, anime=%d", m_characters.size(), m_characterControllers.size(), m_animations.size());
 	debugObjects(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, m_attackObjects);
+	m_characters[1]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
 }
 
 

--- a/Game.h
+++ b/Game.h
@@ -14,6 +14,9 @@ class Character;
 class CharacterData {
 private:
 
+	// 初期化済みか(Y座標の調整のために必要)一度でもキャラが生成されるとtrue
+	bool m_initFlag;
+
 	// 名前
 	const char* m_name;
 
@@ -54,6 +57,7 @@ public:
 	CharacterData(const char* name);
 
 	// ゲッタ
+	inline bool initFlag() const { return m_initFlag; }
 	inline const char* name() const { return m_name; }
 	inline int hp() const { return m_hp; }
 	inline int id() const { return m_id; }
@@ -69,6 +73,7 @@ public:
 	inline std::string controllerName() const { return m_controllerName; }
 
 	// セッタ
+	inline void setInitFlag(bool initFlag) { m_initFlag = initFlag; }
 	inline void setHp(int hp) { m_hp = hp; }
 	inline void setId(int id) { m_id = id; }
 	inline void setGroupId(int groupId) { m_groupId = groupId; }
@@ -160,6 +165,9 @@ public:
 
 	// Worldのデータを自身に反映させる
 	void asignedWorld(World* world);
+
+	// ストーリーが進んだ時にセーブデータを更新する
+	void updateStory(Story* story);
 };
 
 

--- a/Story.cpp
+++ b/Story.cpp
@@ -3,6 +3,7 @@
 #include "CsvReader.h"
 #include "World.h"
 #include "Sound.h"
+#include "CharacterLoader.h"
 #include "ObjectLoader.h"
 #include <sstream>
 
@@ -28,6 +29,13 @@ Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer) {
 		else { m_subEvent.push_back(eventOne); }
 	}
 
+	// キャラクターを用意
+	vector<map<string, string> > characterData = csvReader2.getDomainData("CHARACTER:");
+	m_characterLoader = new CharacterLoader;
+	for (unsigned int i = 0; i < characterData.size(); i++) {
+		m_characterLoader->addCharacter(characterData[i]);
+	}
+
 	// オブジェクトを用意
 	vector<map<string, string> > objectData = csvReader2.getDomainData("OBJECT:");
 	m_objectLoader = new ObjectLoader;
@@ -43,6 +51,7 @@ Story::~Story() {
 	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
 		delete m_subEvent[i];
 	}
+	delete m_characterLoader;
 	delete m_objectLoader;
 }
 

--- a/Story.h
+++ b/Story.h
@@ -6,6 +6,7 @@
 class Event;
 class World;
 class SoundPlayer;
+class CharacterLoader;
 class ObjectLoader;
 
 // ストーリ－
@@ -27,6 +28,9 @@ private:
 	// クリア任意イベント
 	std::vector<Event*> m_subEvent;
 
+	// キャラクターのデータ
+	CharacterLoader* m_characterLoader;
+
 	// オブジェクトのデータ
 	ObjectLoader* m_objectLoader;
 
@@ -42,7 +46,9 @@ public:
 	bool skillAble();
 
 	// ゲッタ
-	ObjectLoader* getObjectLoader() { return m_objectLoader; }
+	inline int getStoryNum() const { return m_storyNum; }
+	inline CharacterLoader* getCharacterLoader() const { return m_characterLoader; }
+	inline ObjectLoader* getObjectLoader() const { return m_objectLoader; }
 
 	// セッタ
 	void setWorld(World* world);

--- a/World.h
+++ b/World.h
@@ -16,6 +16,7 @@ class Animation;
 class SoundPlayer;
 class Conversation;
 class Brain;
+class CharacterLoader;
 class ObjectLoader;
 class CharacterData;
 class DoorData;
@@ -103,7 +104,8 @@ public:
 	inline void setSkillFlag(bool skillFlag) { m_skillFlag = skillFlag; }
 	inline void setFocusId(int id) { m_focusId = id; }
 
-	// ストーリーやイベントによる追加オブジェクト
+	// ストーリーやイベントによる追加
+	void addCharacter(CharacterLoader* characterLoader);
 	void addObject(ObjectLoader* objectLoader);
 
 	//デバッグ
@@ -129,6 +131,9 @@ public:
 
 	// プレイヤーとその仲間をドアの前に移動
 	void setPlayerOnDoor(int from);
+
+	// カメラの位置をリセット
+	void cameraPointInit();
 
 	/*
 	* イベント用


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り
現状、area.csvにメインキャラ（セーブ対象）を配置させるとおかしなことになる。
具体的には、イベント等でキャラの配置が変わっても、エリアを移動したとき、移動先でそのキャラがarea.csvから読み込まれるとイベントによる配置変更が上書きされる。
そのため、メインキャラはarea.csvには書かずstory.csvやevent.csvにのみ書くことにする。

そうなると問題がある。現状セーブ対象は現エリア(World)にいるキャラのみである。そのためエリア外のキャラが読み込まれても一度もエリアに出現しないままゲームが終了しセーブされないキャラが出てくる。これを防ぐためにストーリーが進んだ際ストーリーが読み込んだ情報をいったんセーブする。

もう１つ問題がある。セーブデータにあるキャラの座標情報はキャラの身長を考慮していないため、そのままWorldに適用すると床に埋まるキャラが出てくる。これを防ぐためにCharacterData::m_initFlagを定義する。これは一度でもWorldに適用するとtrueになる。一方でストーリー読み込みによって座標が更新されるとfalseになる。falseのときはWorldに適用する際に慎重を考慮した座標調整が行われる。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
コードが非常に複雑になってしまった。リファクタリングするか要検討
