### PR TITLE
Api: ノックバックのない敵もDAMAGE状態になる

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -628,8 +628,7 @@ void FlightAI::moveOrder(int& right, int& left, int& up, int& down) {
 		}
 		else {
 			// ƒ‰ƒ“ƒ_ƒ€‚Éİ’è
-			m_gx = GetRand(200) - 400;
-			m_gx += x;
+			m_gx = x + (GetRand(200) - 400);
 			m_gy = y + (GetRand(200) - 100);
 		}
 		if (abs(x - m_gx) < 50) { m_gx = x; }
@@ -664,8 +663,7 @@ void FollowFlightAI::moveOrder(int& right, int& left, int& up, int& down) {
 		}
 		else {
 			// ƒ‰ƒ“ƒ_ƒ€‚Éİ’è
-			m_gx = GetRand(200) - 400;
-			m_gx += x;
+			m_gx = x + (GetRand(200) - 400);
 			m_gy = y + (GetRand(200) - 100);
 		}
 		if (abs(x - m_gx) < 50) { m_gx = x; }

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -149,7 +149,7 @@ void CharacterAction::setCharacterLeftDirection(bool leftDirection) {
 
 // É_ÉÅÅ[ÉW
 void CharacterAction::damage(int vx, int vy, int damageValue) {
-	m_damageCnt = 20;
+	m_damageCnt = DAMAGE_TIME;
 	setState(CHARACTER_STATE::DAMAGE);
 	if (!m_heavy) {
 		m_vx += vx;

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -147,6 +147,24 @@ void CharacterAction::setCharacterLeftDirection(bool leftDirection) {
 	m_character_p->setLeftDirection(leftDirection);
 }
 
+// ダメージ
+void CharacterAction::damage(int vx, int vy, int damageValue) {
+	m_damageCnt = 20;
+	setState(CHARACTER_STATE::DAMAGE);
+	if (!m_heavy) {
+		m_vx += vx;
+		m_vy += vy;
+		m_character_p->setLeftDirection(m_vx > 0);
+		// 宙に浮かせる
+		m_grand = false;
+		m_grandRightSlope = false;
+		m_grandLeftSlope = false;
+	}
+	// HP減少
+	m_character_p->damageHp(damageValue);
+	m_boostCnt = 0;
+}
+
 void CharacterAction::startSlash() {
 
 }
@@ -189,9 +207,11 @@ void CharacterAction::setGrand(bool grand) {
 
 void CharacterAction::setSquat(bool squat) {
 	if (squat && m_grand && m_state != CHARACTER_STATE::DAMAGE && m_state != CHARACTER_STATE::SLASH && m_state != CHARACTER_STATE::PREJUMP) {
+		// しゃがめる状態なのでしゃがむ
 		m_squat = true;
 	}
 	else {
+		// しゃがめない状態
 		m_squat = false;
 	}
 }
@@ -653,25 +673,6 @@ Object* StickAction::slashAttack(int gx, int gy) {
 	return m_character_p->slashAttack(m_attackLeftDirection, m_slashCnt, m_soundPlayer_p);
 }
 
-// ダメージを受ける
-void StickAction::damage(int vx, int vy, int damageValue) {
-	if (!m_heavy) {
-		setState(CHARACTER_STATE::DAMAGE);
-		m_vx += vx;
-		m_vy += vy;
-		// 地面についていても少しはダメージモーション
-		if (m_vy >= 0 && m_grand) { m_damageCnt = 20; }
-		m_character_p->setLeftDirection(m_vx > 0);
-		// 宙に浮かせる
-		m_grand = false;
-		m_grandRightSlope = false;
-		m_grandLeftSlope = false;
-	}
-	// HP減少
-	m_character_p->damageHp(damageValue);
-	m_boostCnt = 0;
-}
-
 
 /*
 * ヴァルキリア用Action 斬撃時に移動する
@@ -694,7 +695,7 @@ CharacterAction* ValkiriaAction::createCopy(vector<Character*> characters) {
 	return res;
 }
 
-// 着地
+// 着地 ヴァルキリアは斬撃中に着地しても着地モーションにならない
 void ValkiriaAction::setGrand(bool grand) {
 	if (m_vy > 0) { // 着地モーションになる
 		if (m_slashCnt == 0) {
@@ -734,14 +735,14 @@ void ValkiriaAction::finishSlash() {
 	m_slashCnt = 0;
 }
 
-// ダメージを受ける
+// ダメージを受ける ヴァルキリアは斬撃中はHPが減るだけ
 void ValkiriaAction::damage(int vx, int vy, int damageValue) {
 	if (m_slashCnt > 0) {
 		// HP減少
 		m_character_p->damageHp(damageValue / 2);
 	}
 	else {
-		StickAction::damage(vx, vy, damageValue);
+		CharacterAction::damage(vx, vy, damageValue);
 	}
 }
 
@@ -1027,23 +1028,4 @@ Object* FlightAction::slashAttack(int gx, int gy) {
 	}
 	// 攻撃のタイミングじゃないならnullptrが返る
 	return m_character_p->slashAttack(m_attackLeftDirection, m_slashCnt, m_soundPlayer_p);
-}
-
-// ダメージ
-void FlightAction::damage(int vx, int vy, int damageValue) {
-	if (!m_heavy) {
-		setState(CHARACTER_STATE::DAMAGE);
-		m_vx += vx;
-		m_vy += vy;
-		// ダメージモーションの時間
-		m_damageCnt = 20;
-		m_character_p->setLeftDirection(m_vx > 0);
-		// 宙に浮かせる
-		m_grand = false;
-		m_grandRightSlope = false;
-		m_grandLeftSlope = false;
-	}
-	// HP減少
-	m_character_p->damageHp(damageValue);
-	m_boostCnt = 0;
 }

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -67,6 +67,9 @@ protected:
 	int m_boostCnt;
 	const int BOOST_TIME = 10;
 
+	// やられ状態の時間
+	const int DAMAGE_TIME = 20;
+
 	// ノックバックなしのキャラならtrue
 	bool m_heavy = false;
 

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -191,8 +191,8 @@ public:
 	// 斬撃攻撃
 	virtual Object* slashAttack(int gx, int gy) = 0;
 
-	// ダメージ
-	virtual void damage(int vx, int vy, int damageValue) = 0;
+	// ダメージ 必要に応じてオーバーライド
+	virtual void damage(int vx, int vy, int damageValue);
 
 	// 斬撃開始の処理 必要に応じてオーバーライド
 	virtual void startSlash();
@@ -266,9 +266,6 @@ public:
 
 	// 斬撃攻撃
 	Object* slashAttack(int gx, int gy);
-
-	// ダメージ
-	void damage(int vx, int vy, int damageValue);
 };
 
 
@@ -347,9 +344,6 @@ public:
 
 	// 斬撃攻撃
 	Object* slashAttack(int gx, int gy);
-
-	// ダメージ
-	void damage(int vx, int vy, int damageValue);
 };
 
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#84 

ノックバックのない敵はDAMAGE状態にならないため斬撃等が連続ヒットして瞬殺される問題を解消

# やったこと
CharacterAction::damageを修正。

StickActionのキャラは空中でDAMAGE状態になってすぐに着地しても復帰しなくなるが、まあいいでしょう。

プレイした感じ全く問題ない。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
