### PR TITLE
複製のハートの攻撃を変更（座標ではなく方向で攻撃を決める）

### DIFF
--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -333,12 +333,17 @@ Object* NormalController::bulletAttack() {
 			order = m_bulletRecorder->checkInput();
 			// UŒ‚–Ú•W‚ðŽæ“¾
 			m_bulletRecorder->getGoal(targetX, targetY);
+			targetX += m_characterAction->getCharacter()->getCenterX();
+			targetY += m_characterAction->getCharacter()->getCenterY();
 		}
 		else {
 			order = m_brain->bulletOrder();
 			m_bulletRecorder->writeRecord(order);
 			// UŒ‚–Ú•W‚ð‘‚«ž‚Ý
-			m_bulletRecorder->setGoal(targetX, targetY);
+			m_bulletRecorder->setGoal(
+				targetX - m_characterAction->getCharacter()->getCenterX(),
+				targetY - m_characterAction->getCharacter()->getCenterY()
+			);
 		}
 		m_bulletRecorder->addTime();
 	}
@@ -367,12 +372,17 @@ Object* NormalController::slashAttack() {
 			order = m_slashRecorder->checkInput();
 			// UŒ‚–Ú•W‚ðŽæ“¾
 			m_slashRecorder->getGoal(targetX, targetY);
+			targetX += m_characterAction->getCharacter()->getCenterX();
+			targetY += m_characterAction->getCharacter()->getCenterY();
 		}
 		else {
 			order = m_brain->slashOrder();
 			m_slashRecorder->writeRecord(order);
 			// UŒ‚–Ú•W‚ð‘‚«ž‚Ý
-			m_bulletRecorder->setGoal(targetX, targetY);
+			m_bulletRecorder->setGoal(
+				targetX - m_characterAction->getCharacter()->getCenterX(),
+				targetY - m_characterAction->getCharacter()->getCenterY()
+			);
 		}
 		m_slashRecorder->addTime();
 	}


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
複製のハートはループ時に記録された操作を繰り返すが、攻撃目標（弾の撃つ方向、斬撃の方向）は攻撃時のマウスカーソルの位置を保存して再現されている。
つまり攻撃を受けて複製が記録時と違う座標になっても、攻撃目標は変わらず同じ点を狙い続ける。
しかし、攻撃目標を記録するのではなく攻撃の方向を記録する方が自然である。

例えば
------
記録時：

複製　　----o　　攻撃目標

------
ループ時（攻撃を受け複製は記録時と座標が変わっている）

　　　　　　　　攻撃目標　　o----　　複製
ではなく
　　　　　　　　攻撃目標　　　　　　複製     ----o

となってほしい。

# やったこと
recorderへの記録の仕方と取り出した記録の扱い方を変更しただけ。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
視覚的に確認。よくわかりずらいが多分大丈夫。

# 懸念点
記入欄
