### PR TITLE
Api: 画面の解像度を調節する機能実装の前準備

### DIFF
--- a/Define.cpp
+++ b/Define.cpp
@@ -1,0 +1,2 @@
+int GAME_WIDE = 1920;
+int GAME_HEIGHT = 1080;

--- a/Define.h
+++ b/Define.h
@@ -15,10 +15,10 @@ static int MOUSE_DISP = FALSE;
 //#define GAME_HEIGHT 1600
 //#define GAME_WIDE 2560
 //#define GAME_HEIGHT 1440
-#define GAME_WIDE 1920
-#define GAME_HEIGHT 1080
-//#define GAME_WIDE 1240
-//#define GAME_HEIGHT 1024
+//#define GAME_WIDE 1920
+//#define GAME_HEIGHT 1080
+#define GAME_WIDE 1240
+#define GAME_HEIGHT 1024
 
 // DrawFormatStringä÷êîÇ≈ï\é¶Ç≥ÇÍÇÈï∂éöÇÃëÂÇ´Ç≥ÇÕ20Ç≠ÇÁÇ¢
 #define DRAW_FORMAT_STRING_SIZE 20

--- a/Define.h
+++ b/Define.h
@@ -17,8 +17,12 @@ static int MOUSE_DISP = FALSE;
 //#define GAME_HEIGHT 1440
 //#define GAME_WIDE 1920
 //#define GAME_HEIGHT 1080
-#define GAME_WIDE 1240
-#define GAME_HEIGHT 1024
+#define GAME_WIDE_MAX 3840
+#define GAME_HEIGHT_MAX 2160
+#define GAME_WIDE_MIN 640
+#define GAME_HEIGHT_MIN 480
+extern int GAME_WIDE;
+extern int GAME_HEIGHT;
 
 // DrawFormatStringä÷êîÇ≈ï\é¶Ç≥ÇÍÇÈï∂éöÇÃëÂÇ´Ç≥ÇÕ20Ç≠ÇÁÇ¢
 #define DRAW_FORMAT_STRING_SIZE 20

--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -165,6 +165,7 @@
     <ClCompile Include="ControllerRecorder.cpp" />
     <ClCompile Include="CsvReader.cpp" />
     <ClCompile Include="Debug.cpp" />
+    <ClCompile Include="Define.cpp" />
     <ClCompile Include="Event.cpp" />
     <ClCompile Include="Game.cpp" />
     <ClCompile Include="GameDrawer.cpp" />

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClCompile Include="PausePage.cpp">
       <Filter>ソース ファイル\pages</Filter>
     </ClCompile>
+    <ClCompile Include="Define.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">

--- a/Main.cpp
+++ b/Main.cpp
@@ -44,19 +44,30 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	SetWindowSizeChangeEnableFlag(TRUE);//windowサイズ変更可能
 	SetUseDirectInputFlag(TRUE);
 	SetGraphMode(GAME_WIDE, GAME_HEIGHT, 16);
+
 	ChangeWindowMode(WINDOW), DxLib_Init(), SetDrawScreen(DX_SCREEN_BACK);
+	
 	//SetAlwaysRunFlag(TRUE);//画面を常にアクティブ
+
+	// ウィンドウの名前
 	SetMainWindowText("複製のHeart");
+
 	////マウス関連////
 	SetMouseDispFlag(MOUSE_DISP);//マウス表示
 	//SetMousePoint(320, 240);//マウスカーソルの初期位置
+	
+	// 画像の拡大処理方式
 	//SetDrawMode(DX_DRAWMODE_BILINEAR);
 	SetDrawMode(DX_DRAWMODE_NEAREST);
-	//ゲーム本体
+	SetFullScreenScalingMode(DX_DRAWMODE_NEAREST);
+
+	// ゲーム本体
 	Game game;
 	// ゲーム描画用
 	GameDrawer* gameDrawer = new GameDrawer(&game);
