### PR TITLE
解像度変更に対応してテキストの表示位置が調整される機能

### DIFF
--- a/Define.h
+++ b/Define.h
@@ -11,12 +11,12 @@ static int MOUSE_DISP = FALSE;
 //‰æ–Ê‚Ì‘å‚«‚³
 //#define GAME_WIDE 3840
 //#define GAME_HEIGHT 2160
-//#define GAME_WIDE 2560
-//#define GAME_HEIGHT 1600
+#define GAME_WIDE 2560
+#define GAME_HEIGHT 1600
 //#define GAME_WIDE 2560
 //#define GAME_HEIGHT 1440
-#define GAME_WIDE 1920
-#define GAME_HEIGHT 1080
+//#define GAME_WIDE 1920
+//#define GAME_HEIGHT 1080
 //#define GAME_WIDE 1240
 //#define GAME_HEIGHT 1024
 

--- a/Define.h
+++ b/Define.h
@@ -9,10 +9,16 @@ static int WINDOW = TRUE;
 static int MOUSE_DISP = FALSE;
 
 //âÊñ ÇÃëÂÇ´Ç≥
-//#define GAME_WIDE 1920
-//#define GAME_HEIGHT 1080
-#define GAME_WIDE 1240
-#define GAME_HEIGHT 1024
+//#define GAME_WIDE 3840
+//#define GAME_HEIGHT 2160
+//#define GAME_WIDE 2560
+//#define GAME_HEIGHT 1600
+//#define GAME_WIDE 2560
+//#define GAME_HEIGHT 1440
+#define GAME_WIDE 1920
+#define GAME_HEIGHT 1080
+//#define GAME_WIDE 1240
+//#define GAME_HEIGHT 1024
 
 // DrawFormatStringä÷êîÇ≈ï\é¶Ç≥ÇÍÇÈï∂éöÇÃëÂÇ´Ç≥ÇÕ20Ç≠ÇÁÇ¢
 #define DRAW_FORMAT_STRING_SIZE 20

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -13,11 +13,13 @@ ConversationDrawer::ConversationDrawer(Conversation* conversation) {
 
 	m_conversation = conversation;
 
-	// フォントデータ
-	m_textHandle = CreateFontToHandle(nullptr, TEXT_SIZE, 3);
-	m_nameHandle = CreateFontToHandle(nullptr, NAME_SIZE, 5);
+	m_ex = GAME_WIDE / 1920.0;
 
-	// 画像
+	// フォントデータ
+	m_textHandle = CreateFontToHandle(nullptr, (int)(TEXT_SIZE * m_ex), 3);
+	m_nameHandle = CreateFontToHandle(nullptr, (int)(NAME_SIZE * m_ex), 5);
+
+	// 吹き出し画像
 	m_frameHandle = LoadGraph("picture/textMaterial/frame.png");
 }
 
