### PR TITLE
Api: 一時停止画面と音量調節機能を追加

### DIFF
--- a/Button.cpp
+++ b/Button.cpp
@@ -1,0 +1,69 @@
+#include"Button.h"
+#include"Control.h"
+#include"DxLib.h"
+#include<string>
+#include<sstream>
+
+using namespace std;
+
+/////ボタン/////////////
+Button::Button(string tag, int x, int y, int wide, int height, int color, int color2, int font, int font_color) {
+	m_graph_handle = -1;
+	m_x = x; m_y = y;
+	m_wide = wide; m_height = height;
+	m_color = color;
+	m_color2 = color2;
+	m_font = font;
+	m_font_color = font_color;
+	setString(tag);
+}
+
+//ボタンの描画 下にラベルの文字列も表示できる
+void Button::draw(int hand_x, int hand_y) {
+	if (overlap(hand_x, hand_y)) {
+		DrawBox(m_x - 5, m_y - 5, m_x + m_wide + 5, m_y + m_height + 5, m_color2, TRUE);
+	}
+	DrawBox(m_x, m_y, m_x + m_wide, m_y + m_height, m_color, TRUE);
+	//絵の描画
+	if (!m_flag) { SetDrawBright(100, 100, 100); }
+	DrawRotaGraph(m_x + (m_wide / 2), m_y + (m_height / 2), m_graph_ex, 0, m_graph_handle, TRUE, FALSE);
+	SetDrawBright(255,255,255);
+	//文字の描画
+	DrawStringToHandle(m_dx, m_dy, m_tag.c_str(), m_font_color, m_font);
+}
+
+//ボタンのオン・オフ
+void Button::changeFlag(bool f, int new_color) {
+	m_flag = f;
+	m_color = new_color;
+}
+
+//ボタンがマウスカーソルと重なっているか
+bool Button::overlap(int hand_x, int hand_y) {
+	if (!m_flag) {
+		return false;
+	}
+	if (hand_x >= m_x && hand_x <= m_x + m_wide && hand_y >= m_y && hand_y <= m_y + m_height) {
+		return true;
+	}
+	return false;
+}
+
+//ボタン内に文字ではなく絵を表示するようにセット
+void Button::setGraph(int handle, int ex) {
+	m_graph_handle = handle;
+	m_graph_ex = ex;
+	m_tag = "";
+}
+
+//タグをつけなおす
+void Button::setString(std::string tag) {
+	m_tag = tag;
+	//文字列が取る幅を文字の大きさと文字列の長さから計算
+	int m_font_size;//一文字の大きさ
+	int m_string_size;//文字列がとる幅
+	GetFontStateToHandle(NULL, &m_font_size, NULL, m_font);
+	m_string_size = m_font_size * (m_tag.size() / 2);
+	m_dx = m_x + (m_wide - m_string_size) / 2 - (m_tag.size()/2);
+	m_dy = m_y + (m_height - m_font_size) / 2;
+}

--- a/Button.h
+++ b/Button.h
@@ -1,0 +1,60 @@
+#ifndef INCLUDED_BUTTON_H
+#define INCLUDED_BUTTON_H
+
+
+#include<string>
+
+
+class Button {
+private:
+
+	bool m_flag = true;//機能しないボタンはfalse
+
+	std::string m_tag = ""; // 表示するテキスト
+
+	int m_x, m_y; //ボタンの位置
+
+	int m_wide, m_height; // 四角の高さと幅
+
+	int m_color; //四角の中の色
+
+	int m_color2; //マウスが重なっているときに使う色
+
+	int m_font_color; //文字の色
+
+	int m_font; // テキストのフォント
+
+	int m_dx, m_dy; //文字を表示する座標
+
+	int m_graph_handle = -1; //絵
+
+	int m_graph_ex; //絵の拡大率
+
+public:
+
+	// コンストラクタ
+	Button(std::string, int x, int y, int wide, int height, int color, int color2, int font, int font_color);
+
+	// ゲッタ
+	inline bool getFlag() const { return m_flag; }
+	inline int getHandle() const { return m_graph_handle; } //画像を取得
+	inline int getWide() const { return m_wide; }
+	inline int getHeight() const { return m_height; }
+
+	// セッタ
+	void setGraph(int handle, int ex);
+	void setString(std::string new_string);//タグをつけなおす
+	inline void setX(int x) { m_x = x; }
+
+	// ボタンのon/off切り替え
+	void changeFlag(bool f, int new_color);
+
+	// マウスが重なっているか確認
+	bool overlap(int hand_x, int hand_y);
+
+	// 描画
+	void draw(int hand_x, int hand_y);
+};
+
+
+#endif