-	bool title_flag = false;//trueならタイトル画面終了
+
+	
+
 	while (ScreenFlip() == 0 && ProcessMessage() == 0 && ClearDrawScreen() == 0)
 	{
 		updateKey();

--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -6,49 +6,90 @@
 #include "DxLib.h"
 
 
-GamePause::GamePause(SoundPlayer* soundPlayer) {
-	m_soundPlayer_p = soundPlayer;
-	m_soundBarButton = new Button("", 100, 450, 50, 100, WHITE, GRAY, -1, BLACK);
-	m_handX = 0;
-	m_handY = 0;
-	m_soundFlag = false;
+ControlBar::ControlBar(int x1, int y1, int x2, int y2, int minValue, int maxValue, int initValue) {
+	m_drawX1 = x1;
+	m_drawY1 = y1;
+	m_drawX2 = x2;
+	m_drawY2 = y2;
+
+	m_drawWide = m_drawX2 - m_drawX1;
+	m_drawHeight = m_drawY2 - m_drawY1;
+
+	m_minValue = minValue;
+	m_maxValue = maxValue;
+	m_nowValue = initValue;
+
+	m_buttonWide = m_drawWide / 10;
+	m_controlButton = new Button("", m_drawX1, m_drawY1, m_buttonWide, m_drawHeight, WHITE, GRAY, -1, BLACK);
+	m_buttonWide /= 2;
+
+	m_controlFlag = false;
 }
 
-void GamePause::play() {
-	// マウスカーソルの位置取得
-	GetMousePoint(&m_handX, &m_handY);
+// 調整する
+void ControlBar::play(int handX, int handY) {
 
 	// 左クリック
 	int click = leftClick();
 
-	// 音量調節
-	if (click > 0 && m_soundBarButton->overlap(m_handX, m_handY)) {
-		m_soundFlag = true;
+	// 調節中のON/OFF
+	if (click > 0 && m_controlButton->overlap(handX, handY)) {
+		m_controlFlag = true;
 	}
 	if (click == 0) {
-		m_soundFlag = false;
+		m_controlFlag = false;
 	}
 
-	int length = SOUND_RIGHT_LIMIT - SOUND_LEFT_LIMIT;
-	if (m_soundFlag) {
-		int rate = (m_handX - SOUND_LEFT_LIMIT) * 100 / length;
-		m_soundPlayer_p->setVolume(rate);
+	// マウスの座標に合わせて値を更新
+	if (m_controlFlag) {
+		if (handX > m_drawX2) { m_nowValue = m_maxValue; }
+		else if (handX < m_drawX1) { m_nowValue = m_minValue; }
+		else {
+			int rate = (handX - m_drawX1) * 100 / m_drawWide;
+			m_nowValue = (m_maxValue - m_minValue) * rate / 100;
+		}
 	}
 
-	int soundVolume = m_soundPlayer_p->getVolume();
-	m_soundBarButton->setX(SOUND_LEFT_LIMIT + soundVolume * length / 100 - m_soundBarButton->getWide() / 2);
+	// 値に合わせてボタンの位置を更新
+	m_controlButton->setX(m_drawX1 + m_nowValue * m_drawWide / 100 - m_controlButton->getWide() / 2);
+}
+
+// 描画
+void ControlBar::draw(int handX, int handY) {
+	// 音量調節領域
+	DrawBox(m_drawX1 - m_buttonWide - 10, m_drawY1 - 10, m_drawX2 + m_buttonWide + 10, m_drawY2 + 10, BLACK, TRUE);
+	DrawBox(m_drawX1 - m_buttonWide, m_drawY1, m_drawX2 + m_buttonWide, m_drawY2, GRAY2, TRUE);
+
+	// ボタンの移動範囲
+	DrawBox(m_drawX1, (m_drawY1 + m_drawY2) / 2 - 10, m_drawX2, (m_drawY1 + m_drawY2) / 2 + 10, BLACK, TRUE);
+
+	// 音量調節ボタン
+	m_controlButton->draw(handX, handY);
+}
+
+
+GamePause::GamePause(SoundPlayer* soundPlayer) {
+	m_soundPlayer_p = soundPlayer;
+	m_soundController = new ControlBar(SOUND_X1, SOUND_Y1, SOUND_X2, SOUND_Y2, SOUND_MIN, SOUND_MAX, m_soundPlayer_p->getVolume());
+	m_handX = 0;
+	m_handY = 0;
+}
+
+GamePause::~GamePause() {
+	delete m_soundController;
+}
+
+void GamePause::play() {
+
+	// マウスカーソルの位置取得
+	GetMousePoint(&m_handX, &m_handY);
+
+	m_soundController->play(m_handX, m_handY);
+	m_soundPlayer_p->setVolume(m_soundController->getNowValue());
 }
 
 void GamePause::draw() const {
 
-	// 音量調節領域
-	DrawBox(SOUND_LEFT_LIMIT - 60, SOUND_Y - 110, SOUND_RIGHT_LIMIT + 60, SOUND_Y + 110, BLACK, TRUE);
-	DrawBox(SOUND_LEFT_LIMIT - 50, SOUND_Y - 100, SOUND_RIGHT_LIMIT + 50, SOUND_Y + 100, GRAY2, TRUE);
-
-	// ボタンの移動範囲
-	DrawBox(SOUND_LEFT_LIMIT, SOUND_Y - 10, SOUND_RIGHT_LIMIT, SOUND_Y + 10, BLACK, TRUE);
-
-	// 音量調節ボタン
-	m_soundBarButton->draw(m_handX, m_handY);
+	m_soundController->draw(m_handX, m_handY);
 
 }

--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -7,10 +7,14 @@
 
 
 ControlBar::ControlBar(int x1, int y1, int x2, int y2, int minValue, int maxValue, int initValue) {
-	m_drawX1 = x1;
-	m_drawY1 = y1;
-	m_drawX2 = x2;
-	m_drawY2 = y2;
+	
+	m_exX = GAME_WIDE / 1920.0;
+	m_exY = GAME_HEIGHT / 1080.0;
+
+	m_drawX1 = (int)(x1 * m_exX);
+	m_drawY1 = (int)(y1 * m_exY);
+	m_drawX2 = (int)(x2 * m_exX);
+	m_drawY2 = (int)(y2 * m_exY);
 
 	m_drawWide = m_drawX2 - m_drawX1;
 	m_drawHeight = m_drawY2 - m_drawY1;
@@ -42,32 +46,46 @@ void ControlBar::play(int handX, int handY) {
 
 	// マウスの座標に合わせて値を更新
 	if (m_controlFlag) {
-		if (handX > m_drawX2) { m_nowValue = m_maxValue; }
-		else if (handX < m_drawX1) { m_nowValue = m_minValue; }
+		if (handX > m_drawX2) { 
+			m_nowValue = m_maxValue;
+		}
+		else if (handX < m_drawX1) { 
+			m_nowValue = m_minValue;
+		}
 		else {
 			int rate = (handX - m_drawX1) * 100 / m_drawWide;
-			m_nowValue = (m_maxValue - m_minValue) * rate / 100;
+			m_nowValue = m_minValue + (rate * (m_maxValue - m_minValue) / 100);
 		}
 	}
 
+	int rate = (m_nowValue - m_minValue) * 100 / (m_maxValue - m_minValue);
+
 	// 値に合わせてボタンの位置を更新
-	m_controlButton->setX(m_drawX1 + m_nowValue * m_drawWide / 100 - m_controlButton->getWide() / 2);
+	m_controlButton->setX(m_drawX1 + rate * m_drawWide / 100 - m_controlButton->getWide() / 2);
 }
 
 // 描画
 void ControlBar::draw(int handX, int handY) {
+	int d = (int)(10 * m_exX);
+
 	// 音量調節領域
-	DrawBox(m_drawX1 - m_buttonWide - 10, m_drawY1 - 10, m_drawX2 + m_buttonWide + 10, m_drawY2 + 10, BLACK, TRUE);
+	DrawBox(m_drawX1 - m_buttonWide - d, m_drawY1 - d, m_drawX2 + m_buttonWide + d, m_drawY2 + d, BLACK, TRUE);
 	DrawBox(m_drawX1 - m_buttonWide, m_drawY1, m_drawX2 + m_buttonWide, m_drawY2, GRAY2, TRUE);
 
 	// ボタンの移動範囲
-	DrawBox(m_drawX1, (m_drawY1 + m_drawY2) / 2 - 10, m_drawX2, (m_drawY1 + m_drawY2) / 2 + 10, BLACK, TRUE);
+	DrawBox(m_drawX1, (m_drawY1 + m_drawY2) / 2 - d, m_drawX2, (m_drawY1 + m_drawY2) / 2 + d, BLACK, TRUE);
 
 	// 音量調節ボタン
 	m_controlButton->draw(handX, handY);
+
+	// DrawFormatString(m_drawX1, m_drawY1 - 50, BLACK, "Value = %d, x = %d", m_nowValue, m_drawX1 + m_nowValue * m_drawWide / 100 - m_controlButton->getWide() / 2);
 }
 
 
+
+/*
+* 一時停止画面
+*/
 GamePause::GamePause(SoundPlayer* soundPlayer) {
 	m_soundPlayer_p = soundPlayer;
 	m_soundController = new ControlBar(SOUND_X1, SOUND_Y1, SOUND_X2, SOUND_Y2, SOUND_MIN, SOUND_MAX, m_soundPlayer_p->getVolume());
@@ -86,10 +104,44 @@ void GamePause::play() {
 
 	m_soundController->play(m_handX, m_handY);
 	m_soundPlayer_p->setVolume(m_soundController->getNowValue());
+
 }
 
 void GamePause::draw() const {
 
 	m_soundController->draw(m_handX, m_handY);
+
+}
+
+
+
+/*
+* タイトル画面からいけるオプション画面　GamePauseの機能＋解像度の変更もできる。
+*/
+TitleOption::TitleOption(SoundPlayer* soundPlayer) :
+	GamePause(soundPlayer)
+{
+	m_gameWideController = new ControlBar(WIDE_X1, WIDE_Y1, WIDE_X2, WIDE_Y2, GAME_WIDE_MIN, GAME_WIDE_MAX, GAME_WIDE);
+	m_gameHeightController = new ControlBar(HEIGHT_X1, HEIGHT_Y1, HEIGHT_X2, HEIGHT_Y2, GAME_HEIGHT_MIN, GAME_HEIGHT_MAX, GAME_HEIGHT);
+	m_newWide = GAME_WIDE;
+	m_newHeight = GAME_HEIGHT;
+}
+
+void TitleOption::play() {
+
+	GamePause::play();
+
+	m_gameWideController->play(m_handX, m_handY);
+	m_gameHeightController->play(m_handX, m_handY);
+	m_newWide = m_gameWideController->getNowValue();
+	m_newHeight = m_gameHeightController->getNowValue();
+}
+
+void TitleOption::draw() const {
+
+	GamePause::draw();
+
+	m_gameWideController->draw(m_handX, m_handY);
+	m_gameHeightController->draw(m_handX, m_handY);
 
 }

--- a/PausePage.h
+++ b/PausePage.h
@@ -6,27 +6,67 @@ class Button;
 class SoundPlayer;
 
 
+// マウスでボタンを左右に動かして値を調整する機能
+class ControlBar {
+
+	// 描画範囲
+	int m_drawX1;
+	int m_drawY1;
+	int m_drawX2;
+	int m_drawY2;
+
+	int m_drawWide;
+	int m_drawHeight;
+
+	// 調節幅
+	int m_minValue;
+	int m_maxValue;
+	int m_nowValue;
+
+	// 調整用のボタン
+	Button* m_controlButton;
+	int m_buttonWide;
+
+	// 今調整中（左クリック長押し中）
+	bool m_controlFlag;
+
+public:
+	ControlBar(int x1, int y1, int x2, int y2, int minValue, int maxValue, int initValue);
+
+	// 調整する
+	void play(int handX, int handY);
+
+	// 描画
+	void draw(int handX, int handY);
+	
+	// ゲッタ
+	inline int getNowValue() { return m_nowValue; }
+};
+
+
+// ポーズ画面
 class GamePause {
 private:
-
-	// 音量調節の対象
-	SoundPlayer* m_soundPlayer_p;
 
 	// マウスカーソルの位置
 	int m_handX, m_handY;
 
-	// 音量調節用
-	Button* m_soundBarButton;
+	// 音量調節機能
+	ControlBar* m_soundController;
 
-	// 今調整中
-	bool m_soundFlag;
+	// 音量調節の対象
+	SoundPlayer* m_soundPlayer_p;
 
-	const int SOUND_LEFT_LIMIT = 100;
-	const int SOUND_RIGHT_LIMIT = 1100;
-	const int SOUND_Y = 500;
+	const int SOUND_X1 = 100;
+	const int SOUND_Y1 = 400;
+	const int SOUND_X2 = 1100;
+	const int SOUND_Y2 = 600;
+	const int SOUND_MIN = 0;
+	const int SOUND_MAX = 100;
 
 public:
 	GamePause(SoundPlayer* soundPlayer);
+	~GamePause();
 
 	void play();
 

--- a/PausePage.h
+++ b/PausePage.h
@@ -9,6 +9,11 @@ class SoundPlayer;
 // マウスでボタンを左右に動かして値を調整する機能
 class ControlBar {
 
+	// 1920を基準としたGAME_WIDEの倍率
+	double m_exX;
+	// 1080を基準としたGAME_HEIGHTの倍率
+	double m_exY;
+
 	// 描画範囲
 	int m_drawX1;
 	int m_drawY1;
@@ -46,10 +51,12 @@ public:
 
 // ポーズ画面
 class GamePause {
-private:
+protected:
 
 	// マウスカーソルの位置
 	int m_handX, m_handY;
+
+private:
 
 	// 音量調節機能
 	ControlBar* m_soundController;
@@ -59,7 +66,7 @@ private:
 
 	const int SOUND_X1 = 100;
 	const int SOUND_Y1 = 400;
-	const int SOUND_X2 = 1100;
+	const int SOUND_X2 = 600;
 	const int SOUND_Y2 = 600;
 	const int SOUND_MIN = 0;
 	const int SOUND_MAX = 100;
@@ -71,6 +78,43 @@ public:
 	void play();
 
 	void draw() const;
+};
+
+
+/*
+* タイトル画面からいけるオプション画面 解像度も変えられる
+*/
+class TitleOption :
+	public GamePause 
+{
+	// 解像度調節機能
+	ControlBar* m_gameWideController;
+	ControlBar* m_gameHeightController;
+
+	int m_newWide;
+	int m_newHeight;
+
+	const int WIDE_X1 = 800;
+	const int WIDE_Y1 = 400;
+	const int WIDE_X2 = 1300;
+	const int WIDE_Y2 = 600;
+
+	const int HEIGHT_X1 = 800;
+	const int HEIGHT_Y1 = 800;
+	const int HEIGHT_X2 = 1300;
+	const int HEIGHT_Y2 = 1000;
+
+public:
+	TitleOption(SoundPlayer* soundPlayer);
+
+	void play();
+
+	void draw() const;
+
+	// ゲッタ
+	inline int getNewGameWide() { return m_newWide; }
+	inline int getNewGameHeight() { return m_newHeight; }
+
 };
 
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
できるかはわからない。DxLibの仕様次第。

# やったこと
音量調節機能と同じ要領で実現する。

前段階としてボタンをスライドさせ値を調節する機能を新たなクラスとして一時停止画面のクラスから分離。

要するにリファクタリング。

解像度の変更時には画像をすべてロードしなおさないといけないらしい。加えて、CameraクラスはコンストラクタでGAME_WIDEとGAME_HEIGHTを使って初期化されるので、カメラも設定しなおす必要があるなど、解像度変更はゲーム全体に与える影響が大きい。

さすがにだるすぎるので、画像をほとんどロードする前のタイトル画面でのみ変更できるようにする。

しかしまだタイトル画面がないので、実装するのはまた今度。

とりあえずGamePauseクラスを継承したTitleOptionクラスを作成。GamePauseの音量調節機能に加えて解像度の変更機能も持っている一時停止画面。タイトル画面から遷移できる想定。タイトル画面が完成したら動作確認する。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
解像度を細かく調整できすぎると不都合が生じないか心配。
