### PR TITLE
【バグ修正】基底クラスのデストラクタにvirtualを付与

### DIFF
--- a/Animation.h
+++ b/Animation.h
@@ -89,7 +89,7 @@ protected:
 
 public:
 	Movie(SoundPlayer* soundPlayer_p);
-	~Movie();
+	virtual ~Movie();
 
 	// ƒQƒbƒ^
 	bool getFinishFlag() const { return m_finishFlag; }

--- a/Character.h
+++ b/Character.h
@@ -202,7 +202,7 @@ public:
 	// コンストラクタ
 	Character();
 	Character(int hp, int x, int y, int groupId);
-	~Character();
+	virtual ~Character();
 
 	virtual Character* createCopy() = 0;
 	void setParam(Character* character);

--- a/Event.cpp
+++ b/Event.cpp
@@ -205,7 +205,7 @@ EventElement::EventElement(World* world) {
 }
 
 EventElement::~EventElement() {
-	int test = 0;
+
 }
 
 

--- a/Object.h
+++ b/Object.h
@@ -41,6 +41,7 @@ protected:
 public:
 	Object();
 	Object(int x1, int y1, int x2, int y2, int hp = -1);
+	virtual ~Object() { }
 
 	virtual Object* createCopy() = 0;
 	void setParam(Object* object);

--- a/PausePage.h
+++ b/PausePage.h
@@ -86,7 +86,7 @@ private:
 
 public:
 	GamePause(SoundPlayer* soundPlayer);
-	~GamePause();
+	virtual ~GamePause();
 
 	int getNewSoundVolume();
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#83 で発覚した、派生クラスのデストラクタが呼ばれない問題に対処。

対処しないとメモリリークする。

# やったこと
デストラクタを定義している派生クラスを持つ基底クラスにvirtualのデストラクタを定義してやる。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
一通りテストプレイした感じ変化はないため多分大丈夫。

ブレークポイントを設定し、デバッグモードで派生クラスのデストラクタが呼ばれていることも確認。

# 懸念点
記入欄
