### PR TITLE
Api: ムービーイベントの修正

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -70,6 +70,7 @@ Movie::Movie(SoundPlayer* soundPlayer_p) {
 	m_cnt = 0;
 	m_animation = nullptr;
 	m_soundPlayer_p = soundPlayer_p;
+	m_bgmPath = "";
 }
 
 Movie::~Movie() {
@@ -79,6 +80,12 @@ Movie::~Movie() {
 }
 
 void Movie::play() {
+
+	if (m_cnt == 0) {
+		// 音楽開始
+		m_soundPlayer_p->setBGM(m_bgmPath.c_str());
+		m_soundPlayer_p->clearSoundQueue();
+	}
 
 	m_cnt++;
 
@@ -158,9 +165,8 @@ OpMovie::OpMovie(SoundPlayer* soundPlayer_p):
 	// 最初の画像
 	m_animation = new Animation(GAME_WIDE / 2, GAME_HEIGHT / 2, 120, m_titleH);
 
-	// 音楽
-	m_soundPlayer_p->setBGM("sound/movie/kobune.mp3");
-	m_soundPlayer_p->clearSoundQueue();
+	// BGM
+	m_bgmPath = "sound/movie/kobune.mp3";
 }
 
 OpMovie::~OpMovie() {

--- a/Animation.cpp
+++ b/Animation.cpp
@@ -71,12 +71,14 @@ Movie::Movie(SoundPlayer* soundPlayer_p) {
 	m_animation = nullptr;
 	m_soundPlayer_p = soundPlayer_p;
 	m_bgmPath = "";
+	m_originalBgmPath = m_soundPlayer_p->getBgmName();
 }
 
 Movie::~Movie() {
 	if (m_animation != nullptr) {
 		delete m_animation;
 	}
+	m_soundPlayer_p->setBGM(m_originalBgmPath);
 }
 
 void Movie::play() {

--- a/Animation.h
+++ b/Animation.h
@@ -84,6 +84,9 @@ protected:
 	// BGM‚ÌƒpƒX
 	std::string m_bgmPath;
 
+	// ‚à‚Æ‚à‚Æ—¬‚µ‚Ä‚¢‚½BGM
+	std::string m_originalBgmPath;
+
 public:
 	Movie(SoundPlayer* soundPlayer_p);
 	~Movie();

--- a/Animation.h
+++ b/Animation.h
@@ -2,6 +2,7 @@
 #define ANIMATION_H_INCLUDED
 
 #include <queue>
+#include <string>
 
 class GraphHandle;
 class GraphHandles;
@@ -79,6 +80,9 @@ protected:
 
 	// サウンドプレイヤー
 	SoundPlayer* m_soundPlayer_p;
+
+	// BGMのパス
+	std::string m_bgmPath;
 
 public:
 	Movie(SoundPlayer* soundPlayer_p);

--- a/Event.cpp
+++ b/Event.cpp
@@ -115,7 +115,7 @@ Event::~Event() {
 		delete m_eventFire[i];
 	}
 	for (unsigned int i = 0; i < m_eventElement.size(); i++) {
-		delete m_eventElement[i];
+		delete (m_eventElement[i]);
 	}
 }
 
@@ -202,6 +202,10 @@ void CharacterPointFire::setWorld(World* world) {
 */
 EventElement::EventElement(World* world) {
 	m_world_p = world;
+}
+
+EventElement::~EventElement() {
+	int test = 0;
 }
 
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -151,6 +151,7 @@ EVENT_RESULT Event::play() {
 		}
 		else { 
 			// ‚Ü‚¾ƒCƒxƒ“ƒg‘±‚­
+			m_eventElement[m_nowElement]->init();
 			return EVENT_RESULT::NOW;
 		}
 	}
@@ -322,11 +323,14 @@ MovieEvent::MovieEvent(World* world, SoundPlayer* soundPlayer, std::vector<std::
 {
 	//int textNum = stoi(param[1]);
 	m_movie = new OpMovie(soundPlayer);
-	m_world_p->setMovie(m_movie);
 }
 
 MovieEvent::~MovieEvent() {
 	delete m_movie;
+}
+
+void MovieEvent::init() {
+	m_world_p->setMovie(m_movie);
 }
 
 EVENT_RESULT MovieEvent::play() {

--- a/Event.h
+++ b/Event.h
@@ -49,11 +49,17 @@ protected:
 
 public:
 	EventElement(World* world);
+
+	// 初期化
+	virtual void init(){}
+
+	// プレイ
 	virtual EVENT_RESULT play() = 0;
 
 	// ハートのスキル発動が可能かどうか
 	virtual bool skillAble() = 0;
 
+	// セッタ
 	virtual void setWorld(World* world) { m_world_p = world; }
 };
 
@@ -157,6 +163,7 @@ private:
 public:
 	ChangeBrainEvent(World* world, std::vector<std::string> param);
 
+	// プレイ
 	EVENT_RESULT play();
 
 	// ハートのスキル発動が可能かどうか
@@ -183,6 +190,7 @@ private:
 public:
 	ChangeGroupEvent(World* world, std::vector<std::string> param);
 
+	// プレイ
 	EVENT_RESULT play();
 
 	// ハートのスキル発動が可能かどうか
@@ -207,6 +215,7 @@ private:
 public:
 	DeadCharacterEvent(World* world, std::vector<std::string> param);
 
+	// プレイ
 	EVENT_RESULT play();
 
 	// ハートのスキル発動が可能かどうか
@@ -231,6 +240,7 @@ private:
 public:
 	DeadGroupEvent(World* world, std::vector<std::string> param);
 
+	// プレイ
 	EVENT_RESULT play();
 
 	// ハートのスキル発動が可能かどうか
@@ -249,6 +259,7 @@ public:
 	TalkEvent(World* world, SoundPlayer* soundPlayer, std::vector<std::string> param);
 	~TalkEvent();
 
+	// プレイ
 	EVENT_RESULT play();
 
 	// ハートのスキル発動が可能かどうか
@@ -267,6 +278,10 @@ public:
 	MovieEvent(World* world, SoundPlayer* soundPlayer, std::vector<std::string> param);
 	~MovieEvent();
 
+	// 初期化
+	void init();
+
+	// プレイ
 	EVENT_RESULT play();
 
 	// ハートのスキル発動が可能かどうか

--- a/Event.h
+++ b/Event.h
@@ -49,6 +49,7 @@ protected:
 
 public:
 	EventElement(World* world);
+	virtual ~EventElement();
 
 	// ‰Šú‰»
 	virtual void init(){}

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -48,7 +48,7 @@ void SoundPlayer::setVolume(int volume) {
 
 // BGMをセット（変更）
 void SoundPlayer::setBGM(std::string bgmName, int volume) {
-	if (bgmName == m_bgmName) { return; }
+	if (bgmName == m_bgmName || bgmName == "") { return; }
 	DeleteSoundMem(m_bgmHandle);
 	m_bgmName = bgmName;
 	m_bgmHandle = LoadSoundMem(bgmName.c_str());

--- a/Sound.h
+++ b/Sound.h
@@ -28,9 +28,13 @@ public:
 	SoundPlayer();
 	~SoundPlayer();
 
-	void setVolume(int volume);
+	// ゲッタ
 	inline int getVolume() const { return m_volume; }
 	inline int getCameraX() const { return m_cameraX; }
+	const char* getBgmName() const { return m_bgmName.c_str(); }
+
+	// セッタ
+	void setVolume(int volume);
 	inline void setCameraX(int cameraX) { m_cameraX = cameraX; }
 
 	// BGMをセット（変更）


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
2つの問題を解決する。
- Movieイベントがnewされた瞬間にBGMが流れる+画面に表示され、先にあるTalkイベントと衝突する
- Movieイベント終了後にBGMが戻らずループする

# やったこと
1つ目の問題は、Eventが発火した際すべてのEventElementがnewされるが、その際MovieEventはnewされた瞬間にWorldへMovieを渡すことと、MovieクラスがコンストラクタでBGMを設定しているのが原因。

EventElementにinit関数を用意し、自分の番が来た際最初に一回だけ実行してもらうようにした。MovieEventはinit関数内でWorldへMovieを渡す。

また、Movieクラスはコンストラクタではなくplay関数内でm_cnt == 0のときBGMをセットするように変更。

2つ目の問題は、MovieクラスがもともとのBGM名を記録しておき、デストラクタで再セットすることで対処。

**しかしここで、大きな問題に直面。**

なんとMovieクラスのデストラクタが呼ばれない。

原因は、基底クラスの型で保持しているインスタンスは、delete時派生クラスのデストラクタが呼ばれないことだった。

対処方法としては、基底クラスのデストラクタを仮想関数にすることだった。

今まで知らなかった。すべて仮想関数にしていない。メモリリークしている。

参考：https://torakichi.hateblo.jp/entry/2018/11/17/172634

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
