### PR TITLE
Api: キャラのY座標のセーブデータ(Y1)をY2に変更

### DIFF
--- a/CharacterLoader.cpp
+++ b/CharacterLoader.cpp
@@ -25,7 +25,6 @@ void CharacterLoader::addCharacter(map<string, string> dataMap) {
 	if (dataMap.find("area") != dataMap.end()) {
 		areaNum = stoi(dataMap["area"]);
 	}
-	dataMap["initFlag"] = "false";
 	m_characters[areaNum].push_back(dataMap);
 }
 
@@ -35,7 +34,6 @@ pair<vector<Character*>, vector<CharacterController*> > CharacterLoader::getChar
 	pair<vector<Character*>, vector<CharacterController*> > res;
 
 	for (unsigned int i = 0; i < m_characters[areaNum].size(); i++) {
-		m_characters[areaNum][i]["initFlag"] = "true";
 		string name = m_characters[areaNum][i]["name"];
 		int x = stoi(m_characters[areaNum][i]["x"]);
 		int y = stoi(m_characters[areaNum][i]["y"]);
@@ -91,9 +89,7 @@ void CharacterLoader::saveCharacterData(CharacterData* characterData) {
 		int areaNum = it->first;
 		vector<map<string, string> > characters = it->second;
 		for (unsigned int i = 0; i < characters.size(); i++) {
-			if (characters[i]["initFlag"] == "true") { continue; }
 			if (characters[i]["name"] == characterData->name()) {
-				characterData->setInitFlag(false);
 				characterData->setAreaNum(areaNum);
 				characterData->setX(stoi(characters[i]["x"]));
 				characterData->setY(stoi(characters[i]["y"]));

--- a/Define.h
+++ b/Define.h
@@ -11,12 +11,12 @@ static int MOUSE_DISP = FALSE;
 //‰æ–Ê‚Ì‘å‚«‚³
 //#define GAME_WIDE 3840
 //#define GAME_HEIGHT 2160
-#define GAME_WIDE 2560
-#define GAME_HEIGHT 1600
+//#define GAME_WIDE 2560
+//#define GAME_HEIGHT 1600
 //#define GAME_WIDE 2560
 //#define GAME_HEIGHT 1440
-//#define GAME_WIDE 1920
-//#define GAME_HEIGHT 1080
+#define GAME_WIDE 1920
+#define GAME_HEIGHT 1080
 //#define GAME_WIDE 1240
 //#define GAME_HEIGHT 1024
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -20,7 +20,6 @@ using namespace std;
 * キャラのデータ
 */
 CharacterData::CharacterData(const char* name) {
-	m_initFlag = false;
 	m_name = name;
 	m_hp = -1;
 	// id=-1はデータなしを意味する
@@ -38,7 +37,6 @@ CharacterData::CharacterData(const char* name) {
 
 // セーブ
 void CharacterData::save(FILE* intFp, FILE* strFp) {
-	fwrite(&m_initFlag, sizeof(m_initFlag), 1, intFp);
 	fwrite(&m_hp, sizeof(m_hp), 1, intFp);
 	fwrite(&m_id, sizeof(m_id), 1, intFp);
 	fwrite(&m_groupId, sizeof(m_groupId), 1, intFp);
@@ -57,7 +55,6 @@ void CharacterData::save(FILE* intFp, FILE* strFp) {
 
 // ロード
 void CharacterData::load(FILE* intFp, FILE* strFp) {
-	fread(&m_initFlag, sizeof(m_initFlag), 1, intFp);
 	fread(&m_hp, sizeof(m_hp), 1, intFp);
 	fread(&m_id, sizeof(m_id), 1, intFp);
 	fread(&m_groupId, sizeof(m_groupId), 1, intFp);

--- a/Game.h
+++ b/Game.h
@@ -15,9 +15,6 @@ class GamePause;
 class CharacterData {
 private:
 
-	// 初期化済みか(Y座標の調整のために必要)一度でもキャラが生成されるとtrue
-	bool m_initFlag;
-
 	// 名前
 	std::string m_name;
 
@@ -62,7 +59,6 @@ public:
 	void load(FILE* intFp, FILE* strFp);
 
 	// ゲッタ
-	inline bool initFlag() const { return m_initFlag; }
 	inline const char* name() const { return m_name.c_str(); }
 	inline int hp() const { return m_hp; }
 	inline int id() const { return m_id; }
@@ -78,7 +74,6 @@ public:
 	inline std::string controllerName() const { return m_controllerName; }
 
 	// セッタ
-	inline void setInitFlag(bool initFlag) { m_initFlag = initFlag; }
 	inline void setHp(int hp) { m_hp = hp; }
 	inline void setId(int id) { m_id = id; }
 	inline void setGroupId(int groupId) { m_groupId = groupId; }

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -64,7 +64,7 @@ void ConversationDrawer::draw() {
 	DrawExtendGraph(EDGE_X, Y1, GAME_WIDE - EDGE_X, GAME_HEIGHT - EDGE_DOWN, m_frameHandle, TRUE);
 
 	// 名前
-	DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE + graphSize + NAME_SIZE * m_ex, GAME_HEIGHT - EDGE_DOWN - NAME_SIZE * m_ex - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
+	DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE + graphSize + (int)(NAME_SIZE * m_ex), GAME_HEIGHT - EDGE_DOWN - (int)(NAME_SIZE * m_ex) - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
 
 	// テキスト
 	int now = 0;
@@ -73,7 +73,7 @@ void ConversationDrawer::draw() {
 	while (now < text.size()) {
 		int next = now + min(MAX_TEXT_LEN, (int)text.size() - now);
 		string disp = text.substr(now, next - now);
-		DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize, Y1  + TEXT_GRAPH_EDGE + (i * (TEXT_SIZE * m_ex + CHAR_EDGE)), disp.c_str(), BLACK, m_textHandle);
+		DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize, Y1  + TEXT_GRAPH_EDGE + (i * ((int)(TEXT_SIZE * m_ex) + CHAR_EDGE)), disp.c_str(), BLACK, m_textHandle);
 		now = next;
 		i++;
 	}

--- a/World.cpp
+++ b/World.cpp
@@ -299,13 +299,8 @@ void World::asignedCharacter(Character* character, CharacterData* data) {
 	//character->setId(data.id());
 	character->setGroupId(data->groupId());
 	character->setX(data->x());
-	if (data->initFlag()) {
-		character->setY(data->y());
-	}
-	else {
-		// 座標が変更されたので身長に合わせて調整
-		character->setY(data->y() - character->getHeight());
-	}
+	// Y座標は身長に合わせて調整
+	character->setY(data->y() - character->getHeight());
 }
 
 // コントローラ1個の情報を世界に反映
@@ -371,13 +366,12 @@ void World::asignCharacterData(const char* name, CharacterData* data, int fromAr
 	for (unsigned i = 0; i < size; i++) {
 		if (m_characterControllers[i]->getAction()->getCharacter()->getName() == name) {
 			const Character* c = m_characterControllers[i]->getAction()->getCharacter();
-			data->setInitFlag(true);
 			data->setHp(c->getHp());
 			data->setId(c->getId());
 			data->setGroupId(c->getGroupId());
 			data->setAreaNum(fromAreaNum);
 			data->setX(c->getX());
-			data->setY(c->getY());
+			data->setY(c->getY() + c->getHeight()); // Y2座標を保存 ロード時は身長で補正
 			data->setBrainName(m_characterControllers[i]->getBrain()->getBrainName());
 			data->setTargetName(m_characterControllers[i]->getBrain()->getTargetName());
 			if (m_characterControllers[i]->getBrain()->getFollow() != nullptr) {


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#74 の対応

今まではキャラのY1座標をセーブしていた。csvファイルにはY2座標が記述されるので、そこからロードするときだけは-身長して座標を補正していた。

これが複雑なうえ、以下の問題もある。

- セーブ時のキャラのポーズによって身長が変わりY1座標も変わる。ロード時は必ず立ち状態スタートのため、少し宙に浮いたり地面に埋まった状態からスタートしてしまう。

対策として、Y2座標をセーブするように変更。csvファイルから読み込んだかは関係なくなるので、GameData::initFlagも必要なって削除できる。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
実際にセーブ・ロードやエリア移動をして問題ないことを確認した。

# 懸念点
記入欄
