### PR TITLE
Api: タイトル・オプション・セーブデータ選択画面の実装

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -63,6 +63,9 @@ GraphHandle* Animation::getHandle() const {
 * 動画の基底クラス
 */
 Movie::Movie(SoundPlayer* soundPlayer_p) {
+	double exX, exY;
+	getGameEx(exX, exY);
+	m_ex = min(exX, exY);
 	m_finishFlag = false;
 	m_cnt = 0;
 	m_animation = nullptr;
@@ -75,6 +78,25 @@ Movie::~Movie() {
 	}
 }
 
+void Movie::play() {
+
+	m_cnt++;
+
+	// メイン画像
+	m_animation->count();
+
+	// サブ画像
+	unsigned int size = (unsigned int)m_subAnimation.size();
+	for (unsigned int i = 0; i < size; i++) {
+		Animation* subAnimation = m_subAnimation.front();
+		m_subAnimation.pop();
+		subAnimation->count();
+		if (!subAnimation->getFinishFlag()) {
+			m_subAnimation.push(subAnimation);
+		}
+	}
+}
+
 
 // オープニング
 OpMovie::OpMovie(SoundPlayer* soundPlayer_p):
@@ -82,34 +104,34 @@ OpMovie::OpMovie(SoundPlayer* soundPlayer_p):
 {
 	string path = "picture/movie/op/";
 	// タイトル
-	m_titleH = new GraphHandles((path + "title/" + "h").c_str(), 4);
-	m_title = new GraphHandles((path + "title/" + "title").c_str(), 8);
-	m_titleChara = new GraphHandles((path + "title/" + "キャラ").c_str(), 5);
-	m_titleBlue = new GraphHandles((path + "title/" + "titleBlue").c_str(), 1);
-	m_titleOrange = new GraphHandles((path + "title/" + "titleOrange").c_str(), 1);
-	m_titleHeart = new GraphHandles((path + "title/" + "heart").c_str(), 1);
+	m_titleH = new GraphHandles((path + "title/" + "h").c_str(), 4, m_ex);
+	m_title = new GraphHandles((path + "title/" + "title").c_str(), 8, m_ex);
+	m_titleChara = new GraphHandles((path + "title/" + "キャラ").c_str(), 5, m_ex);
+	m_titleBlue = new GraphHandles((path + "title/" + "titleBlue").c_str(), 1, m_ex);
+	m_titleOrange = new GraphHandles((path + "title/" + "titleOrange").c_str(), 1, m_ex);
+	m_titleHeart = new GraphHandles((path + "title/" + "heart").c_str(), 1, m_ex);
 	// キャラ
-	m_archive = new GraphHandles((path + "アーカイブ").c_str(), 1);
-	m_aigis = new GraphHandles((path + "アイギス").c_str(), 1);
-	m_assault = new GraphHandles((path + "アサルト03").c_str(), 1);
-	m_vermelia = new GraphHandles((path + "ヴェルメリア").c_str(), 1);
-	m_exlucina = new GraphHandles((path + "エクスルキナ").c_str(), 1);
-	m_msadi = new GraphHandles((path + "エムサディ").c_str(), 1);
-	m_elnino = new GraphHandles((path + "エルニーニョ").c_str(), 1);
-	m_onyx = new GraphHandles((path + "オニュクス").c_str(), 1);
-	m_courir = new GraphHandles((path + "クーリール").c_str(), 1);
-	m_cornein = new GraphHandles((path + "コーネイン").c_str(), 1);
-	m_koharu = new GraphHandles((path + "コハル").c_str(), 1);
-	m_siesta = new GraphHandles((path + "シエスタ").c_str(), 5);
-	m_chocola = new GraphHandles((path + "ショコラ").c_str(), 1);
-	m_titius = new GraphHandles((path + "ティティウス").c_str(), 1);
-	m_heart = new GraphHandles((path + "ハート").c_str(), 1);
-	m_fred = new GraphHandles((path + "フレッド").c_str(), 1);
-	m_french = new GraphHandles((path + "フレンチ").c_str(), 1);
-	m_mascara = new GraphHandles((path + "マスカーラ").c_str(), 1);
-	m_yuri = new GraphHandles((path + "ユーリ").c_str(), 1);
-	m_rabbi = new GraphHandles((path + "ラビ―").c_str(), 1);
-	m_tank = new GraphHandles((path + "棒タンク").c_str(), 1);
+	m_archive = new GraphHandles((path + "アーカイブ").c_str(), 1, m_ex);
+	m_aigis = new GraphHandles((path + "アイギス").c_str(), 1, m_ex);
+	m_assault = new GraphHandles((path + "アサルト03").c_str(), 1, m_ex);
+	m_vermelia = new GraphHandles((path + "ヴェルメリア").c_str(), 1, m_ex);
+	m_exlucina = new GraphHandles((path + "エクスルキナ").c_str(), 1, m_ex);
+	m_msadi = new GraphHandles((path + "エムサディ").c_str(), 1, m_ex);
+	m_elnino = new GraphHandles((path + "エルニーニョ").c_str(), 1, m_ex);
+	m_onyx = new GraphHandles((path + "オニュクス").c_str(), 1, m_ex);
+	m_courir = new GraphHandles((path + "クーリール").c_str(), 1, m_ex);
+	m_cornein = new GraphHandles((path + "コーネイン").c_str(), 1, m_ex);
+	m_koharu = new GraphHandles((path + "コハル").c_str(), 1, m_ex);
+	m_siesta = new GraphHandles((path + "シエスタ").c_str(), 5, m_ex);
+	m_chocola = new GraphHandles((path + "ショコラ").c_str(), 1, m_ex);
+	m_titius = new GraphHandles((path + "ティティウス").c_str(), 1, m_ex);
+	m_heart = new GraphHandles((path + "ハート").c_str(), 1, m_ex);
+	m_fred = new GraphHandles((path + "フレッド").c_str(), 1, m_ex);
+	m_french = new GraphHandles((path + "フレンチ").c_str(), 1, m_ex);
+	m_mascara = new GraphHandles((path + "マスカーラ").c_str(), 1, m_ex);
+	m_yuri = new GraphHandles((path + "ユーリ").c_str(), 1, m_ex);
+	m_rabbi = new GraphHandles((path + "ラビ―").c_str(), 1, m_ex);
+	m_tank = new GraphHandles((path + "棒タンク").c_str(), 1, m_ex);
 
 	// 表示する順にpush
 	characterQueue.push(make_pair(m_koharu, 30));
@@ -178,8 +200,9 @@ OpMovie::~OpMovie() {
 }
 
 void OpMovie::play() {
-	m_cnt++;
-	m_animation->count();
+
+	// カウント
+	Movie::play();
 
 	// 画像を設定
 	if (m_cnt == 45) {
@@ -196,7 +219,7 @@ void OpMovie::play() {
 	}
 	else if (m_cnt < 600 && m_cnt >= 440) {
 		m_animation->changeGraph(m_titleHeart, 60);
-		m_animation->setX(m_animation->getX() + 8);
+		m_animation->setX(m_animation->getX() + (int)(8 * m_ex));
 	}
 	else if (m_cnt < 690 && m_cnt >= 600) {
 		m_animation->setX(GAME_WIDE / 2);

--- a/Animation.h
+++ b/Animation.h
@@ -61,14 +61,21 @@ public:
 // 動画の基底クラス
 class Movie {
 protected:
+
+	// 解像度の変更に対応
+	double m_ex;
+
 	// 終了したらtrue
 	bool m_finishFlag;
 
 	// 開始からの経過時間
 	int m_cnt;
 
-	// 画像を入れて動かす
+	// 画像を入れて動かすメイン画像
 	Animation* m_animation;
+
+	// サブ画像 cntが0になったものはpopしていく
+	std::queue<Animation*> m_subAnimation;
 
 	// サウンドプレイヤー
 	SoundPlayer* m_soundPlayer_p;
@@ -80,10 +87,11 @@ public:
 	// ゲッタ
 	bool getFinishFlag() const { return m_finishFlag; }
 	Animation* getAnimation() const { return m_animation; }
+	std::queue<Animation*> getSubAnimation() const { return m_subAnimation; }
 	inline int getCnt() const { return m_cnt; }
 
 	// 再生
-	virtual void play() = 0;
+	virtual void play();
 };
 
 

--- a/Button.h
+++ b/Button.h
@@ -45,6 +45,7 @@ public:
 	void setGraph(int handle, int ex);
 	void setString(std::string new_string);//タグをつけなおす
 	inline void setX(int x) { m_x = x; }
+	inline void setColor(int colorHandle) { m_color = colorHandle; }
 
 	// ボタンのon/off切り替え
 	void changeFlag(bool f, int new_color);

--- a/Define.cpp
+++ b/Define.cpp
@@ -1,2 +1,9 @@
 int GAME_WIDE = 1920;
 int GAME_HEIGHT = 1080;
+
+
+// ‰ð‘œ“x‚Ì”{—¦
+void getGameEx(double& exX, double& exY) {
+	exX = GAME_WIDE / 1920.0;
+	exY = GAME_HEIGHT / 1080.0;
+}

--- a/Define.h
+++ b/Define.h
@@ -6,7 +6,7 @@
 // フルスクリーンならFALSE
 static int WINDOW = TRUE;
 // マウスを表示するならFALSE
-static int MOUSE_DISP = FALSE;
+static int MOUSE_DISP = TRUE;
 
 //画面の大きさ
 //#define GAME_WIDE 3840

--- a/Define.h
+++ b/Define.h
@@ -24,6 +24,9 @@ static int MOUSE_DISP = TRUE;
 extern int GAME_WIDE;
 extern int GAME_HEIGHT;
 
+// ‰ğ‘œ“x‚Ì”{—¦
+void getGameEx(double& exX, double& exY);
+
 // DrawFormatStringŠÖ”‚Å•\¦‚³‚ê‚é•¶š‚Ì‘å‚«‚³‚Í20‚­‚ç‚¢
 #define DRAW_FORMAT_STRING_SIZE 20
 
@@ -33,6 +36,7 @@ const int GRAY = GetColor(100, 100, 100);
 const int GRAY2 = GetColor(200, 200, 200);
 const int WHITE = GetColor(255, 255, 255);
 const int RED = GetColor(255, 0, 0);
+const int LIGHT_RED = GetColor(255, 100, 100);
 const int BLUE = GetColor(0, 0, 255);
 const int LIGHT_BLUE = GetColor(100, 100, 255);
 

--- a/Define.h
+++ b/Define.h
@@ -27,6 +27,8 @@ extern int GAME_HEIGHT;
 // ‰ğ‘œ“x‚Ì”{—¦
 void getGameEx(double& exX, double& exY);
 
+#define GAME_COLOR_BIT_NUM 16
+
 // DrawFormatStringŠÖ”‚Å•\¦‚³‚ê‚é•¶š‚Ì‘å‚«‚³‚Í20‚­‚ç‚¢
 #define DRAW_FORMAT_STRING_SIZE 20
 

--- a/Define.h
+++ b/Define.h
@@ -4,7 +4,7 @@
 #include"DxLib.h"
 
 // フルスクリーンならFALSE
-static int WINDOW = TRUE;
+static int WINDOW = FALSE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = TRUE;
 

--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -179,6 +179,7 @@
     <ClCompile Include="Story.cpp" />
     <ClCompile Include="Text.cpp" />
     <ClCompile Include="TextDrawer.cpp" />
+    <ClCompile Include="Title.cpp" />
     <ClCompile Include="World.cpp" />
     <ClCompile Include="WorldDrawer.cpp" />
   </ItemGroup>
@@ -209,6 +210,7 @@
     <ClInclude Include="Story.h" />
     <ClInclude Include="Text.h" />
     <ClInclude Include="TextDrawer.h" />
+    <ClInclude Include="Title.h" />
     <ClInclude Include="World.h" />
     <ClInclude Include="WorldDrawer.h" />
   </ItemGroup>

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -135,6 +135,9 @@
     <ClCompile Include="Define.cpp">
       <Filter>ソース ファイル</Filter>
     </ClCompile>
+    <ClCompile Include="Title.cpp">
+      <Filter>ソース ファイル\pages</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">
@@ -219,6 +222,9 @@
       <Filter>ヘッダー ファイル\Domain</Filter>
     </ClInclude>
     <ClInclude Include="PausePage.h">
+      <Filter>ヘッダー ファイル\pages</Filter>
+    </ClInclude>
+    <ClInclude Include="Title.h">
       <Filter>ヘッダー ファイル\pages</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Game.cpp
+++ b/Game.cpp
@@ -174,7 +174,7 @@ GameData::GameData(const char* saveFilePath):
 	// セーブ場所
 	m_saveFilePath = saveFilePath;
 	// セーブデータを読み込んで初期状態のデータを上書き
-	load();
+	m_exist = load();
 }
 
 GameData::~GameData() {
@@ -277,10 +277,10 @@ void GameData::updateStory(Story* story) {
 /*
 * ゲーム本体
 */
-Game::Game() {
+Game::Game(const char* saveFilePath) {
 	// データ
 	//m_gameData = new GameData();
-	m_gameData = new GameData("savedata/test/");
+	m_gameData = new GameData(saveFilePath);
 
 	// サウンドプレイヤー
 	m_soundPlayer = new SoundPlayer();

--- a/Game.cpp
+++ b/Game.cpp
@@ -188,7 +188,18 @@ GameData::~GameData() {
 
 // セーブ
 bool GameData::save() {
-	FILE *intFp = nullptr, *strFp = nullptr;
+	FILE *intFp = nullptr, *strFp = nullptr, *commonFp = nullptr;
+	int r = fopen_s(&commonFp, "savedata/commonData.dat", "wb");
+	// 全セーブデータ共通
+	if (r != 0) {
+		return false;
+	}
+	fwrite(&m_soundVolume, sizeof(m_soundVolume), 1, commonFp);
+	fwrite(&GAME_WIDE, sizeof(GAME_WIDE), 1, commonFp);
+	fwrite(&GAME_HEIGHT, sizeof(GAME_HEIGHT), 1, commonFp);
+	fclose(commonFp);
+
+	// セーブデータ固有
 	string fileName = m_saveFilePath;
 	if (fopen_s(&intFp, (fileName + "intData.dat").c_str(), "wb") != 0 || fopen_s(&strFp, (fileName + "strData.dat").c_str(), "wb") != 0) {
 		return false;
@@ -196,7 +207,6 @@ bool GameData::save() {
 	// Write
 	fwrite(&m_areaNum, sizeof(m_areaNum), 1, intFp);
 	fwrite(&m_storyNum, sizeof(m_storyNum), 1, intFp);
-	fwrite(&m_soundVolume, sizeof(m_soundVolume), 1, intFp);
 	for (unsigned int i = 0; i < m_characterData.size(); i++) {
 		m_characterData[i]->save(intFp, strFp);
 	}
@@ -213,7 +223,18 @@ bool GameData::save() {
 
 // ロード
 bool GameData::load() {
-	FILE* intFp = nullptr, * strFp = nullptr;
+	FILE* intFp = nullptr, * strFp = nullptr, * commonFp = nullptr;
+
+	// 全セーブデータ共通
+	if (fopen_s(&commonFp, "savedata/commonData.dat", "rb") != 0) {
+		return false;
+	}
+	fread(&m_soundVolume, sizeof(m_soundVolume), 1, commonFp);
+	fread(&GAME_WIDE, sizeof(GAME_WIDE), 1, commonFp);
+	fread(&GAME_HEIGHT, sizeof(GAME_HEIGHT), 1, commonFp);
+	fclose(commonFp);
+
+	// セーブデータ固有
 	string fileName = m_saveFilePath;
 	if (fopen_s(&intFp, (fileName + "intData.dat").c_str(), "rb") != 0 || fopen_s(&strFp, (fileName + "strData.dat").c_str(), "rb") != 0) {
 		return false;
@@ -221,7 +242,6 @@ bool GameData::load() {
 	// Read
 	fread(&m_areaNum, sizeof(m_areaNum), 1, intFp);
 	fread(&m_storyNum, sizeof(m_storyNum), 1, intFp);
-	fread(&m_soundVolume, sizeof(m_soundVolume), 1, intFp);
 	for (unsigned int i = 0; i < m_characterData.size(); i++) {
 		m_characterData[i]->load(intFp, strFp);
 	}
@@ -271,6 +291,13 @@ void GameData::updateStory(Story* story) {
 	// ドアの情報も取得
 	ObjectLoader* objectLoader = story->getObjectLoader();
 	objectLoader->saveDoorData(m_doorData);
+}
+
+// セーブデータ削除
+void GameData::removeSaveData() {
+	string fileName = m_saveFilePath;
+	remove((fileName + "intData.dat").c_str());
+	remove((fileName + "strData.dat").c_str());
 }
 
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -138,6 +138,9 @@ void DoorData::load(FILE* intFp, FILE* strFp) {
 */
 // 初期状態のデータを作成
 GameData::GameData() {
+
+	loadCommon(&m_soundVolume, &GAME_WIDE, &GAME_HEIGHT);
+
 	m_saveFilePath = "";
 
 	const bool test = false;
@@ -188,16 +191,10 @@ GameData::~GameData() {
 
 // セーブ
 bool GameData::save() {
-	FILE *intFp = nullptr, *strFp = nullptr, *commonFp = nullptr;
-	int r = fopen_s(&commonFp, "savedata/commonData.dat", "wb");
+	FILE* intFp = nullptr, * strFp = nullptr;
+
 	// 全セーブデータ共通
-	if (r != 0) {
-		return false;
-	}
-	fwrite(&m_soundVolume, sizeof(m_soundVolume), 1, commonFp);
-	fwrite(&GAME_WIDE, sizeof(GAME_WIDE), 1, commonFp);
-	fwrite(&GAME_HEIGHT, sizeof(GAME_HEIGHT), 1, commonFp);
-	fclose(commonFp);
+	if (!saveCommon(m_soundVolume, GAME_WIDE, GAME_HEIGHT)) { return false; }
 
 	// セーブデータ固有
 	string fileName = m_saveFilePath;
@@ -226,13 +223,7 @@ bool GameData::load() {
 	FILE* intFp = nullptr, * strFp = nullptr, * commonFp = nullptr;
 
 	// 全セーブデータ共通
-	if (fopen_s(&commonFp, "savedata/commonData.dat", "rb") != 0) {
-		return false;
-	}
-	fread(&m_soundVolume, sizeof(m_soundVolume), 1, commonFp);
-	fread(&GAME_WIDE, sizeof(GAME_WIDE), 1, commonFp);
-	fread(&GAME_HEIGHT, sizeof(GAME_HEIGHT), 1, commonFp);
-	fclose(commonFp);
+	if (!loadCommon(&m_soundVolume, &GAME_WIDE, &GAME_HEIGHT)) { return false; }
 
 	// セーブデータ固有
 	string fileName = m_saveFilePath;
@@ -253,6 +244,32 @@ bool GameData::load() {
 	// ファイルを閉じる
 	fclose(intFp);
 	fclose(strFp);
+	return true;
+}
+
+// 全セーブデータ共通
+bool GameData::saveCommon(int soundVolume, int gameWide, int gameHeight) {
+
+	FILE* commonFp = nullptr;
+	if (fopen_s(&commonFp, "savedata/commonData.dat", "wb") != 0) {
+		return false;
+	}
+	fwrite(&soundVolume, sizeof(soundVolume), 1, commonFp);
+	fwrite(&gameWide, sizeof(gameWide), 1, commonFp);
+	fwrite(&gameHeight, sizeof(gameHeight), 1, commonFp);
+	fclose(commonFp);
+	return true;
+}
+bool GameData::loadCommon(int* soundVolume, int* gameWide, int* gameHeight) {
+
+	FILE* commonFp = nullptr;
+	if (fopen_s(&commonFp, "savedata/commonData.dat", "rb") != 0) {
+		return false;
+	}
+	fread(soundVolume, sizeof(*soundVolume), 1, commonFp);
+	fread(gameWide, sizeof(*gameWide), 1, commonFp);
+	fread(gameHeight, sizeof(*gameHeight), 1, commonFp);
+	fclose(commonFp);
 	return true;
 }
 

--- a/Game.h
+++ b/Game.h
@@ -161,6 +161,9 @@ public:
 	// セーブとロード
 	bool save();
 	bool load();
+	// 全セーブデータ共通
+	bool saveCommon(int soundVolume, int gameWide, int gameHeight);
+	bool loadCommon(int* soundVolume, int* gameWide, int* gameHeight);
 
 	// ゲッタ
 	inline bool getExist() const { return m_exist; }

--- a/Game.h
+++ b/Game.h
@@ -133,7 +133,10 @@ public:
 class GameData {
 private:
 	// セーブする場所
-	const char* m_saveFilePath;
+	std::string m_saveFilePath;
+
+	// セーブデータが存在するか
+	bool m_exist;
 
 	// キャラのデータ
 	std::vector<CharacterData*> m_characterData;
@@ -160,9 +163,11 @@ public:
 	bool load();
 
 	// ゲッタ
+	inline bool getExist() const { return m_exist; }
 	inline int getAreaNum() const { return m_areaNum; }
 	inline int getStoryNum() const { return m_storyNum; }
 	inline int getSoundVolume() const { return m_soundVolume; }
+	inline const char* getSaveFilePath() const { return m_saveFilePath.c_str(); }
 
 	// セッタ
 	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }
@@ -254,7 +259,7 @@ private:
 	GamePause* m_gamePause;
 
 public:
-	Game();
+	Game(const char* saveFilePath = "savedata/test/");
 	~Game();
 
 	// ゲッタ

--- a/Game.h
+++ b/Game.h
@@ -182,6 +182,10 @@ public:
 
 	// ストーリーが進んだ時にセーブデータを更新する
 	void updateStory(Story* story);
+
+	// セーブデータ削除
+	void removeSaveData();
+
 };
 
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -29,7 +29,7 @@ bool Update() {
 }
 
 void Draw(int x, int y, int color) {
-	DrawFormatString(0, 0, WHITE, "デバッグモード：%.1f FPS", mFps);
+	DrawFormatString(0, 0, WHITE, "デバッグモード：%.1f FPS, 解像度：%d*%d", mFps, GAME_WIDE, GAME_HEIGHT);
 }
 
 void Wait() {

--- a/Main.cpp
+++ b/Main.cpp
@@ -29,7 +29,7 @@ bool Update() {
 }
 
 void Draw(int x, int y, int color) {
-	DrawFormatString(0, 0, WHITE, "デバッグモード：%.1f FPS, 解像度：%d*%d", mFps, GAME_WIDE, GAME_HEIGHT);
+	DrawFormatString(0, 0, RED, "デバッグモード：%.1f FPS, 解像度：%d*%d", mFps, GAME_WIDE, GAME_HEIGHT);
 }
 
 void Wait() {
@@ -44,7 +44,9 @@ void Wait() {
 int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	SetWindowSizeChangeEnableFlag(TRUE);//windowサイズ変更可能
 	SetUseDirectInputFlag(TRUE);
-	SetGraphMode(GAME_WIDE, GAME_HEIGHT, 16);
+	GameData* gameData = new GameData();
+	SetGraphMode(GAME_WIDE, GAME_HEIGHT, GAME_COLOR_BIT_NUM);
+	delete gameData;
 
 	ChangeWindowMode(WINDOW), DxLib_Init(), SetDrawScreen(DX_SCREEN_BACK);
 	
@@ -85,13 +87,19 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 			gameDrawer->draw();
 		}
 		else {
-			bool result = title->play();
+			Title::TITLE_RESULT result = title->play();
 			title->draw();
-			if (result) {
+			if (result == Title::START) {
 				game = new Game(title->useSaveFile());
 				gameDrawer = new GameDrawer(game);
 				delete title;
 				gamePlay = true;
+			}
+			else if (result == Title::REBOOT) {
+				// ゲームを再起動
+				delete title;
+				ChangeWindowMode(WINDOW), DxLib_Init(), SetDrawScreen(DX_SCREEN_BACK);
+				title = new Title();
 			}
 		}
 		///////////////

--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -5,10 +5,20 @@
 #include "Define.h"
 #include "DxLib.h"
 
+#include <sstream>
+#include <string>
 
-ControlBar::ControlBar(int x1, int y1, int x2, int y2, int minValue, int maxValue, int initValue) {
+
+using namespace std;
+
+
+ControlBar::ControlBar(int x1, int y1, int x2, int y2, int minValue, int maxValue, int initValue, string name) {
 	
+	m_name = name;
+
 	getGameEx(m_exX, m_exY);
+	m_fontSize = (int)(50 * m_exX);
+	m_font = CreateFontToHandle(nullptr, m_fontSize, 3);
 
 	m_drawX1 = (int)(x1 * m_exX);
 	m_drawY1 = (int)(y1 * m_exY);
@@ -27,6 +37,10 @@ ControlBar::ControlBar(int x1, int y1, int x2, int y2, int minValue, int maxValu
 	m_buttonWide /= 2;
 
 	m_controlFlag = false;
+}
+
+ControlBar::~ControlBar() {
+	DeleteFontToHandle(m_font);
 }
 
 // í≤êÆÇ∑ÇÈ
@@ -67,6 +81,10 @@ void ControlBar::play(int handX, int handY) {
 void ControlBar::draw(int handX, int handY) {
 	int d = (int)(10 * m_exX);
 
+	ostringstream oss;
+	oss << m_name << " : " << m_nowValue;
+	DrawStringToHandle(m_drawX1 - m_buttonWide - d, m_drawY1 - d - m_fontSize, oss.str().c_str(), WHITE, m_font);
+
 	// âπó í≤êﬂóÃàÊ
 	DrawBox(m_drawX1 - m_buttonWide - d, m_drawY1 - d, m_drawX2 + m_buttonWide + d, m_drawY2 + d, BLACK, TRUE);
 	DrawBox(m_drawX1 - m_buttonWide, m_drawY1, m_drawX2 + m_buttonWide, m_drawY2, GRAY2, TRUE);
@@ -87,7 +105,7 @@ void ControlBar::draw(int handX, int handY) {
 */
 GamePause::GamePause(SoundPlayer* soundPlayer) {
 	m_soundPlayer_p = soundPlayer;
-	m_soundController = new ControlBar(SOUND_X1, SOUND_Y1, SOUND_X2, SOUND_Y2, SOUND_MIN, SOUND_MAX, m_soundPlayer_p->getVolume());
+	m_soundController = new ControlBar(SOUND_X1, SOUND_Y1, SOUND_X2, SOUND_Y2, SOUND_MIN, SOUND_MAX, m_soundPlayer_p->getVolume(), "Sound Volume");
 	m_handX = 0;
 	m_handY = 0;
 }
@@ -120,10 +138,14 @@ void GamePause::draw() const {
 TitleOption::TitleOption(SoundPlayer* soundPlayer) :
 	GamePause(soundPlayer)
 {
-	m_gameWideController = new ControlBar(WIDE_X1, WIDE_Y1, WIDE_X2, WIDE_Y2, GAME_WIDE_MIN, GAME_WIDE_MAX, GAME_WIDE);
-	m_gameHeightController = new ControlBar(HEIGHT_X1, HEIGHT_Y1, HEIGHT_X2, HEIGHT_Y2, GAME_HEIGHT_MIN, GAME_HEIGHT_MAX, GAME_HEIGHT);
+	m_gameWideController = new ControlBar(WIDE_X1, WIDE_Y1, WIDE_X2, WIDE_Y2, GAME_WIDE_MIN, GAME_WIDE_MAX, GAME_WIDE, "Display resolution (wide)");
+	m_gameHeightController = new ControlBar(HEIGHT_X1, HEIGHT_Y1, HEIGHT_X2, HEIGHT_Y2, GAME_HEIGHT_MIN, GAME_HEIGHT_MAX, GAME_HEIGHT, "Display resolution (height)");
 	m_newWide = GAME_WIDE;
 	m_newHeight = GAME_HEIGHT;
+}
+
+TitleOption::~TitleOption() {
+
 }
 
 void TitleOption::play() {

--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -8,8 +8,7 @@
 
 ControlBar::ControlBar(int x1, int y1, int x2, int y2, int minValue, int maxValue, int initValue) {
 	
-	m_exX = GAME_WIDE / 1920.0;
-	m_exY = GAME_HEIGHT / 1080.0;
+	getGameEx(m_exX, m_exY);
 
 	m_drawX1 = (int)(x1 * m_exX);
 	m_drawY1 = (int)(y1 * m_exY);

--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -142,10 +142,18 @@ TitleOption::TitleOption(SoundPlayer* soundPlayer) :
 	m_gameHeightController = new ControlBar(HEIGHT_X1, HEIGHT_Y1, HEIGHT_X2, HEIGHT_Y2, GAME_HEIGHT_MIN, GAME_HEIGHT_MAX, GAME_HEIGHT, "Display resolution (height)");
 	m_newWide = GAME_WIDE;
 	m_newHeight = GAME_HEIGHT;
+
+	getGameEx(m_exX, m_exY);
+	m_fontSize = (int)(50 * m_exX);
+	m_font = CreateFontToHandle(nullptr, m_fontSize, 3);
+	m_leftButton = new Button("←", m_gameWideController->getLeftX(), (int)((HEIGHT_Y2 + 50) * m_exY), (int)(100 * m_exX), (int)(100 * m_exY), WHITE, GRAY2, m_font, BLACK);
+	m_rightButton = new Button("→", m_gameWideController->getRightX() - (int)(100 * m_exX), (int)((HEIGHT_Y2 + 50) * m_exY), (int)(100 * m_exX), (int)(100 * m_exY), WHITE, GRAY2, m_font, BLACK);
+	m_tmpApplyButton = new Button("Apply", m_gameWideController->getLeftX(), (int)((HEIGHT_Y2 + 170) * m_exY), m_gameWideController->getRightX() - m_gameWideController->getLeftX(), (int)(100 * m_exY), WHITE, GRAY2, m_font, BLACK);
+	m_nowTmpIndex = 0;
 }
 
 TitleOption::~TitleOption() {
-
+	DeleteFontToHandle(m_font);
 }
 
 void TitleOption::play() {
@@ -156,6 +164,22 @@ void TitleOption::play() {
 	m_gameHeightController->play(m_handX, m_handY);
 	m_newWide = m_gameWideController->getNowValue();
 	m_newHeight = m_gameHeightController->getNowValue();
+	
+	if (m_leftButton->overlap(m_handX, m_handY) && leftClick() == 1) {
+		if (m_nowTmpIndex == 0) { 
+			m_nowTmpIndex = TMP_SUM - 1;
+		}
+		else {
+			m_nowTmpIndex = (m_nowTmpIndex - 1) % TMP_SUM;
+		}
+	}
+	if (m_rightButton->overlap(m_handX, m_handY) && leftClick() == 1) {
+		m_nowTmpIndex = (m_nowTmpIndex + 1) % TMP_SUM;
+	}
+	if (m_tmpApplyButton->overlap(m_handX, m_handY) && leftClick() == 1) {
+		m_gameWideController->setValue(TMP[m_nowTmpIndex][0]);
+		m_gameHeightController->setValue(TMP[m_nowTmpIndex][1]);
+	}
 }
 
 void TitleOption::draw() const {
@@ -164,5 +188,16 @@ void TitleOption::draw() const {
 
 	m_gameWideController->draw(m_handX, m_handY);
 	m_gameHeightController->draw(m_handX, m_handY);
+
+	// 解像度のテンプレート
+	m_tmpApplyButton->draw(m_handX, m_handY);
+	m_leftButton->draw(m_handX, m_handY);
+	ostringstream oss;
+	oss << TMP[m_nowTmpIndex][0] << " : " << TMP[m_nowTmpIndex][1];
+	DrawStringToHandle(m_gameWideController->getLeftX() + (int)(150 * m_exX), (int)((HEIGHT_Y2 + 75) * m_exY), oss.str().c_str(), WHITE, m_font);
+	m_rightButton->draw(m_handX, m_handY);
+	int x1 = m_gameWideController->getLeftX();
+	int y1 = (int)((HEIGHT_Y2 + 300) * m_exY);
+	DrawBox(x1, y1, x1 + (int)(TMP[m_nowTmpIndex][0] * m_exX) / 20, y1 + (int)(TMP[m_nowTmpIndex][1] * m_exY) / 20, LIGHT_BLUE, TRUE);
 
 }

--- a/PausePage.h
+++ b/PausePage.h
@@ -2,12 +2,19 @@
 #define PAUSE_PAGE_H_INCLUDED
 
 
+#include <string>
+
 class Button;
 class SoundPlayer;
 
 
 // マウスでボタンを左右に動かして値を調整する機能
 class ControlBar {
+
+	// 設定する項目の名前
+	std::string m_name;
+	int m_font;
+	int m_fontSize;
 
 	// 1920を基準としたGAME_WIDEの倍率
 	double m_exX;
@@ -36,7 +43,8 @@ class ControlBar {
 	bool m_controlFlag;
 
 public:
-	ControlBar(int x1, int y1, int x2, int y2, int minValue, int maxValue, int initValue);
+	ControlBar(int x1, int y1, int x2, int y2, int minValue, int maxValue, int initValue, std::string name);
+	~ControlBar();
 
 	// 調整する
 	void play(int handX, int handY);
@@ -100,12 +108,13 @@ class TitleOption :
 	const int WIDE_Y2 = 600;
 
 	const int HEIGHT_X1 = 800;
-	const int HEIGHT_Y1 = 800;
+	const int HEIGHT_Y1 = 700;
 	const int HEIGHT_X2 = 1300;
-	const int HEIGHT_Y2 = 1000;
+	const int HEIGHT_Y2 = 900;
 
 public:
 	TitleOption(SoundPlayer* soundPlayer);
+	~TitleOption();
 
 	void play();
 

--- a/PausePage.h
+++ b/PausePage.h
@@ -54,6 +54,11 @@ public:
 	
 	// ゲッタ
 	inline int getNowValue() { return m_nowValue; }
+	inline int getLeftX() { return m_drawX1 - m_buttonWide; }
+	inline int getRightX() { return m_drawX2 + m_buttonWide; }
+
+	// セッタ
+	inline void setValue(int value) { m_nowValue = value; }
 };
 
 
@@ -103,14 +108,33 @@ class TitleOption :
 	int m_newHeight;
 
 	const int WIDE_X1 = 800;
-	const int WIDE_Y1 = 400;
+	const int WIDE_Y1 = 200;
 	const int WIDE_X2 = 1300;
-	const int WIDE_Y2 = 600;
+	const int WIDE_Y2 = 300;
 
 	const int HEIGHT_X1 = 800;
-	const int HEIGHT_Y1 = 700;
+	const int HEIGHT_Y1 = 400;
 	const int HEIGHT_X2 = 1300;
-	const int HEIGHT_Y2 = 900;
+	const int HEIGHT_Y2 = 500;
+
+	// 解像度のテンプレート
+	// フォント
+	int m_font;
+	int m_fontSize;
+	// 1920を基準としたGAME_WIDEの倍率
+	double m_exX;
+	// 1080を基準としたGAME_HEIGHTの倍率
+	double m_exY;
+	Button* m_tmpApplyButton;
+	Button* m_leftButton;
+	Button* m_rightButton;
+	static const int TMP_SUM = 24;
+	const int TMP[TMP_SUM][2] = { {3840, 2160}, {2560, 1600}, {2560, 1440}, {2048, 1536}, {1920, 1440},
+		{1920, 1200}, {1920, 1080}, {1680, 1050}, {1600, 1200}, {1600, 900}, {1440, 1080},
+		{1440, 900}, {1366, 768}, {1360, 768}, {1280, 1024}, {1280, 960}, {1280, 800},
+		{1280, 768}, {1280, 720}, {1176, 664}, {1152, 864}, {1024, 768}, {800, 600},
+		{640, 480} };
+	int m_nowTmpIndex;
 
 public:
 	TitleOption(SoundPlayer* soundPlayer);

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -13,11 +13,11 @@ ConversationDrawer::ConversationDrawer(Conversation* conversation) {
 
 	m_conversation = conversation;
 
-	m_ex = GAME_WIDE / 1920.0;
+	getGameEx(m_exX, m_exY);
 
 	// フォントデータ
-	m_textHandle = CreateFontToHandle(nullptr, (int)(TEXT_SIZE * m_ex), 3);
-	m_nameHandle = CreateFontToHandle(nullptr, (int)(NAME_SIZE * m_ex), 5);
+	m_textHandle = CreateFontToHandle(nullptr, (int)(TEXT_SIZE * m_exX), 3);
+	m_nameHandle = CreateFontToHandle(nullptr, (int)(NAME_SIZE * m_exX), 5);
 
 	// 吹き出し画像
 	m_frameHandle = LoadGraph("picture/textMaterial/frame.png");
@@ -39,14 +39,14 @@ void ConversationDrawer::draw() {
 	// キャラの顔画像は正方形を想定
 	int graphSize = 0;
 	GetGraphSize(graph->getHandle(), &graphSize, &graphSize);
-	graphSize = (int)(graphSize * m_ex);
+	graphSize = (int)(graphSize * m_exX);
 
 	// フキダシのフチの幅
-	static const int TEXT_GRAPH_EDGE = (int)(35 * m_ex);
+	static const int TEXT_GRAPH_EDGE = (int)(35 * m_exX);
 
 	// 端の余白
-	static const int EDGE_X = (int)(48 * m_ex);
-	static const int EDGE_DOWN = (int)(48 * m_ex);
+	static const int EDGE_X = (int)(48 * m_exX);
+	static const int EDGE_DOWN = (int)(48 * m_exX);
 
 	// 上端
 	static const int Y1 = GAME_HEIGHT - EDGE_DOWN - graphSize - (TEXT_GRAPH_EDGE * 2);
@@ -64,21 +64,21 @@ void ConversationDrawer::draw() {
 	DrawExtendGraph(EDGE_X, Y1, GAME_WIDE - EDGE_X, GAME_HEIGHT - EDGE_DOWN, m_frameHandle, TRUE);
 
 	// 名前
-	DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE + graphSize + (int)(NAME_SIZE * m_ex), GAME_HEIGHT - EDGE_DOWN - (int)(NAME_SIZE * m_ex) - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
+	DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE + graphSize + (int)(NAME_SIZE * m_exX), GAME_HEIGHT - EDGE_DOWN - (int)(NAME_SIZE * m_exX) - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
 
 	// テキスト
 	int now = 0;
 	int i = 0;
-	static const int CHAR_EDGE = (int)(30 * m_ex);
+	static const int CHAR_EDGE = (int)(30 * m_exX);
 	while (now < text.size()) {
 		int next = now + min(MAX_TEXT_LEN, (int)text.size() - now);
 		string disp = text.substr(now, next - now);
-		DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize, Y1  + TEXT_GRAPH_EDGE + (i * ((int)(TEXT_SIZE * m_ex) + CHAR_EDGE)), disp.c_str(), BLACK, m_textHandle);
+		DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize, Y1  + TEXT_GRAPH_EDGE + (i * ((int)(TEXT_SIZE * m_exX) + CHAR_EDGE)), disp.c_str(), BLACK, m_textHandle);
 		now = next;
 		i++;
 	}
 
 	// キャラの顔画像
-	graph->draw(EDGE_X + TEXT_GRAPH_EDGE + graphSize / 2, Y1 + TEXT_GRAPH_EDGE + graphSize / 2, m_ex);
+	graph->draw(EDGE_X + TEXT_GRAPH_EDGE + graphSize / 2, Y1 + TEXT_GRAPH_EDGE + graphSize / 2, m_exX);
 
 }

--- a/TextDrawer.h
+++ b/TextDrawer.h
@@ -12,7 +12,8 @@ private:
 	const Conversation* m_conversation;
 
 	// テキストやフォントのサイズの倍率
-	double m_ex;
+	double m_exX;
+	double m_exY;
 	
 	// フォント（テキスト）
 	int m_textHandle;

--- a/Title.cpp
+++ b/Title.cpp
@@ -20,6 +20,9 @@ using namespace std;
 * セーブデータ選択画面
 */
 SelectSaveData::SelectSaveData() {
+
+	m_initCnt = 0;
+
 	for (int i = 0; i < GAME_DATA_SUM; i++) {
 		ostringstream oss;
 		oss << "savedata/" << i + 1 << "/";
@@ -27,8 +30,8 @@ SelectSaveData::SelectSaveData() {
 	}
 
 	// ボタン
-	double exX = GAME_WIDE / 1920.0;
-	double exY = GAME_HEIGHT / 1080.0;
+	double exX, exY;
+	getGameEx(exX, exY);
 	m_font = CreateFontToHandle(nullptr, (int)(50 * exX), 3);
 	for (int i = 0; i < GAME_DATA_SUM; i++) {
 		string text;
@@ -40,9 +43,10 @@ SelectSaveData::SelectSaveData() {
 		else {
 			text = "New Game";
 		}
-		m_dataButton[i] = new Button(text, 100 * exX, 300 * exY + (i * 150 * exY), 800 * exX, 100 * exY, WHITE, GRAY2, m_font, BLACK);
+		m_dataButton[i] = new Button(text, (int)(100 * exX), (int)(300 * exY + (i * 150 * exY)), (int)(500 * exX), (int)(100 * exY), WHITE, GRAY2, m_font, BLACK);
+		m_dataInitButton[i] = new Button("削除", (int)(650 * exX), (int)(300 * exY + (i * 150 * exY)), (int)(100 * exX), (int)(100 * exY), LIGHT_RED, RED, m_font, BLACK);
 	}
-	m_cancelButton = new Button("Backward", 50 * exX, 50 * exY, 300 * exX, 100 * exY, GRAY2, WHITE, m_font, BLACK);
+	m_cancelButton = new Button("Backward", (int)(50 * exX), (int)(50 * exY), (int)(300 * exX), (int)(100 * exY), GRAY2, WHITE, m_font, BLACK);
 
 }
 
@@ -51,6 +55,7 @@ SelectSaveData::~SelectSaveData() {
 	for (int i = 0; i < GAME_DATA_SUM; i++) {
 		delete m_gameData[i];
 		delete m_dataButton[i];
+		delete m_dataInitButton[i];
 	}
 	delete m_cancelButton;
 }
@@ -73,6 +78,26 @@ bool SelectSaveData::play(int handX, int handY) {
 			m_useSaveDataIndex = i;
 			return true;
 		}
+		if (m_dataInitButton[i]->overlap(handX, handY) && leftClick() > 0) {
+			if (leftClick() == 1) { m_initCnt++; }
+			else if (m_initCnt > 0 && m_initCnt < 70) { 
+				m_initCnt++;
+				m_dataInitButton[i]->setColor(GetColor(255, 100 + m_initCnt * 2, 100 + m_initCnt * 2));
+			}
+			else { 
+				if (m_initCnt == 70) {
+					// セーブデータ削除
+					m_gameData[i]->removeSaveData();
+					m_dataButton[i]->setString("New Game");
+				}
+				m_initCnt = 0;
+				m_dataInitButton[i]->setColor(LIGHT_RED);
+			}
+		}
+		if (leftClick() == 0) { 
+			m_initCnt = 0;
+			m_dataInitButton[i]->setColor(LIGHT_RED);
+		}
 	}
 
 	// 戻るボタン
@@ -88,6 +113,7 @@ void SelectSaveData::draw(int handX, int handY) {
 	// ボタン
 	for (int i = 0; i < GAME_DATA_SUM; i++) {
 		m_dataButton[i]->draw(handX, handY);
+		m_dataInitButton[i]->draw(handX, handY);
 	}
 	m_cancelButton->draw(handX, handY);
 
@@ -124,11 +150,11 @@ Title::Title() {
 		m_movie = nullptr;
 	}
 
-	double exX = GAME_WIDE / 1920.0;
-	double exY = GAME_HEIGHT / 1080.0;
+	double exX, exY;
+	getGameEx(exX, exY);
 	m_font = CreateFontToHandle(nullptr, (int)(50 * exX), 3);
-	m_selectButton = new Button("Game Start", 500 * exX, 800 * exY, 920 * exX, 80 * exY, GRAY2, BLUE, m_font, BLACK);
-	m_optionButton = new Button("Setting", 500 * exX, 900 * exY, 920 * exX, 80 * exY, GRAY2, BLUE, m_font, BLACK);
+	m_selectButton = new Button("Game Start", (int)(500 * exX), (int)(800 * exY), (int)(920 * exX), (int)(80 * exY), GRAY2, BLUE, m_font, BLACK);
+	m_optionButton = new Button("Setting", (int)(500 * exX), (int)(900 * exY), (int)(920 * exX), (int)(80 * exY), GRAY2, BLUE, m_font, BLACK);
 
 }
 

--- a/Title.cpp
+++ b/Title.cpp
@@ -1,0 +1,211 @@
+#include "Title.h"
+#include "PausePage.h"
+#include "Animation.h"
+#include "AnimationDrawer.h"
+#include "Game.h"
+#include "Button.h"
+#include "Define.h"
+#include "Control.h"
+#include "Sound.h"
+#include "DxLib.h"
+
+#include <sstream>
+#include <string>
+
+
+using namespace std;
+
+
+/*
+* セーブデータ選択画面
+*/
+SelectSaveData::SelectSaveData() {
+	for (int i = 0; i < GAME_DATA_SUM; i++) {
+		ostringstream oss;
+		oss << "savedata/" << i + 1 << "/";
+		m_gameData[i] = new GameData(oss.str().c_str());
+	}
+
+	// ボタン
+	double exX = GAME_WIDE / 1920.0;
+	double exY = GAME_HEIGHT / 1080.0;
+	m_font = CreateFontToHandle(nullptr, (int)(50 * exX), 3);
+	for (int i = 0; i < GAME_DATA_SUM; i++) {
+		string text;
+		ostringstream oss;
+		if (m_gameData[i]->getExist()) { 
+			oss << "Chapter" << m_gameData[i]->getStoryNum();
+			text = oss.str();
+		}
+		else {
+			text = "New Game";
+		}
+		m_dataButton[i] = new Button(text, 100 * exX, 300 * exY + (i * 150 * exY), 800 * exX, 100 * exY, WHITE, GRAY2, m_font, BLACK);
+	}
+	m_cancelButton = new Button("Backward", 50 * exX, 50 * exY, 300 * exX, 100 * exY, GRAY2, WHITE, m_font, BLACK);
+
+}
+
+SelectSaveData::~SelectSaveData() {
+	DeleteFontToHandle(m_font);
+	for (int i = 0; i < GAME_DATA_SUM; i++) {
+		delete m_gameData[i];
+		delete m_dataButton[i];
+	}
+	delete m_cancelButton;
+}
+
+// セーブデータが1つでも存在するか
+bool SelectSaveData::saveDataExist() {
+	for (int i = 0; i < GAME_DATA_SUM; i++) {
+		if (m_gameData[i]->getExist()) { return true; }
+	}
+	return false;
+}
+
+// セーブデータ選択画面の処理
+bool SelectSaveData::play(int handX, int handY) {
+
+	// セーブデータを選ぶ
+	m_useSaveDataIndex = NOT_DECIDE_DATA;
+	for (int i = 0; i < GAME_DATA_SUM; i++) {
+		if (m_dataButton[i]->overlap(handX, handY) && leftClick() == 1) {
+			m_useSaveDataIndex = i;
+			return true;
+		}
+	}
+
+	// 戻るボタン
+	if (m_cancelButton->overlap(handX, handY) && leftClick() == 1) {
+		return true;
+	}
+
+	return false;
+}
+
+void SelectSaveData::draw(int handX, int handY) {
+	
+	// ボタン
+	for (int i = 0; i < GAME_DATA_SUM; i++) {
+		m_dataButton[i]->draw(handX, handY);
+	}
+	m_cancelButton->draw(handX, handY);
+
+}
+
+// 使用するセーブデータのディレクトリ名
+const char* SelectSaveData::useDirName() {
+	if (m_useSaveDataIndex == NOT_DECIDE_DATA) { return ""; }
+	return m_gameData[m_useSaveDataIndex]->getSaveFilePath();
+}
+
+
+/*
+* タイトル画面
+*/
+Title::Title() {
+
+	m_state = TITLE;
+
+	m_handX = 0; m_handY = 0;
+
+	m_soundPlayer = new SoundPlayer();
+
+	m_titleGraph = LoadGraph("picture/movie/op/title/titleBlue.png");
+
+	m_selectSaveData = new SelectSaveData();
+
+	// セーブデータがあるならOP
+	if (m_selectSaveData->saveDataExist()) { 
+		m_movie = new OpMovie(m_soundPlayer);
+		m_animationDrawer = new AnimationDrawer(nullptr);
+	}
+	else {
+		m_movie = nullptr;
+	}
+
+	double exX = GAME_WIDE / 1920.0;
+	double exY = GAME_HEIGHT / 1080.0;
+	m_font = CreateFontToHandle(nullptr, (int)(50 * exX), 3);
+	m_selectButton = new Button("Game Start", 500 * exX, 800 * exY, 920 * exX, 80 * exY, GRAY2, BLUE, m_font, BLACK);
+	m_optionButton = new Button("Setting", 500 * exX, 900 * exY, 920 * exX, 80 * exY, GRAY2, BLUE, m_font, BLACK);
+
+}
+
+Title::~Title() {
+
+	delete m_soundPlayer;
+
+	DeleteGraph(m_titleGraph);
+
+	delete m_selectSaveData;
+
+	DeleteFontToHandle(m_font);
+	delete m_selectButton;
+	delete m_optionButton;
+
+}
+
+// タイトル画面の処理 終了ならtrue
+bool Title::play() {
+	
+	// OP
+	if (m_movie != nullptr) { 
+		m_movie->play();
+		// OPの終了
+		if (m_movie->getFinishFlag() || leftClick() == 1) {
+			delete m_movie;
+			m_movie = nullptr;
+		}
+		return false;
+	}
+
+	// マウスカーソルの位置
+	GetMousePoint(&m_handX, &m_handY);
+
+	string filePath = "";
+	switch (m_state) {
+	case TITLE: // タイトル画面
+		if (m_selectButton->overlap(m_handX, m_handY) && leftClick() == 1) { m_state = SELECT; }
+		break;
+	case SELECT: // セーブデータ選択画面
+		if (m_selectSaveData->play(m_handX, m_handY)) {
+			filePath = m_selectSaveData->useDirName();
+			if (filePath == "") { m_state = TITLE; }
+			else { return true; }
+		}
+		break;
+	case OPTION:
+
+		break;
+	}
+
+	return false;
+
+}
+
+// 描画
+void Title::draw() {
+
+	// OP
+	if (m_movie != nullptr) {
+		m_animationDrawer->setAnimation(m_movie->getAnimation());
+		m_animationDrawer->drawAnimation();
+		return;
+	}
+
+	switch (m_state) {
+	case TITLE: // タイトル画面
+		DrawExtendGraph(0, 0, GAME_WIDE, GAME_HEIGHT, m_titleGraph, TRUE);
+		m_selectButton->draw(m_handX, m_handY);
+		m_optionButton->draw(m_handX, m_handY);
+		break;
+	case SELECT: // セーブデータ選択画面
+		m_selectSaveData->draw(m_handX, m_handY);
+		break;
+	case OPTION:
+
+		break;
+	}
+
+}

--- a/Title.h
+++ b/Title.h
@@ -27,6 +27,10 @@ private:
 
 	// セーブデータの選択ボタン
 	Button* m_dataButton[GAME_DATA_SUM];
+	
+	// セーブデータ削除ボタン
+	Button* m_dataInitButton[GAME_DATA_SUM];
+	int m_initCnt; // 長押しの時間
 
 	// 戻るボタン
 	Button* m_cancelButton;

--- a/Title.h
+++ b/Title.h
@@ -1,0 +1,122 @@
+#ifndef TITLE_H_INCLUDED
+#define TITLE_H_INCLUDED
+
+
+class SoundPlayer;
+class Button;
+class TitleOption;
+class OpMovie;
+class AnimationDrawer;
+class GameData;
+
+
+/*
+* セーブデータ選択画面
+*/
+class SelectSaveData {
+private:
+	
+	// セーブデータの数
+	static const int GAME_DATA_SUM = 3;
+	
+	// セーブデータ
+	GameData* m_gameData[GAME_DATA_SUM];
+
+	// フォント
+	int m_font;
+
+	// セーブデータの選択ボタン
+	Button* m_dataButton[GAME_DATA_SUM];
+
+	// 戻るボタン
+	Button* m_cancelButton;
+
+	// 使用するセーブデータが決まっていないとき
+	static const int NOT_DECIDE_DATA = -1;
+
+	// 使用するセーブデータのインデックス
+	int m_useSaveDataIndex;
+
+public:
+
+	SelectSaveData();
+
+	~SelectSaveData();
+
+	// セーブデータが1つでも存在するか
+	bool saveDataExist();
+
+	// セーブデータ選択画面の処理
+	bool play(int handX, int handY);
+
+	// 描画
+	void draw(int handX, int handY);
+
+	// 使用するセーブデータのディレクトリ名
+	const char* useDirName();
+
+};
+
+
+/*
+* タイトル画面
+*/
+class Title {
+private:
+
+	// マウスカーソルの位置
+	int m_handX, m_handY;
+
+	// サウンドプレイヤー
+	SoundPlayer* m_soundPlayer;
+
+	// タイトルの画像
+	int m_titleGraph;
+
+	// オプション画面
+	TitleOption* m_option;
+
+	// OPムービー
+	OpMovie* m_movie;
+
+	// OP描画用
+	AnimationDrawer* m_animationDrawer;
+
+	// セーブデータ選択画面
+	SelectSaveData* m_selectSaveData;
+
+	// 今どの画面
+	enum TITLE_STATE {
+		OP,
+		TITLE,
+		SELECT,
+		OPTION
+	};
+	TITLE_STATE m_state;
+
+	// ボタン
+	int m_font;
+	Button* m_selectButton;
+	Button* m_optionButton;
+
+public:
+
+	Title();
+
+	~Title();
+
+	// タイトル画面の処理 終了ならtrue
+	bool play();
+
+	// 描画
+	void draw();
+
+	// 使用するセーブデータのフォルダ名
+	inline const char* useSaveFile() { 
+		return m_selectSaveData->useDirName();
+	}
+
+};
+
+
+#endif

--- a/Title.h
+++ b/Title.h
@@ -32,9 +32,6 @@ private:
 	Button* m_dataInitButton[GAME_DATA_SUM];
 	int m_initCnt; // 長押しの時間
 
-	// 戻るボタン
-	Button* m_cancelButton;
-
 	// 使用するセーブデータが決まっていないとき
 	static const int NOT_DECIDE_DATA = -1;
 
@@ -58,6 +55,9 @@ public:
 
 	// 使用するセーブデータのディレクトリ名
 	const char* useDirName();
+
+	// 全セーブデータ共通のデータをセーブ(タイトル画面のオプション用)
+	void saveCommon();
 
 };
 
@@ -103,14 +103,22 @@ private:
 	Button* m_selectButton;
 	Button* m_optionButton;
 
+	// 戻るボタン
+	Button* m_cancelButton;
+
 public:
 
 	Title();
 
 	~Title();
 
-	// タイトル画面の処理 終了ならtrue
-	bool play();
+	// タイトル画面の処理 継続、再起動、ゲーム開始
+	enum TITLE_RESULT {
+		CONTINUE,
+		REBOOT,
+		START
+	};
+	TITLE_RESULT play();
 
 	// 描画
 	void draw();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要

設定の初期化ボタンがほしい。やっぱなくていいかも。

sound volumeの変更が反映されない。訳が分からなくなっているのでいったん整理しよう。

タイトルオプションを終了し再起動するとマウスカーソルが消える。

# やったこと
タイトル画面追加　セーブデータが１つでもあればOPを流す仕様。

音量と解像度は全セーブデータで共通にした。

セーブデータ選択画面追加

セーブデータの削除機能も追加（ボタン長押し）

ゲーム起動時の解像度もセーブデータから取得するように。

解像度はテンプレから選ぶこともできるようにした。

動画が解像度変更に対応。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
唯一のグローバル変数（解像度）がすでにややこしい。どこで変更されるか追えなくなる。