@@ -33,44 +35,50 @@ void ConversationDrawer::draw() {
 	string text = m_conversation->getText();
 	string name = m_conversation->getSpeakerName();
 	GraphHandle* graph = m_conversation->getGraph();
+
+	// キャラの顔画像は正方形を想定
 	int graphSize = 0;
 	GetGraphSize(graph->getHandle(), &graphSize, &graphSize);
-
-	// 端の余白
-	static const int EDGE = 52;
+	graphSize = (int)(graphSize * m_ex);
 
 	// フキダシのフチの幅
-	static const int TEXT_GRAPH_EDGE = 32;
+	static const int TEXT_GRAPH_EDGE = (int)(35 * m_ex);
+
+	// 端の余白
+	static const int EDGE_X = (int)(48 * m_ex);
+	static const int EDGE_DOWN = (int)(48 * m_ex);
 
 	// 上端
-	static const int Y1 = 551;
+	static const int Y1 = GAME_HEIGHT - EDGE_DOWN - graphSize - (TEXT_GRAPH_EDGE * 2);
 
 	// 会話終了時
 	int finishCnt = m_conversation->getFinishCnt() * 8;
+	if ((Y1 + finishCnt) > (GAME_HEIGHT - EDGE_DOWN - finishCnt)) { return; }
 	if (finishCnt > 0) {
 		// フキダシ
-		DrawExtendGraph(EDGE, Y1 + finishCnt, GAME_WIDE - EDGE, GAME_HEIGHT - EDGE - finishCnt, m_frameHandle, TRUE);
+		DrawExtendGraph(EDGE_X, Y1 + finishCnt, GAME_WIDE - EDGE_X, GAME_HEIGHT - EDGE_DOWN - finishCnt, m_frameHandle, TRUE);
 		return;
 	}
 
 	// フキダシ
-	DrawExtendGraph(EDGE, Y1, GAME_WIDE - EDGE, GAME_HEIGHT - EDGE, m_frameHandle, TRUE);
+	DrawExtendGraph(EDGE_X, Y1, GAME_WIDE - EDGE_X, GAME_HEIGHT - EDGE_DOWN, m_frameHandle, TRUE);
 
 	// 名前
-	DrawStringToHandle(EDGE * 2 + graphSize, GAME_HEIGHT - EDGE - NAME_SIZE - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
+	DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE + graphSize + NAME_SIZE, GAME_HEIGHT - EDGE_DOWN - NAME_SIZE - TEXT_GRAPH_EDGE - (int)(30 * m_ex), name.c_str(), BLACK, m_nameHandle);
 
 	// テキスト
 	int now = 0;
 	int i = 0;
+	static const int CHAR_EDGE = (int)(30 * m_ex);
 	while (now < text.size()) {
 		int next = now + min(MAX_TEXT_LEN, (int)text.size() - now);
 		string disp = text.substr(now, next - now);
-		DrawStringToHandle(EDGE * 3 + graphSize, Y1 + 5 + EDGE + (i * (TEXT_SIZE + 10)), disp.c_str(), BLACK, m_textHandle);
+		DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize, Y1  + TEXT_GRAPH_EDGE + (i * (TEXT_SIZE + CHAR_EDGE)), disp.c_str(), BLACK, m_textHandle);
 		now = next;
 		i++;
 	}
 
 	// キャラの顔画像
-	graph->draw(EDGE + TEXT_GRAPH_EDGE + graphSize / 2, Y1 + TEXT_GRAPH_EDGE + graphSize / 2, 1.0);
+	graph->draw(EDGE_X + TEXT_GRAPH_EDGE + graphSize / 2, Y1 + TEXT_GRAPH_EDGE + graphSize / 2, m_ex);
 
 }

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -64,7 +64,7 @@ void ConversationDrawer::draw() {
 	DrawExtendGraph(EDGE_X, Y1, GAME_WIDE - EDGE_X, GAME_HEIGHT - EDGE_DOWN, m_frameHandle, TRUE);
 
 	// 名前
-	DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE + graphSize + NAME_SIZE, GAME_HEIGHT - EDGE_DOWN - NAME_SIZE - TEXT_GRAPH_EDGE - (int)(30 * m_ex), name.c_str(), BLACK, m_nameHandle);
+	DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE + graphSize + NAME_SIZE * m_ex, GAME_HEIGHT - EDGE_DOWN - NAME_SIZE * m_ex - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
 
 	// テキスト
 	int now = 0;
@@ -73,7 +73,7 @@ void ConversationDrawer::draw() {
 	while (now < text.size()) {
 		int next = now + min(MAX_TEXT_LEN, (int)text.size() - now);
 		string disp = text.substr(now, next - now);
-		DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize, Y1  + TEXT_GRAPH_EDGE + (i * (TEXT_SIZE + CHAR_EDGE)), disp.c_str(), BLACK, m_textHandle);
+		DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize, Y1  + TEXT_GRAPH_EDGE + (i * (TEXT_SIZE * m_ex + CHAR_EDGE)), disp.c_str(), BLACK, m_textHandle);
 		now = next;
 		i++;
 	}

--- a/TextDrawer.h
+++ b/TextDrawer.h
@@ -10,6 +10,9 @@ private:
 	
 	// 会話
 	const Conversation* m_conversation;
+
+	// テキストやフォントのサイズの倍率
+	double m_ex;
 	
 	// フォント（テキスト）
 	int m_textHandle;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#71 への対応

テキストイベント中、ゲームの解像度（画面の大きさ）に合わせてキャラの顔画像、名前、セリフがちょうどよい大きさではみ出ないように表示する。

# やったこと
画面の横の大きさに応じて文字や顔画像のサイズを変える。具体的には、1920を1.0倍とする。

# やらないこと
将来的にはゲーム内での解像度の変更機能も実装したい。

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
