### PR TITLE
Api: AIのバグ修正

### DIFF
--- a/Brain.h
+++ b/Brain.h
@@ -235,7 +235,7 @@ protected:
 	const Character* m_follow_p;
 
 	// í«ê’ëŒè€ÇÃãﬂÇ≠Ç…Ç¢ÇÈÇ∆Ç›Ç»Ç∑åÎç∑ Å}GX_ERROR
-	const int FOLLOW_X_ERROR = 500;
+	const int FOLLOW_X_ERROR = 800;
 
 public:
 	static const char* BRAIN_NAME;

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -40,7 +40,7 @@ void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, anime=%d", m_characters.size(), m_characterControllers.size(), m_animations.size());
 	debugObjects(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, m_attackObjects);
-	m_characterControllers[0]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
+	m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
 }
 
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
CPUがたまに挙動不審になるバグが存在。
具体的には、その場で移動→立ち→移動→立ち・・・と繰り返す。
原因は、目標地点まで移動した際、足を止めて画像のサイズが変わり目標地点未到達に変わること。

# やったこと
2つの変更点がある。
- 目標地点に到達しても1Fだけ余分に移動し続けるように。
- 目標地点の到達・目標地点の設定について、考慮する座標をX1ではなくCenterXに。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
目視で確認。明らかにバグはなくなった。

# 懸念点
記入欄
