### PR TITLE
Api: ヴァルキリアの攻撃の修正とヒエラルキーがLand状態で固まるバグの修正

### DIFF
--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -698,3 +698,14 @@ void ValkiriaAction::finishSlash() {
 	}
 	m_slashCnt = 0;
 }
+
+// ƒ_ƒ[ƒW‚ðŽó‚¯‚é
+void ValkiriaAction::damage(int vx, int vy, int damageValue) {
+	if (m_slashCnt > 0) {
+		// HPŒ¸­
+		m_character_p->damageHp(damageValue / 2);
+	}
+	else {
+		StickAction::damage(vx, vy, damageValue);
+	}
+}

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -291,6 +291,9 @@ public:
 
 	// 斬撃終了の処理
 	void finishSlash();
+
+	// ダメージ
+	void damage(int vx, int vy, int damageValue);
 };
 
 

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -210,10 +210,12 @@ void CharacterGraphHandle::switchSlash(int index){
 }
 // しゃがみ画像をセット
 void CharacterGraphHandle::switchSquat(int index){
+	if (m_squatHandles == nullptr) { switchStand(index); }
 	setGraph(m_squatHandles, index);
 }
 // しゃがみ射撃画像をセット
 void CharacterGraphHandle::switchSquatBullet(int index) {
+	if (m_squatBulletHandles == nullptr) { switchBullet(index); }
 	setGraph(m_squatBulletHandles, index);
 }
 // 走り画像をセット


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
ヴァルキリアが斬撃で突進するとき、攻撃を受けると吹っ飛んで攻撃が中断されるが、これは遠距離攻撃を持たないヴァルキリアにとって大きな弱点であり、弱い。
攻撃中はふっとばず、ダメージも半減するように変更。

ヒエラルキーはしゃがみ画像がないため、しゃがもうとすると画像が固まる。そのため着地と同時にしゃがむとLand画像で固まってしまう。しゃがみ画像がないときは立ち画像を代わりに表示するように変更。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
