### PR TITLE
Api: ムービー再生イベントの追加

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -81,7 +81,14 @@ OpMovie::OpMovie(SoundPlayer* soundPlayer_p):
 	Movie(soundPlayer_p)
 {
 	string path = "picture/movie/op/";
-	m_title = new GraphHandles((path + "複製のHeartタイトル").c_str(), 1);
+	// タイトル
+	m_titleH = new GraphHandles((path + "title/" + "h").c_str(), 4);
+	m_title = new GraphHandles((path + "title/" + "title").c_str(), 8);
+	m_titleChara = new GraphHandles((path + "title/" + "キャラ").c_str(), 5);
+	m_titleBlue = new GraphHandles((path + "title/" + "titleBlue").c_str(), 1);
+	m_titleOrange = new GraphHandles((path + "title/" + "titleOrange").c_str(), 1);
+	m_titleHeart = new GraphHandles((path + "title/" + "heart").c_str(), 1);
+	// キャラ
 	m_archive = new GraphHandles((path + "アーカイブ").c_str(), 1);
 	m_aigis = new GraphHandles((path + "アイギス").c_str(), 1);
 	m_assault = new GraphHandles((path + "アサルト03").c_str(), 1);
@@ -104,16 +111,46 @@ OpMovie::OpMovie(SoundPlayer* soundPlayer_p):
 	m_rabbi = new GraphHandles((path + "ラビ―").c_str(), 1);
 	m_tank = new GraphHandles((path + "棒タンク").c_str(), 1);
 
+	// 表示する順にpush
+	characterQueue.push(make_pair(m_koharu, 30));
+	characterQueue.push(make_pair(m_assault, 30));
+	characterQueue.push(make_pair(m_msadi, 30));
+	characterQueue.push(make_pair(m_exlucina, 30));
+	characterQueue.push(make_pair(m_yuri, 30));
+	characterQueue.push(make_pair(m_titius, 30));
+	characterQueue.push(make_pair(m_tank, 30));
+	characterQueue.push(make_pair(m_chocola, 30));
+	characterQueue.push(make_pair(m_vermelia, 30));
+	characterQueue.push(make_pair(m_french, 30));
+	characterQueue.push(make_pair(m_courir, 30));
+	characterQueue.push(make_pair(m_cornein, 30));
+	characterQueue.push(make_pair(m_aigis, 30));
+	characterQueue.push(make_pair(m_elnino, 30));
+	characterQueue.push(make_pair(m_onyx, 30));
+	characterQueue.push(make_pair(m_fred, 30));
+	characterQueue.push(make_pair(m_mascara, 30));
+	characterQueue.push(make_pair(m_rabbi, 30));
+	characterQueue.push(make_pair(m_archive, 30));
+	characterQueue.push(make_pair(m_siesta, 30));
+
 	// 最初の画像
-	m_animation = new Animation(GAME_WIDE / 2, GAME_HEIGHT / 2, 100, m_title);
+	m_animation = new Animation(GAME_WIDE / 2, GAME_HEIGHT / 2, 16, m_titleChara);
 
 	// 音楽
-	m_soundPlayer_p->setBGM("sound/movie/kobune_full.mp3");
+	m_soundPlayer_p->setBGM("sound/movie/kobune.mp3");
+	m_soundPlayer_p->clearSoundQueue();
 }
 
 OpMovie::~OpMovie() {
 	// 画像
+	// タイトル
+	delete m_titleH;
 	delete m_title;
+	delete m_titleChara;
+	delete m_titleBlue;
+	delete m_titleOrange;
+	delete m_titleHeart;
+	// キャラ
 	delete m_archive;
 	delete m_aigis;
 	delete m_assault;
@@ -143,15 +180,46 @@ OpMovie::~OpMovie() {
 void OpMovie::play() {
 	m_cnt++;
 	m_animation->count();
-	if (m_cnt == 180) {
-		m_animation->changeGraph(m_siesta, 10);
+
+	// 画像を設定
+	if (m_cnt < 120 && m_animation->getFinishFlag()) {
+		m_animation->changeGraph(m_titleH, 1000);
 	}
-	else if (m_cnt == 230) {
+	else if (m_cnt == 180) {
+		m_animation->changeGraph(m_titleH, 5);
+	}
+	else if (m_cnt < 440 && m_animation->getFinishFlag()) {
+		m_animation->changeGraph(m_title, 30);
+	}
+	else if (m_cnt < 600 && m_cnt >= 440) {
+		m_animation->changeGraph(m_titleHeart, 60);
+		m_animation->setX(m_animation->getX() + 8);
+	}
+	else if (m_cnt < 690 && m_cnt >= 600) {
+		m_animation->setX(GAME_WIDE / 2);
+		if (m_cnt / 5 % 2 == 0) {
+			m_animation->changeGraph(m_titleBlue, 60);
+		}
+		else {
+			m_animation->changeGraph(m_titleOrange, 60);
+		}
+	}
+	else if (m_cnt < 700 && m_cnt >= 690) {
+		m_animation->changeGraph(m_titleOrange, 60);
+	}
+	else if (m_cnt >= 2130 && m_cnt < 2740) {
+		if (m_animation->getFinishFlag() && !characterQueue.empty()) {
+			GraphHandles* next = characterQueue.front().first;
+			m_animation->changeGraph(next, characterQueue.front().second / next->getSize());
+			characterQueue.pop();
+		}
+	}
+	else if (m_cnt == 2760) {
 		m_animation->changeGraph(m_heart);
 	}
 
 	// 終了
-	if (m_soundPlayer_p->checkBGMplay() == 0) {
+	if (m_cnt == 5000) {
 		m_finishFlag = true;
 	}
 }

--- a/Animation.cpp
+++ b/Animation.cpp
@@ -134,7 +134,7 @@ OpMovie::OpMovie(SoundPlayer* soundPlayer_p):
 	characterQueue.push(make_pair(m_siesta, 30));
 
 	// Å‰‚Ì‰æ‘œ
-	m_animation = new Animation(GAME_WIDE / 2, GAME_HEIGHT / 2, 16, m_titleChara);
+	m_animation = new Animation(GAME_WIDE / 2, GAME_HEIGHT / 2, 120, m_titleH);
 
 	// ‰¹Šy
 	m_soundPlayer_p->setBGM("sound/movie/kobune.mp3");
@@ -182,7 +182,10 @@ void OpMovie::play() {
 	m_animation->count();
 
 	// ‰æ‘œ‚ğİ’è
-	if (m_cnt < 120 && m_animation->getFinishFlag()) {
+	if (m_cnt == 45) {
+		m_animation->changeGraph(m_titleChara, 12);
+	}
+	else if (m_cnt < 120 && m_animation->getFinishFlag()) {
 		m_animation->changeGraph(m_titleH, 1000);
 	}
 	else if (m_cnt == 180) {

--- a/Animation.cpp
+++ b/Animation.cpp
@@ -1,15 +1,22 @@
 #include "Animation.h"
 #include "GraphHandle.h"
+#include "Sound.h"
+#include "Define.h"
+
+#include<string>
+
+using namespace std;
 
 
+/*
+* アニメーションのクラス
+*/
 Animation::Animation(int x, int y, int flameCnt, GraphHandles* graphHandles) {
 	m_x = x;
 	m_y = y;
 	m_handles = graphHandles;
 	m_flameCnt = flameCnt;
-	m_cnt = 0;
-	m_finishCnt = m_flameCnt * m_handles->getSize();
-	m_finishFlag = false;
+	init();
 }
 
 Animation* Animation::createCopy() {
@@ -18,6 +25,20 @@ Animation* Animation::createCopy() {
 	res->setFinishCnt(m_finishCnt);
 	res->setFinishFlag(m_finishFlag);
 	return res;
+}
+
+// 初期化
+void Animation::init() {
+	m_cnt = 0;
+	m_finishCnt = m_flameCnt * m_handles->getSize();
+	m_finishFlag = false;
+}
+
+// アニメーションの切り替え
+void Animation::changeGraph(GraphHandles* nextGraph, int flameCnt) {
+	m_handles = nextGraph;
+	if (flameCnt > 0) { m_flameCnt = flameCnt; }
+	init();
 }
 
 
@@ -34,4 +55,103 @@ void Animation::count() {
 // 描画用
 GraphHandle* Animation::getHandle() const {
 	return m_handles->getGraphHandle((m_cnt - 1) / m_flameCnt);
+}
+
+
+
+/*
+* 動画の基底クラス
+*/
+Movie::Movie(SoundPlayer* soundPlayer_p) {
+	m_finishFlag = false;
+	m_cnt = 0;
+	m_animation = nullptr;
+	m_soundPlayer_p = soundPlayer_p;
+}
+
+Movie::~Movie() {
+	if (m_animation != nullptr) {
+		delete m_animation;
+	}
+}
+
+
+// オープニング
+OpMovie::OpMovie(SoundPlayer* soundPlayer_p):
+	Movie(soundPlayer_p)
+{
+	string path = "picture/movie/op/";
+	m_title = new GraphHandles((path + "複製のHeartタイトル").c_str(), 1);
+	m_archive = new GraphHandles((path + "アーカイブ").c_str(), 1);
+	m_aigis = new GraphHandles((path + "アイギス").c_str(), 1);
+	m_assault = new GraphHandles((path + "アサルト03").c_str(), 1);
+	m_vermelia = new GraphHandles((path + "ヴェルメリア").c_str(), 1);
+	m_exlucina = new GraphHandles((path + "エクスルキナ").c_str(), 1);
+	m_msadi = new GraphHandles((path + "エムサディ").c_str(), 1);
+	m_elnino = new GraphHandles((path + "エルニーニョ").c_str(), 1);
+	m_onyx = new GraphHandles((path + "オニュクス").c_str(), 1);
+	m_courir = new GraphHandles((path + "クーリール").c_str(), 1);
+	m_cornein = new GraphHandles((path + "コーネイン").c_str(), 1);
+	m_koharu = new GraphHandles((path + "コハル").c_str(), 1);
+	m_siesta = new GraphHandles((path + "シエスタ").c_str(), 5);
+	m_chocola = new GraphHandles((path + "ショコラ").c_str(), 1);
+	m_titius = new GraphHandles((path + "ティティウス").c_str(), 1);
+	m_heart = new GraphHandles((path + "ハート").c_str(), 1);
+	m_fred = new GraphHandles((path + "フレッド").c_str(), 1);
+	m_french = new GraphHandles((path + "フレンチ").c_str(), 1);
+	m_mascara = new GraphHandles((path + "マスカーラ").c_str(), 1);
+	m_yuri = new GraphHandles((path + "ユーリ").c_str(), 1);
+	m_rabbi = new GraphHandles((path + "ラビ―").c_str(), 1);
+	m_tank = new GraphHandles((path + "棒タンク").c_str(), 1);
+
+	// 最初の画像
+	m_animation = new Animation(GAME_WIDE / 2, GAME_HEIGHT / 2, 100, m_title);
+
+	// 音楽
+	m_soundPlayer_p->setBGM("sound/movie/kobune_full.mp3");
+}
+
+OpMovie::~OpMovie() {
+	// 画像
+	delete m_title;
+	delete m_archive;
+	delete m_aigis;
+	delete m_assault;
+	delete m_vermelia;
+	delete m_exlucina;
+	delete m_msadi;
+	delete m_elnino;
+	delete m_onyx;
+	delete m_courir;
+	delete m_cornein;
+	delete m_koharu;
+	delete m_siesta;
+	delete m_chocola;
+	delete m_titius;
+	delete m_heart;
+	delete m_fred;
+	delete m_french;
+	delete m_mascara;
+	delete m_yuri;
+	delete m_rabbi;
+	delete m_tank;
+
+	// 音楽を止める
+	m_soundPlayer_p->stopBGM();
+}
+
+void OpMovie::play() {
+	m_cnt++;
+	m_animation->count();
+	if (m_cnt == 180) {
+		m_animation->changeGraph(m_siesta, 10);
+	}
+	else if (m_cnt == 230) {
+		m_animation->changeGraph(m_heart);
+	}
+
+	// 終了
+	if (m_soundPlayer_p->checkBGMplay() == 0) {
+		m_finishFlag = true;
+	}
 }

--- a/Animation.h
+++ b/Animation.h
@@ -3,6 +3,7 @@
 
 class GraphHandle;
 class GraphHandles;
+class SoundPlayer;
 
 class Animation {
 private:
@@ -39,11 +40,86 @@ public:
 	inline void setFinishCnt(int finishCnt) { m_finishCnt = finishCnt; }
 	inline void setFinishFlag(int finishFlag) { m_finishFlag = finishFlag; }
 
+	// 初期化
+	void init();
+
+	// アニメーションの切り替え
+	void changeGraph(GraphHandles* nextGraph, int flameCnt = -1);
+
 	// カウント
 	void count();
 
 	// 描画用
 	GraphHandle* getHandle() const;
 };
+
+
+// 動画の基底クラス
+class Movie {
+protected:
+	// 終了したらtrue
+	bool m_finishFlag;
+
+	// 開始からの経過時間
+	int m_cnt;
+
+	// 画像を入れて動かす
+	Animation* m_animation;
+
+	// サウンドプレイヤー
+	SoundPlayer* m_soundPlayer_p;
+
+public:
+	Movie(SoundPlayer* soundPlayer_p);
+	~Movie();
+
+	// ゲッタ
+	bool getFinishFlag() const { return m_finishFlag; }
+	Animation* getAnimation() const { return m_animation; }
+	inline int getCnt() const { return m_cnt; }
+
+	// 再生
+	virtual void play() = 0;
+};
+
+
+// オープニング
+class OpMovie:
+	public Movie
+{
+private:
+
+	// 画像
+	GraphHandles* m_title;
+	GraphHandles* m_archive;
+	GraphHandles* m_aigis;
+	GraphHandles* m_assault;
+	GraphHandles* m_vermelia;
+	GraphHandles* m_exlucina;
+	GraphHandles* m_msadi;
+	GraphHandles* m_elnino;
+	GraphHandles* m_onyx;
+	GraphHandles* m_courir;
+	GraphHandles* m_cornein;
+	GraphHandles* m_koharu;
+	GraphHandles* m_siesta;
+	GraphHandles* m_chocola;
+	GraphHandles* m_titius;
+	GraphHandles* m_heart;
+	GraphHandles* m_fred;
+	GraphHandles* m_french;
+	GraphHandles* m_mascara;
+	GraphHandles* m_yuri;
+	GraphHandles* m_rabbi;
+	GraphHandles* m_tank;
+
+public:
+	OpMovie(SoundPlayer* soundPlayer_p);
+	~OpMovie();
+
+	// 再生
+	void play();
+};
+
 
 #endif

--- a/Animation.h
+++ b/Animation.h
@@ -1,6 +1,8 @@
 #ifndef ANIMATION_H_INCLUDED
 #define ANIMATION_H_INCLUDED
 
+#include <queue>
+
 class GraphHandle;
 class GraphHandles;
 class SoundPlayer;
@@ -36,6 +38,8 @@ public:
 	inline bool getFinishFlag() const { return m_finishFlag; }
 
 	// セッタ
+	inline void setX(int x) { m_x = x; }
+	inline void setY(int y) { m_y = y; }
 	inline void setCnt(int cnt) { m_cnt = cnt; }
 	inline void setFinishCnt(int finishCnt) { m_finishCnt = finishCnt; }
 	inline void setFinishFlag(int finishFlag) { m_finishFlag = finishFlag; }
@@ -90,7 +94,14 @@ class OpMovie:
 private:
 
 	// 画像
+	// タイトル
+	GraphHandles* m_titleH;
 	GraphHandles* m_title;
+	GraphHandles* m_titleChara;
+	GraphHandles* m_titleBlue;
+	GraphHandles* m_titleOrange;
+	GraphHandles* m_titleHeart;
+	// キャラ
 	GraphHandles* m_archive;
 	GraphHandles* m_aigis;
 	GraphHandles* m_assault;
@@ -112,6 +123,9 @@ private:
 	GraphHandles* m_yuri;
 	GraphHandles* m_rabbi;
 	GraphHandles* m_tank;
+
+	// キャラを順に表示する用 (graph, cntSum)
+	std::queue<std::pair<GraphHandles*, int> > characterQueue;
 
 public:
 	OpMovie(SoundPlayer* soundPlayer_p);

--- a/AnimationDrawer.cpp
+++ b/AnimationDrawer.cpp
@@ -15,6 +15,8 @@ void AnimationDrawer::drawAnimation(const Camera* camera) {
 	double ex = handle->getEx();
 
 	// ƒJƒƒ‰‚Å•â³‚µ‚Ä•`‰æ
-	camera->setCamera(&x, &y, &ex);
+	if (camera != nullptr) {
+		camera->setCamera(&x, &y, &ex);
+	}
 	handle->draw(x, y, ex);
 }

--- a/AnimationDrawer.h
+++ b/AnimationDrawer.h
@@ -12,7 +12,7 @@ public:
 
 	inline void setAnimation(const Animation* animation) { m_animation = animation; };
 
-	void drawAnimation(const Camera* const camera);
+	void drawAnimation(const Camera* const camera = nullptr);
 };
 
 #endif

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -249,10 +249,11 @@ int NormalAI::jumpOrder() {
 	}
 
 	int maxJump = m_characterAction_p->getPreJumpMax();
+	int minJump = maxJump / 3;
 
 	if (m_jumpCnt == 0) {
 		// ランダムでジャンプ
-		if (m_squatCnt == 0 && GetRand(99) == 0) { m_jumpCnt = GetRand(maxJump - 5) + 5; }
+		if (m_squatCnt == 0 && GetRand(99) == 0) { m_jumpCnt = GetRand(maxJump - minJump) + minJump; }
 
 		// 壁にぶつかったからジャンプ
 		if (m_rightKey > 0 && m_characterAction_p->getRightLock()) { m_jumpCnt = maxJump; }

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -441,6 +441,7 @@ const Character* FollowNormalAI::getFollow() const {
 }
 
 bool FollowNormalAI::checkAlreadyFollow() {
+	if (m_follow_p == nullptr) { return true; }
 	int followX = m_follow_p->getCenterX();
 	return  m_gx < followX + FOLLOW_X_ERROR && m_gx > followX - FOLLOW_X_ERROR;
 }

--- a/Brain.h
+++ b/Brain.h
@@ -235,7 +235,7 @@ protected:
 	const Character* m_follow_p;
 
 	// í«ê’ëŒè€ÇÃãﬂÇ≠Ç…Ç¢ÇÈÇ∆Ç›Ç»Ç∑åÎç∑ Å}GX_ERROR
-	const int FOLLOW_X_ERROR = 800;
+	const int FOLLOW_X_ERROR = 600;
 
 public:
 	static const char* BRAIN_NAME;

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -62,5 +62,5 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int bright) {
 	int height = (int)(HP_BAR_HEIGHT * camera->getEx());
 	y -= (int)(10 * camera->getEx());
 	// ‘Ì—Í‚Ì•`‰æ
-	drawHpBar(x - wide, y - height, x + wide, y, character->getHp(), character->getMaxHp(), DAMAGE_COLOR, HP_COLOR);
+	//drawHpBar(x - wide, y - height, x + wide, y, character->getHp(), character->getMaxHp(), DAMAGE_COLOR, HP_COLOR);
 }

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -40,7 +40,10 @@ void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, anime=%d", m_characters.size(), m_characterControllers.size(), m_animations.size());
 	debugObjects(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, m_attackObjects);
-	m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
+	//m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
+	if (m_movie_p != NULL) {
+		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "Movie: cnt=%d", m_movie_p->getCnt());
+	}
 }
 
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -7,6 +7,7 @@
 #include "Character.h"
 #include "Text.h"
 #include "Brain.h"
+#include "Animation.h"
 #include <sstream>
 
 using namespace std;
@@ -101,6 +102,9 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	}
 	else if (param0 == "Talk") {
 		element = new TalkEvent(world, soundPlayer, param);
+	}
+	else if (param0 == "Movie") {
+		element = new MovieEvent(world, soundPlayer, param);
 	}
 
 	if (element != NULL) { m_eventElement.push_back(element); }
@@ -308,6 +312,27 @@ EVENT_RESULT TalkEvent::play() {
 	m_world_p->setConversation(m_conversation);
 	m_world_p->talk();
 	if (m_conversation->getFinishFlag()) {
+		return EVENT_RESULT::SUCCESS;
+	}
+	return EVENT_RESULT::NOW;
+}
+
+
+MovieEvent::MovieEvent(World* world, SoundPlayer* soundPlayer, std::vector<std::string> param) :
+	EventElement(world)
+{
+	//int textNum = stoi(param[1]);
+	m_movie = new OpMovie(soundPlayer);
+	m_world_p->setMovie(m_movie);
+}
+
+MovieEvent::~MovieEvent() {
+	delete m_movie;
+}
+
+EVENT_RESULT MovieEvent::play() {
+	m_world_p->moviePlay();
+	if (m_movie->getFinishFlag()) {
 		return EVENT_RESULT::SUCCESS;
 	}
 	return EVENT_RESULT::NOW;

--- a/Event.cpp
+++ b/Event.cpp
@@ -219,7 +219,7 @@ EVENT_RESULT ChangeBrainEvent::play() {
 	m_controller_p->setBrain(brain);
 
 	// 追跡対象が必要なBrainは追跡対象を設定
-	if (brain->getBrainName() == FollowNormalAI::BRAIN_NAME) {
+	if (brain->getBrainName() == FollowNormalAI::BRAIN_NAME || brain->getBrainName() == ValkiriaAI::BRAIN_NAME) {
 		Character* follow = m_world_p->getCharacterWithName(m_param[3]);
 		brain->searchFollow(follow);
 	}
@@ -244,7 +244,7 @@ ChangeGroupEvent::ChangeGroupEvent(World* world, std::vector<string> param) :
 	m_character_p = m_world_p->getCharacterWithName(param[2]);
 }
 EVENT_RESULT ChangeGroupEvent::play() {
-	// 対象のキャラのBrainを変更する
+	// 対象のキャラのGroupIdを変更する
 	m_character_p->setGroupId(m_groupId);
 	return EVENT_RESULT::SUCCESS;
 }

--- a/Event.h
+++ b/Event.h
@@ -10,6 +10,7 @@ class SoundPlayer;
 class CharacterController;
 class Character;
 class Conversation;
+class Movie;
 
 
 enum class EVENT_RESULT {
@@ -247,6 +248,24 @@ private:
 public:
 	TalkEvent(World* world, SoundPlayer* soundPlayer, std::vector<std::string> param);
 	~TalkEvent();
+
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+};
+
+// ムービーイベント
+class MovieEvent :
+	public EventElement
+{
+private:
+
+	Movie* m_movie;
+
+public:
+	MovieEvent(World* world, SoundPlayer* soundPlayer, std::vector<std::string> param);
+	~MovieEvent();
 
 	EVENT_RESULT play();
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -173,10 +173,13 @@ bool Game::play() {
 	if (controlQ() == 1) {
 		if (m_gamePause == NULL) {
 			m_gamePause = new GamePause(m_soundPlayer);
+			// ‚±‚±‚Å‰¹Šy‚àŽ~‚ß‚é
+			m_soundPlayer->stopBGM();
 		}
 		else {
 			delete m_gamePause;
 			m_gamePause = NULL;
+			m_soundPlayer->playBGM();
 		}
 	}
 	if (m_gamePause != NULL) {

--- a/Game.cpp
+++ b/Game.cpp
@@ -55,7 +55,7 @@ DoorData::DoorData(int x1, int y1, int x2, int y2, int from, int to, const char*
 GameData::GameData() {
 	m_saveFilePath = "data/save/savedata1.dat";
 
-	const bool test = true;
+	const bool test = false;
 
 	m_areaNum = 1;
 	m_storyNum = 1;

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -77,6 +77,11 @@ void SoundPlayer::pushSoundQueue(int soundHandle, int panPal) {
 	m_soundQueue.push(make_pair(soundHandle, panPal));
 }
 
+// Œø‰Ê‰¹‚ÌÄ¶‘Ò‹@—ñ‚ğƒNƒŠƒA
+void SoundPlayer::clearSoundQueue() {
+	queue<pair<int, int> >().swap(m_soundQueue);
+}
+
 // Œø‰Ê‰¹‚ğ–Â‚ç‚·
 void SoundPlayer::play() {
 	while (!m_soundQueue.empty()) {

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -59,7 +59,7 @@ void SoundPlayer::setBGM(std::string bgmName, int volume) {
 
 // BGMを再生
 void SoundPlayer::playBGM() {
-	PlaySoundMem(m_bgmHandle, DX_PLAYTYPE_LOOP);
+	PlaySoundMem(m_bgmHandle, DX_PLAYTYPE_LOOP, FALSE);
 }
 
 // BGMをストップ

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -67,6 +67,11 @@ void SoundPlayer::stopBGM() {
 	StopSoundMem(m_bgmHandle);
 }
 
+// BGMが再生していないか調べる
+int SoundPlayer::checkBGMplay() {
+	return CheckSoundMem(m_bgmHandle);
+}
+
 // 効果音の再生待機列へプッシュ
 void SoundPlayer::pushSoundQueue(int soundHandle, int panPal) {
 	m_soundQueue.push(make_pair(soundHandle, panPal));

--- a/Sound.h
+++ b/Sound.h
@@ -45,6 +45,9 @@ public:
 	// BGMをストップ
 	void stopBGM();
 
+	// BGMが再生していないか調べる
+	int checkBGMplay();
+
 	// 効果音の再生待機列へプッシュ
 	void pushSoundQueue(int soundHandle, int panPal = 0);
 

--- a/Sound.h
+++ b/Sound.h
@@ -51,6 +51,9 @@ public:
 	// 効果音の再生待機列へプッシュ
 	void pushSoundQueue(int soundHandle, int panPal = 0);
 
+	// 効果音の再生待機列をクリア
+	void clearSoundQueue();
+
 	// 効果音を鳴らす
 	void play();
 };

--- a/World.cpp
+++ b/World.cpp
@@ -85,6 +85,9 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) {
 	// 会話イベント
 	m_conversation_p = NULL;
 
+	// ムービー
+	m_movie_p = NULL;
+
 	// スキル発動中
 	m_skillFlag = false;
 
@@ -138,6 +141,7 @@ World::World(const World* original) {
 	m_duplicationFlag = true;
 	m_brightValue = 255;
 	m_conversation_p = NULL;
+	m_movie_p = NULL;
 	m_skillFlag = false;
 	m_areaNum = original->getAreaNum();
 
@@ -778,9 +782,21 @@ void World::atariAttackAndAttack() {
 // 会話させる
 void World::talk() {
 	if (m_conversation_p != NULL) {
+		m_conversation_p->play();
 		// 会話終了
-		if (m_conversation_p->play()) {
+		if (m_conversation_p->getFinishFlag()) {
 			m_conversation_p = NULL;
+		}
+	}
+}
+
+// ムービーを流す
+void World::moviePlay() {
+	if (m_movie_p != NULL) {
+		m_movie_p->play();
+		// ムービー終了
+		if (m_movie_p->getFinishFlag()) {
+			m_movie_p = NULL;
 		}
 	}
 }

--- a/World.cpp
+++ b/World.cpp
@@ -457,7 +457,9 @@ void World::setPlayerOnDoor(int from) {
 	// プレイヤーの仲間
 	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
 		const Character* follow = m_characterControllers[i]->getBrain()->getFollow();
+		// 追跡対象がプレイヤーなら
 		if (follow != nullptr && m_playerId == follow->getId()) {
+			// Controllerに対応するCharacterに変更を加える
 			for (unsigned int j = 0; j < m_characters.size(); j++) {
 				if (m_characterControllers[i]->getAction()->getCharacter()->getId() == m_characters[j]->getId()) {
 					m_characters[j]->setX(doorX1);
@@ -465,7 +467,6 @@ void World::setPlayerOnDoor(int from) {
 					break;
 				}
 			}
-			break;
 		}
 	}
 	cameraPointInit();

--- a/World.h
+++ b/World.h
@@ -20,6 +20,7 @@ class CharacterLoader;
 class ObjectLoader;
 class CharacterData;
 class DoorData;
+class Movie;
 
 
 class World {
@@ -32,6 +33,9 @@ private:
 
 	// 会話イベント EventElementクラスからもらう
 	Conversation* m_conversation_p;
+
+	// ムービー EventElementクラスからもらう
+	Movie* m_movie_p;
 
 	// スキル発動中はエリア間の移動できない
 	bool m_skillFlag;
@@ -98,6 +102,7 @@ public:
 	inline const int getBackGroundGraph() const { return m_backGroundGraph; }
 	inline const int getBackGroundColor() const { return m_backGroundColor; }
 	inline const Conversation* getConversation() const { return m_conversation_p; }
+	inline const Movie* getMovie() const { return m_movie_p; }
 	inline SoundPlayer* getSoundPlayer() const { return m_soundPlayer_p; }
 
 	// セッタ
@@ -116,6 +121,9 @@ public:
 
 	// キャラに会話させる
 	void talk();
+
+	// ムービーを流す
+	void moviePlay();
 
 	// キャラの状態を変更する いないなら作成する
 	void asignedCharacterData(const char* name, CharacterData* data);
@@ -143,6 +151,7 @@ public:
 	Character* getCharacterWithId(int id) const;
 	void setBrainWithId(int id, Brain* brain);
 	inline void setConversation(Conversation* conversation){ m_conversation_p = conversation; }
+	inline void setMovie(Movie* movie) { m_movie_p = movie; }
 	void pushCharacter(Character* character, CharacterController* controller);
 	void popCharacter(int id);
 	void createRecorder();

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -5,6 +5,7 @@
 #include "CharacterAction.h"
 #include "ObjectDrawer.h"
 #include "AnimationDrawer.h"
+#include "Animation.h"
 #include "TextDrawer.h"
 #include "Text.h"
 #include "Define.h"
@@ -123,6 +124,13 @@ void WorldDrawer::draw() {
 	m_targetDrawer.setEx(camera->getEx());
 	m_targetDrawer.draw();
 	SetDrawBright(255, 255, 255);
+
+	// ムービー
+	const Movie* movie = m_world->getMovie();
+	if (movie != NULL) {
+		m_animationDrawer->setAnimation(movie->getAnimation());
+		m_animationDrawer->drawAnimation();
+	}
 
 	// テキストイベント
 	const Conversation* conversation = m_world->getConversation();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り。
テキストイベントと同じ要領でムービーイベントも実現させる。

その他、AIを少し修正。

# やったこと
Movieクラスを作成。派生クラスにOPクラスを作成。
Animationクラスを使って動画を作る。
SoundPlayerクラスを修正。一時停止時にBGMを止め、解除時に途中から再生する。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
![op](https://github.com/kuriuminoki/DuplicationHeart/assets/92528385/f660f1fc-644e-41bf-97ad-03acbbfd04ca)

# 懸念点
ムービーが終わった後、ムービー用のBGMが繰り返し流れてしまうので、EventElement？が終了時にBGMを元に戻すべき。
