### PR TITLE
Api: 坂を上り切れないバグの修正

### DIFF
--- a/Debug.cpp
+++ b/Debug.cpp
@@ -40,7 +40,7 @@ void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, anime=%d", m_characters.size(), m_characterControllers.size(), m_animations.size());
 	debugObjects(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, m_attackObjects);
-	//m_characterControllers[1]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
+	m_characterControllers[0]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
 	if (m_movie_p != nullptr) {
 		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "Movie: cnt=%d", m_movie_p->getCnt());
 	}
@@ -92,7 +92,7 @@ void FollowNormalAI::debug(int x, int y, int color) const {
 // Actionクラスのデバッグ
 void CharacterAction::debugAction(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**CharacterAction**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "state=%d, grand=%d(%d%d), (vx,vy)=(%d,%d), runCnt=%d", (int)m_state, m_grand, m_grandLeftSlope, m_grandRightSlope, m_vx, m_vy, m_runCnt);
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "state=%d, grand=%d(%d%d), (vx,vy)=(%d,%d), slope=(%d,%d)", (int)m_state, m_grand, m_grandLeftSlope, m_grandRightSlope, m_vx, m_vy, m_grandLeftSlope, m_grandRightSlope);
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "制限中：(←, →, ↑, ↓)=(%d,%d,%d,%d)", m_leftLock, m_rightLock, m_upLock, m_downLock);
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "移動中：(←, →, ↑, ↓)=(%d,%d,%d,%d)", m_moveLeft, m_moveRight, m_moveUp, m_moveDown);
 	m_character_p->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 4, color);

--- a/Object.cpp
+++ b/Object.cpp
@@ -118,10 +118,11 @@ bool BoxObject::atari(CharacterController* characterController) {
 
 	// キャラが左右移動で当たっているか判定
 	if (characterY2 + characterVy > m_y1 && characterY1 + characterVy < m_y2) {
+		bool slope = characterController->getAction()->getGrandLeftSlope() || characterController->getAction()->getGrandRightSlope();
 		// 右に移動中のキャラが左から当たっているか判定
 		if (characterX2 <= m_x1 && characterX2 + characterVx >= m_x1) {
 			// 段差とみなして乗り越える
-			if (characterY2 - STAIR_HEIGHT <= m_y1) {
+			if (slope && characterY2 - STAIR_HEIGHT <= m_y1) {
 				// 適切な座標へ
 				characterController->setCharacterX(m_x1 - characterWide / 2 - characterVx);
 				characterController->setCharacterY(m_y1 - characterHeight);
@@ -140,7 +141,7 @@ bool BoxObject::atari(CharacterController* characterController) {
 		}
 		// 左に移動中のキャラが右から当たっているか判定
 		else if (characterX1 >= m_x2 && characterX1 + characterVx <= m_x2) {
-			if (characterY2 - STAIR_HEIGHT <= m_y1) {
+			if (slope && characterY2 - STAIR_HEIGHT <= m_y1) {
 				// 適切な座標へ
 				characterController->setCharacterX(m_x2 - characterWide / 2 + characterVx);
 				characterController->setCharacterY(m_y1 - characterHeight);

--- a/Object.h
+++ b/Object.h
@@ -122,7 +122,7 @@ class BoxObject :
 {
 private:
 	// 段差とみなして自動で乗り越えられる高さ
-	const int STAIR_HEIGHT = 50;
+	const int STAIR_HEIGHT = 200;
 
 	// オブジェクトの色
 	int m_color;

--- a/World.cpp
+++ b/World.cpp
@@ -681,6 +681,7 @@ void World::controlCharacter() {
 		// オブジェクトとの当たり判定
 		atariCharacterAndObject(controller, m_stageObjects);
 		atariCharacterAndObject(controller, m_attackObjects);
+		atariCharacterAndObject(controller, m_stageObjects);
 		if (controller->getAction()->getCharacter()->getId() == m_playerId) {
 			atariCharacterAndDoor(controller, m_doorObjects);
 		}


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#76 の対応

# やったこと
斜面を登っているとき（Action::m_grandRightSlope、Action::m_grandLeftSlopeがtrue）のときにのみ段差を登れるようにし、登れる段差の高さを高くした。

しかし、それだけでは解決にならない。

m_grandRightSlopeは毎フレームfalseにして坂に当たるとtrueになるが、for文で全Objectとの当たり判定をする際Objectの並びによっては上りたい段差との当たり判定が坂との当たり判定の前に到達してしまい、登れない。

妥協案として、当たり判定を毎フレーム2回行うことにした。

今後直すかも。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