--- a/Control.cpp
+++ b/Control.cpp
@@ -74,6 +74,11 @@ int controlF() {
 	return Key[KEY_INPUT_F];
 }
 
+// Qキー（一時停止）
+int controlQ() {
+	return Key[KEY_INPUT_Q];
+}
+
 //デバッグモード起動用
 int controlDebug() {
 	if (Key[KEY_INPUT_P] == 1) { // Pキーが押されていたら

--- a/Control.h
+++ b/Control.h
@@ -25,6 +25,9 @@ int controlD();
 // Fキー（スキル発動）
 int controlF();
 
+// Qキー（一時停止）
+int controlQ();
+
 //FPS表示のオンオフ
 int controlDebug();
 

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -11,6 +11,7 @@
 #include "Event.h"
 #include "Story.h"
 #include "Brain.h"
+#include "Sound.h"
 #include "DxLib.h"
 
 /*
@@ -19,7 +20,7 @@
 // Gameクラスのデバッグ
 void Game::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**GAME**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "StoryNum=%d", m_gameData->getStoryNum());
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "StoryNum=%d, soundVolume=%d", m_gameData->getStoryNum(), m_soundPlayer->getVolume());
 	//m_story->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	m_world->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
 }

--- a/Define.h
+++ b/Define.h
@@ -3,6 +3,11 @@
 
 #include"DxLib.h"
 
+// フルスクリーンならFALSE
+static int WINDOW = TRUE;
+// マウスを表示するならFALSE
+static int MOUSE_DISP = FALSE;
+
 //画面の大きさ
 #define GAME_WIDE 1920
 #define GAME_HEIGHT 1080

--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -154,6 +154,7 @@
     <ClCompile Include="Animation.cpp" />
     <ClCompile Include="AnimationDrawer.cpp" />
     <ClCompile Include="Brain.cpp" />
+    <ClCompile Include="Button.cpp" />
     <ClCompile Include="Camera.cpp" />
     <ClCompile Include="Character.cpp" />
     <ClCompile Include="CharacterAction.cpp" />
@@ -172,6 +173,7 @@
     <ClCompile Include="Object.cpp" />
     <ClCompile Include="ObjectDrawer.cpp" />
     <ClCompile Include="ObjectLoader.cpp" />
+    <ClCompile Include="PausePage.cpp" />
     <ClCompile Include="Sound.cpp" />
     <ClCompile Include="Story.cpp" />
     <ClCompile Include="Text.cpp" />
@@ -183,6 +185,7 @@
     <ClInclude Include="Animation.h" />
     <ClInclude Include="AnimationDrawer.h" />
     <ClInclude Include="Brain.h" />
+    <ClInclude Include="Button.h" />
     <ClInclude Include="Camera.h" />
     <ClInclude Include="Character.h" />
     <ClInclude Include="CharacterAction.h" />
@@ -200,6 +203,7 @@
     <ClInclude Include="Object.h" />
     <ClInclude Include="ObjectDrawer.h" />
     <ClInclude Include="ObjectLoader.h" />
+    <ClInclude Include="PausePage.h" />
     <ClInclude Include="Sound.h" />
     <ClInclude Include="Story.h" />
     <ClInclude Include="Text.h" />

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -37,6 +37,12 @@
     <Filter Include="ヘッダー ファイル\Loader">
       <UniqueIdentifier>{ed248952-e8e8-41aa-bff0-b4ac934a8e07}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ヘッダー ファイル\pages">
+      <UniqueIdentifier>{dc0df2ee-2308-4450-835a-c887e7892cc9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ソース ファイル\pages">
+      <UniqueIdentifier>{4f6a2357-f2bf-45ed-b9ad-c42312feccfb}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp">
@@ -120,6 +126,12 @@
     <ClCompile Include="ObjectLoader.cpp">
       <Filter>ソース ファイル\Loader</Filter>
     </ClCompile>
+    <ClCompile Include="Button.cpp">
+      <Filter>ソース ファイル\Domain</Filter>
+    </ClCompile>
+    <ClCompile Include="PausePage.cpp">
+      <Filter>ソース ファイル\pages</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">
@@ -199,6 +211,12 @@
     </ClInclude>
     <ClInclude Include="ObjectLoader.h">
       <Filter>ヘッダー ファイル\Loader</Filter>
+    </ClInclude>
+    <ClInclude Include="Button.h">
+      <Filter>ヘッダー ファイル\Domain</Filter>
+    </ClInclude>
+    <ClInclude Include="PausePage.h">
+      <Filter>ヘッダー ファイル\pages</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Game.cpp
+++ b/Game.cpp
@@ -10,6 +10,7 @@
 #include "CharacterLoader.h"
 #include "Brain.h"
 #include "ControllerRecorder.h"
+#include "PausePage.h"
 #include "DxLib.h"
 
 /*
@@ -64,7 +65,7 @@ GameData::GameData() {
 		m_storyNum = 0;
 	}
 
-	m_soundVolume = 10;
+	m_soundVolume = 50;
 
 	// 主要キャラを設定
 	const int mainSum = 5;
@@ -155,6 +156,9 @@ Game::Game() {
 
 	// スキル
 	m_skill = NULL;
+
+	// 一時停止画面
+	m_gamePause = NULL;
 }
 
 Game::~Game() {
@@ -164,6 +168,21 @@ Game::~Game() {
 }
 
 bool Game::play() {
+
+	// 一時停止
+	if (controlQ() == 1) {
+		if (m_gamePause == NULL) {
+			m_gamePause = new GamePause(m_soundPlayer);
+		}
+		else {
+			delete m_gamePause;
+			m_gamePause = NULL;
+		}
+	}
+	if (m_gamePause != NULL) {
+		m_gamePause->play();
+		return false;
+	}
 
 	// これ以上ストーリーを進ませない（テスト用）
 	if (m_gameData->getStoryNum() == 5 || m_gameData->getStoryNum() == 0) {

--- a/Game.h
+++ b/Game.h
@@ -8,6 +8,7 @@ class SoundPlayer;
 class World;
 class Story;
 class Character;
+class GamePause;
 
 
 // キャラのセーブデータ
@@ -241,6 +242,9 @@ private:
 	// スキル
 	HeartSkill* m_skill;
 
+	// 一時停止画面
+	GamePause* m_gamePause;
+
 public:
 	Game();
 	~Game();
@@ -248,6 +252,7 @@ public:
 	// ゲッタ
 	World* getWorld() const { return m_world; }
 	HeartSkill* getSkill() const { return m_skill; }
+	GamePause* getGamePause() const { return m_gamePause; }
 
 	// デバッグ
 	void debug(int x, int y, int color) const;

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -2,6 +2,7 @@
 #include "Game.h"
 #include "World.h"
 #include "WorldDrawer.h"
+#include "PausePage.h"
 #include "Define.h"
 #include "DxLib.h"
 #include <string>
@@ -25,6 +26,7 @@ GameDrawer::~GameDrawer() {
 }
 
 void GameDrawer::draw() {
+
 	// 世界を描画
 	HeartSkill* skill = m_game->getSkill();
 	if (skill != NULL) {
@@ -47,4 +49,14 @@ void GameDrawer::draw() {
 			DrawStringToHandle(700, 50, oss.str().c_str(), BLACK, m_skillHandle);
 		}
 	}
+
+	// 一時停止画面
+	if (m_game->getGamePause() != NULL) {
+		SetMouseDispFlag(TRUE);//マウス表示
+		m_game->getGamePause()->draw();
+	}
+	else{
+		SetMouseDispFlag(MOUSE_DISP);//マウス表示
+	}
+
 }

--- a/Main.cpp
+++ b/Main.cpp
@@ -5,11 +5,6 @@
 #include "DxLib.h"
 
 
-// フルスクリーンならFALSE
-static int WINDOW = TRUE;
-// マウスを表示するならFALSE
-static int MOUSE_DISP = FALSE;
-
 ///////fpsの調整///////////////
 static int mStartTime;
 static int mCount;

--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -1,0 +1,54 @@
+#include "PausePage.h"
+#include "Button.h"
+#include "Sound.h"
+#include "Control.h"
+#include "Define.h"
+#include "DxLib.h"
+
+
+GamePause::GamePause(SoundPlayer* soundPlayer) {
+	m_soundPlayer_p = soundPlayer;
+	m_soundBarButton = new Button("", 100, 450, 50, 100, WHITE, GRAY, -1, BLACK);
+	m_handX = 0;
+	m_handY = 0;
+	m_soundFlag = false;
+}
+
+void GamePause::play() {
+	// マウスカーソルの位置取得
+	GetMousePoint(&m_handX, &m_handY);
+
+	// 左クリック
+	int click = leftClick();
+
+	// 音量調節
+	if (click > 0 && m_soundBarButton->overlap(m_handX, m_handY)) {
+		m_soundFlag = true;
+	}
+	if (click == 0) {
+		m_soundFlag = false;
+	}
+
+	int length = SOUND_RIGHT_LIMIT - SOUND_LEFT_LIMIT;
+	if (m_soundFlag) {
+		int rate = (m_handX - SOUND_LEFT_LIMIT) * 100 / length;
+		m_soundPlayer_p->setVolume(rate);
+	}
+
+	int soundVolume = m_soundPlayer_p->getVolume();
+	m_soundBarButton->setX(SOUND_LEFT_LIMIT + soundVolume * length / 100 - m_soundBarButton->getWide() / 2);
+}
+
+void GamePause::draw() const {
+
+	// 音量調節領域
+	DrawBox(SOUND_LEFT_LIMIT - 60, SOUND_Y - 110, SOUND_RIGHT_LIMIT + 60, SOUND_Y + 110, BLACK, TRUE);
+	DrawBox(SOUND_LEFT_LIMIT - 50, SOUND_Y - 100, SOUND_RIGHT_LIMIT + 50, SOUND_Y + 100, GRAY2, TRUE);
+
+	// ボタンの移動範囲
+	DrawBox(SOUND_LEFT_LIMIT, SOUND_Y - 10, SOUND_RIGHT_LIMIT, SOUND_Y + 10, BLACK, TRUE);
+
+	// 音量調節ボタン
+	m_soundBarButton->draw(m_handX, m_handY);
+
+}

--- a/PausePage.h
+++ b/PausePage.h
@@ -1,0 +1,37 @@
+#ifndef PAUSE_PAGE_H_INCLUDED
+#define PAUSE_PAGE_H_INCLUDED
+
+
+class Button;
+class SoundPlayer;
+
+
+class GamePause {
+private:
+
+	// 音量調節の対象
+	SoundPlayer* m_soundPlayer_p;
+
+	// マウスカーソルの位置
+	int m_handX, m_handY;
+
+	// 音量調節用
+	Button* m_soundBarButton;
+
+	// 今調整中
+	bool m_soundFlag;
+
+	const int SOUND_LEFT_LIMIT = 100;
+	const int SOUND_RIGHT_LIMIT = 1100;
+	const int SOUND_Y = 500;
+
+public:
+	GamePause(SoundPlayer* soundPlayer);
+
+	void play();
+
+	void draw() const;
+};
+
+
+#endif

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -41,9 +41,9 @@ SoundPlayer::~SoundPlayer() {
 void SoundPlayer::setVolume(int volume) {
 	if (volume < 0) { m_volume = 0; }
 	else {
-		m_volume = min(m_volume, 100);
+		m_volume = min(volume, 100);
 	}
-	changeSoundVolume(m_bgmHandle, m_volume);
+	changeSoundVolume(m_volume, m_bgmHandle);
 }
 
 // BGMをセット（変更）


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

# やったこと
pagesフィルターを作成、一時停止画面など、ユーザが直接触る画面を含む。
音量の変更が適用されないバグを修正。引数の順番を間違っていただけ。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
![sound](https://github.com/kuriuminoki/DuplicationHeart/assets/92528385/40816bf4-800d-4249-b7c1-bc4100c61b38)

# 懸念点
見た目は将来的に改善する予定。
