### PR TITLE
Api: Brainのバグ修正、ヴァルキリアのAI改善

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -735,7 +735,7 @@ int ValkiriaAI::jumpOrder() {
 bool ValkiriaAI::needSearchTarget() const {
 	// 今のターゲットは距離が遠いから
 	if (m_target_p != nullptr && m_target_p->getHp() > 0) {
-		if (abs(m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX()) > SLASH_REACH) {
+		if (abs(m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX()) > SLASH_REACH * 2) {
 			return true;
 		}
 	}

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -69,6 +69,31 @@ Brain* createBrain(const string brainName, const Camera* camera_p) {
 }
 
 
+// targetを持つAI用、targetIdに対応するCharacterをcopyのtargetにセット
+void copyTarget(std::vector<Character*> characters, int targetId, NormalAI* copy) {
+	if (targetId != -1) {
+		for (unsigned int i = 0; i < characters.size(); i++) {
+			if (targetId == characters[i]->getId()) {
+				copy->setTarget(characters[i]);
+				break;
+			}
+		}
+	}
+}
+
+// followを持つAI用、followIdに対応するCharacterをcopyのfollowにセット
+void copyFollow(std::vector<Character*> characters, int followId, FollowNormalAI* copy) {
+	if (followId != -1) {
+		for (unsigned int i = 0; i < characters.size(); i++) {
+			if (followId == characters[i]->getId()) {
+				copy->setFollow(characters[i]);
+				break;
+			}
+		}
+	}
+}
+
+
 // Brainクラス
 Brain::Brain() {
 	m_characterAction_p = nullptr;
@@ -92,6 +117,10 @@ void KeyboardBrain::bulletTargetPoint(int& x, int& y) {
 
 	x = mouseX;
 	y = mouseY;
+}
+
+void KeyboardBrain::slashTargetPoint(int& x, int& y) {
+	bulletTargetPoint(x, y);
 }
 
 // 話しかけたり扉入ったり
@@ -147,15 +176,7 @@ NormalAI::NormalAI() {
 
 Brain* NormalAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
 	NormalAI* res = new NormalAI();
-
-	if (m_target_p != nullptr) {
-		for (unsigned int i = 0; i < characters.size(); i++) {
-			if (m_target_p->getId() == characters[i]->getId()) {
-				res->setTarget(characters[i]);
-				break;
-			}
-		}
-	}
+	copyTarget(characters, getTargetId(), res);
 	setParam(res);
 	return res;
 }
@@ -191,6 +212,17 @@ void NormalAI::bulletTargetPoint(int& x, int& y) {
 	else { // ターゲットに向かって射撃攻撃
 		x = m_target_p->getCenterX() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2);
 		y = m_target_p->getCenterY() + (GetRand(BULLET_ERROR) - BULLET_ERROR / 2);
+	}
+}
+
+void NormalAI::slashTargetPoint(int& x, int& y) {
+	if (m_target_p == nullptr) {
+		x = 0;
+		y = 0;
+	}
+	else { // ターゲットに向かって射撃攻撃
+		x = m_target_p->getCenterX();
+		y = m_target_p->getCenterY();
 	}
 }
 
@@ -335,6 +367,9 @@ int NormalAI::squatOrder() {
 	if (m_characterAction_p->getState() == CHARACTER_STATE::DAMAGE) {
 		m_squatCnt = 0;
 	}
+	if (m_characterAction_p->getBulletCnt() > 0 || m_characterAction_p->getSlashCnt() > 0) {
+		m_squatCnt = 0;
+	}
 
 	// 目標地点にいないならしゃがまない
 	int x = m_characterAction_p->getCharacter()->getCenterX();
@@ -414,58 +449,12 @@ bool NormalAI::needSearchTarget() const {
 	return false;
 }
 
-int  NormalAI::getTargetId() const { return m_target_p == nullptr ? -1 : m_target_p->getId(); }
-
-const char*  NormalAI::getTargetName() const { return m_target_p == nullptr ? "" : m_target_p->getName().c_str(); }
-
-// 斜方投射の計算をする
-void setParabolaBulletTarget(int& x, int& y, const CharacterAction* characterAction_p, const Character* target_p) {
-	if (target_p == nullptr) {
-		x = 0;
-		y = 0;
-	}
-	else { // ターゲットに向かって射撃攻撃
-		const int G = -ParabolaBullet::G;
-		int dx = target_p->getCenterX() - characterAction_p->getCharacter()->getCenterX();
-		int gx = abs(dx);
-		int gy = -(target_p->getCenterY() - characterAction_p->getCharacter()->getCenterY());
-		int v = characterAction_p->getCharacter()->getAttackInfo()->bulletSpeed();
-		double A = (G * gx * gx) / (2 * v * v);
-		double a = gx / A;
-		double b = 1 - (gy / A);
-		double routeInside = a * a / 4 - b;
-		if (routeInside >= 0) {
-			double route = sqrt(routeInside);
-			if (GetRand(99) < 50) { route *= -1; }
-			double r = atan(route - (a / 2));
-			if (dx > 0) {
-				x = (int)(characterAction_p->getCharacter()->getCenterX() + v * cos(r));
-			}
-			else {
-				x = (int)(characterAction_p->getCharacter()->getCenterX() - v * cos(r));
-			}
-			y = (int)(characterAction_p->getCharacter()->getCenterY() - v * sin(r));
-		}
-		else {
-			// 射程外なら45度で投げる
-			double r = 3.14 / 4;
-			if (dx > 0) {
-				x = (int)(characterAction_p->getCharacter()->getCenterX() + v * cos(r));
-			}
-			else {
-				x = (int)(characterAction_p->getCharacter()->getCenterX() - v * cos(r));
-			}
-			y = (int)(characterAction_p->getCharacter()->getCenterY() - v * sin(r));
-		}
-	}
+int  NormalAI::getTargetId() const { 
+	return m_target_p == nullptr ? -1 : m_target_p->getId();
 }
 
-void ParabolaAI::bulletTargetPoint(int& x, int& y) {
-	setParabolaBulletTarget(x, y, m_characterAction_p, m_target_p);
-}
-
-void FollowParabolaAI::bulletTargetPoint(int& x, int& y) {
-	setParabolaBulletTarget(x, y, m_characterAction_p, m_target_p);
+const char*  NormalAI::getTargetName() const { 
+	return m_target_p == nullptr ? "" : m_target_p->getName().c_str();
 }
 
 
@@ -500,15 +489,23 @@ Brain* FollowNormalAI::createCopy(std::vector<Character*> characters, const Came
 	return res;
 }
 
-int FollowNormalAI::getFollowId() const { return m_follow_p == nullptr ? -1 : m_follow_p->getId(); }
+int FollowNormalAI::getFollowId() const { 
+	return m_follow_p == nullptr ? -1 : m_follow_p->getId();
+}
 
-const char* FollowNormalAI::getFollowName() const { return m_follow_p == nullptr ? "ハート" : m_follow_p->getName().c_str(); }
+const char* FollowNormalAI::getFollowName() const { 
+	return m_follow_p == nullptr ? "ハート" : m_follow_p->getName().c_str();
+}
+
 const Character* FollowNormalAI::getFollow() const {
 	return m_follow_p;
 }
 
 bool FollowNormalAI::checkAlreadyFollow() {
+	// 追跡対象がいない
 	if (m_follow_p == nullptr) { return true; }
+	// ハートがスキル発動中で動かないなら無視
+	if (m_follow_p->getFreeze()) { return true; }
 	int followX = m_follow_p->getCenterX();
 	return  m_gx < followX + FOLLOW_X_ERROR && m_gx > followX - FOLLOW_X_ERROR;
 }
@@ -564,31 +561,125 @@ bool FollowNormalAI::needSearchFollow() const {
 
 
 /*
-* ヴァルキリア用AI
+* 斜方投射するNormalAI
 */
-bool ValkiriaAI::checkAlreadyFollow() {
-	// 戦闘中の敵が近くにいるならハートとの距離を気にしない
-	if (m_target_p != nullptr) {
-		if (m_target_p->getHp() > 0) {
-			if (abs(m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX()) <= 2000) {
-				return true;
+ParabolaAI::ParabolaAI() :
+	NormalAI()
+{
+
+}
+
+Brain* ParabolaAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	ParabolaAI* res = new ParabolaAI();
+	copyTarget(characters, getTargetId(), res);
+	setParam(res);
+	return res;
+}
+
+// 斜方投射の計算をする
+void setParabolaBulletTarget(int& x, int& y, const CharacterAction* characterAction_p, const Character* target_p) {
+	if (target_p == nullptr) {
+		x = 0;
+		y = 0;
+	}
+	else { // ターゲットに向かって射撃攻撃
+		const int G = -ParabolaBullet::G;
+		int dx = target_p->getCenterX() - characterAction_p->getCharacter()->getCenterX();
+		int gx = abs(dx);
+		int gy = -(target_p->getCenterY() - characterAction_p->getCharacter()->getCenterY());
+		int v = characterAction_p->getCharacter()->getAttackInfo()->bulletSpeed();
+		double A = (G * gx * gx) / (2 * v * v);
+		double a = gx / A;
+		double b = 1 - (gy / A);
+		double routeInside = a * a / 4 - b;
+		if (routeInside >= 0) {
+			double route = sqrt(routeInside);
+			if (GetRand(99) < 50) { route *= -1; }
+			double r = atan(route - (a / 2));
+			if (dx > 0) {
+				x = (int)(characterAction_p->getCharacter()->getCenterX() + v * cos(r));
 			}
+			else {
+				x = (int)(characterAction_p->getCharacter()->getCenterX() - v * cos(r));
+			}
+			y = (int)(characterAction_p->getCharacter()->getCenterY() - v * sin(r));
+		}
+		else {
+			// 射程外なら45度で投げる
+			double r = 3.14 / 4;
+			if (dx > 0) {
+				x = (int)(characterAction_p->getCharacter()->getCenterX() + v * cos(r));
+			}
+			else {
+				x = (int)(characterAction_p->getCharacter()->getCenterX() - v * cos(r));
+			}
+			y = (int)(characterAction_p->getCharacter()->getCenterY() - v * sin(r));
 		}
 	}
-	// ハートに近いか判定
-	return FollowNormalAI::checkAlreadyFollow();
+}
+
+void ParabolaAI::bulletTargetPoint(int& x, int& y) {
+	setParabolaBulletTarget(x, y, m_characterAction_p, m_target_p);
+}
+
+
+/*
+* 斜方投射するFollowNormalAI
+*/
+FollowParabolaAI::FollowParabolaAI() :
+	FollowNormalAI()
+{
+
+}
+
+Brain* FollowParabolaAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	FollowParabolaAI* res = new FollowParabolaAI();
+	copyTarget(characters, getTargetId(), res);
+	copyFollow(characters, getFollowId(), res);
+	setParam(res);
+	return res;
+}
+void FollowParabolaAI::bulletTargetPoint(int& x, int& y) {
+	setParabolaBulletTarget(x, y, m_characterAction_p, m_target_p);
+}
+
+
+/*
+* ヴァルキリア用AI
+*/
+ValkiriaAI::ValkiriaAI() :
+	FollowNormalAI()
+{
+
+}
+
+Brain* ValkiriaAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	ValkiriaAI* res = new ValkiriaAI();
+	copyTarget(characters, getTargetId(), res);
+	copyFollow(characters, getFollowId(), res);
+	setParam(res);
+	return res;
 }
 
 int ValkiriaAI::slashOrder() {
 	if (m_target_p == nullptr || m_target_p->getHp() == 0) {
 		return 0;
 	}
+	int x = m_characterAction_p->getCharacter()->getCenterX();
+	int y = m_characterAction_p->getCharacter()->getCenterY();
+	// 距離の近い敵が高くにいるなら
+	if ((abs(x - m_target_p->getCenterX()) < SLASH_REACH) && (y - m_target_p->getCenterY() > 200)) {
+		// 地面にいるうちは斬撃しない
+		if (m_characterAction_p->getGrand()) {
+			return 0;
+		}
+	}
 	// 遠距離の敵には斬撃しない
-	if (abs(m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX()) > 2000) {
+	if (abs(m_target_p->getCenterX() - x) >= SLASH_REACH) {
 		return 0;
 	}
 	// ランダムで斬撃
-	if (GetRand(30) == 0) {
+	if (GetRand(50) == 0) {
 		return 1;
 	}
 	return 0;
@@ -598,12 +689,63 @@ void ValkiriaAI::moveOrder(int& right, int& left, int& up, int& down) {
 	if (m_characterAction_p->getSlashCnt() > 0) {
 		// 攻撃中は移動しない
 		right = 0; left = 0; up = 0; down = 0;
+		return;
 	}
-	else {
-		FollowNormalAI::moveOrder(right, left, up, down);
+	int x = m_characterAction_p->getCharacter()->getCenterX();
+	if (m_target_p != nullptr && m_target_p->getHp() > 0) {
+		// 戦闘中の敵が近くにいるならハートとの距離をある程度気にせずtargetを追跡
+		if (abs(m_follow_p->getCenterX() - x) < FOLLOW_X_ERROR * 2 && abs(m_target_p->getCenterX() - x) < SLASH_REACH) {
+			NormalAI::moveOrder(right, left, up, down);
+			return;
+		}
 	}
+	FollowNormalAI::moveOrder(right, left, up, down);
 }
 
+int ValkiriaAI::jumpOrder() {
+	int maxJump = m_characterAction_p->getPreJumpMax();
+	int minJump = maxJump / 3;
+	int x = m_characterAction_p->getCharacter()->getCenterX();
+	int y = m_characterAction_p->getCharacter()->getCenterY();
+	if (m_jumpCnt == 0) {
+		// ランダムでジャンプ
+		if (m_squatCnt == 0 && GetRand(99) < 20 && m_target_p != nullptr && m_target_p->getHp() > 0) {
+			// 距離の近い敵が高くにいるなら
+			if ((abs(x - m_target_p->getCenterX()) < SLASH_REACH) && (y - m_target_p->getCenterY() > 200)) {
+				m_jumpCnt = GetRand(maxJump - minJump) + minJump;
+			}
+		}
+	}
+	return NormalAI::jumpOrder();
+}
+
+// 攻撃対象を変更する必要があるならtrueでアピールする。
+bool ValkiriaAI::needSearchTarget() const {
+	// 今のターゲットは距離が遠いから
+	if (m_target_p != nullptr && m_target_p->getHp() > 0) {
+		if (abs(m_target_p->getCenterX() - m_characterAction_p->getCharacter()->getCenterX()) > SLASH_REACH) {
+			return true;
+		}
+	}
+	return NormalAI::needSearchTarget();
+}
+
+
+/*
+* 空を飛ぶAI
+*/
+FlightAI::FlightAI() :
+	NormalAI()
+{
+
+}
+
+Brain* FlightAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	FlightAI* res = new FlightAI();
+	copyTarget(characters, getTargetId(), res);
+	setParam(res);
+	return res;
+}
 
 void FlightAI::moveOrder(int& right, int& left, int& up, int& down) {
 	// 現在地
@@ -638,6 +780,23 @@ void FlightAI::moveOrder(int& right, int& left, int& up, int& down) {
 }
 
 
+/*
+* 空を飛ぶAI
+*/
+FollowFlightAI::FollowFlightAI() :
+	FollowNormalAI()
+{
+
+}
+
+Brain* FollowFlightAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	FollowFlightAI* res = new FollowFlightAI();
+	copyTarget(characters, getTargetId(), res);
+	copyFollow(characters, getFollowId(), res);
+	setParam(res);
+	return res;
+}
+
 void FollowFlightAI::moveOrder(int& right, int& left, int& up, int& down) {
 	// 現在地
 	int x = m_characterAction_p->getCharacter()->getCenterX();
@@ -670,4 +829,55 @@ void FollowFlightAI::moveOrder(int& right, int& left, int& up, int& down) {
 		m_try = false;
 	}
 	stickOrder(right, left, up, down);
+}
+
+
+/*
+* 射撃だけのNormalAI
+*/
+BulletOnlyAI::BulletOnlyAI() :
+	NormalAI()
+{
+
+}
+
+Brain* BulletOnlyAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	BulletOnlyAI* res = new BulletOnlyAI();
+	copyTarget(characters, getTargetId(), res);
+	setParam(res);
+	return res;
+}
+
+
+/*
+* 斬撃だけのNormalAI
+*/
+SlashOnlyAI::SlashOnlyAI() :
+	NormalAI()
+{
+
+}
+
+Brain* SlashOnlyAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	SlashOnlyAI* res = new SlashOnlyAI();
+	copyTarget(characters, getTargetId(), res);
+	setParam(res);
+	return res;
+}
+
+
+/*
+* 斜方投射だけのNormalAI
+*/
+ParabolaOnlyAI::ParabolaOnlyAI() :
+	ParabolaAI()
+{
+
+}
+
+Brain* ParabolaOnlyAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	ParabolaOnlyAI* res = new ParabolaOnlyAI();
+	copyTarget(characters, getTargetId(), res);
+	setParam(res);
+	return res;
 }

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -504,13 +504,18 @@ const Character* FollowNormalAI::getFollow() const {
 bool FollowNormalAI::checkAlreadyFollow() {
 	// 追跡対象がいない
 	if (m_follow_p == nullptr) { return true; }
-	// ハートがスキル発動中で動かないなら無視
-	if (m_follow_p->getFreeze()) { return true; }
 	int followX = m_follow_p->getCenterX();
 	return  m_gx < followX + FOLLOW_X_ERROR && m_gx > followX - FOLLOW_X_ERROR;
 }
 
 void FollowNormalAI::moveOrder(int& right, int& left, int& up, int& down) {
+
+	// ハートがスキル発動中で動かないなら無視
+	if (m_follow_p != nullptr && m_follow_p->getFreeze()) { 
+		NormalAI::moveOrder(right, left, up, down);
+		return;
+	}
+
 	// 現在地
 	int x = m_characterAction_p->getCharacter()->getCenterX();
 	int y = m_characterAction_p->getCharacter()->getCenterY();
@@ -686,6 +691,13 @@ int ValkiriaAI::slashOrder() {
 }
 
 void ValkiriaAI::moveOrder(int& right, int& left, int& up, int& down) {
+
+	// ハートがスキル発動中で動かないなら無視
+	if (m_follow_p != nullptr && m_follow_p->getFreeze()) {
+		NormalAI::moveOrder(right, left, up, down);
+		return;
+	}
+
 	if (m_characterAction_p->getSlashCnt() > 0) {
 		// 攻撃中は移動しない
 		right = 0; left = 0; up = 0; down = 0;
@@ -798,6 +810,13 @@ Brain* FollowFlightAI::createCopy(std::vector<Character*> characters, const Came
 }
 
 void FollowFlightAI::moveOrder(int& right, int& left, int& up, int& down) {
+
+	// ハートがスキル発動中で動かないなら無視
+	if (m_follow_p != nullptr && m_follow_p->getFreeze()) {
+		NormalAI::moveOrder(right, left, up, down);
+		return;
+	}
+
 	// 現在地
 	int x = m_characterAction_p->getCharacter()->getCenterX();
 	int y = m_characterAction_p->getCharacter()->getCenterY();

--- a/Brain.h
+++ b/Brain.h
@@ -35,6 +35,9 @@ public:
 	// 遠距離攻撃の目標座標
 	virtual void bulletTargetPoint(int& x, int& y) = 0;
 
+	// 近距離攻撃の目標座標
+	virtual void slashTargetPoint(int& x, int& y) = 0;
+
 	// 移動（上下左右の入力）
 	virtual void moveOrder(int& right, int& left, int& up, int& down) = 0;
 
@@ -72,7 +75,7 @@ public:
 	virtual void setTarget(Character* character) {  }
 
 	// 追跡対象の近くにいるか判定
-	bool checkAlreadyFollow() { return true; }
+	virtual bool checkAlreadyFollow() { return true; }
 };
 
 
@@ -93,11 +96,18 @@ private:
 public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
+
 	KeyboardBrain(const Camera* camera);
+
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera) { return new KeyboardBrain(camera); }
+
 	void debug(int x, int y, int color) const;
+
+	// セッタ
 	inline void setCharacterAction(const CharacterAction* characterAction) { m_characterAction_p = characterAction; }
+
 	void bulletTargetPoint(int& x, int& y);
+	void slashTargetPoint(int& x, int& y);
 	bool actionOrder();
 	void moveOrder(int& right, int& left, int& up, int& down);
 	int jumpOrder();
@@ -116,12 +126,19 @@ class Freeze :
 public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
+
 	Freeze() { }
+
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera) { return new Freeze(); }
+
 	void debug(int x, int y, int color) const { }
-	bool actionOrder() { return false; }
+
+	// セッタ
 	void setCharacterAction(const CharacterAction* characterAction) {  }
+
+	bool actionOrder() { return false; }
 	void bulletTargetPoint(int& x, int& y) {  }
+	void slashTargetPoint(int& x, int& y) {  }
 	void moveOrder(int& right, int& left, int& up, int& down) { right = 0; left = 0; up = 0; down = 0; }
 	int jumpOrder() { return 0; }
 	int squatOrder() { return 0; }
@@ -174,10 +191,15 @@ protected:
 public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
+
 	NormalAI();
+
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
 	void setParam(NormalAI* brain);
 
+	void debug(int x, int y, int color) const;
+
+	// セッタ
 	void setRightKey(int rightKey) { m_rightKey = rightKey; }
 	void setLeftKey(int leftKey) { m_leftKey = leftKey; }
 	void setUpKey(int upKey) { m_upKey = upKey; }
@@ -188,10 +210,10 @@ public:
 	void setGy(int gy) { m_gy = gy; }
 	void setMoveCnt(int cnt) { m_moveCnt = cnt; }
 	void setTarget(Character* character) { m_target_p = character; }
-
-	void debug(int x, int y, int color) const;
 	void setCharacterAction(const CharacterAction* characterAction);
+
 	void bulletTargetPoint(int& x, int& y);
+	void slashTargetPoint(int& x, int& y);
 	void moveOrder(int& right, int& left, int& up, int& down);
 	void moveUpDownOrder(int x, int y, bool& tryFlag);
 	int jumpOrder();
@@ -216,18 +238,8 @@ protected:
 
 
 /*
-* ParabolaBulletを使うAI
+* 仲間についていきつつ戦うNormalAI
 */
-class ParabolaAI :
-	public NormalAI
-{
-public:
-	static const char* BRAIN_NAME;
-	const char* getBrainName() const { return this->BRAIN_NAME; }
-	void bulletTargetPoint(int& x, int& y);
-};
-
-
 class FollowNormalAI :
 	public NormalAI
 {
@@ -241,6 +253,7 @@ protected:
 public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
+
 	FollowNormalAI();
 
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
@@ -268,6 +281,25 @@ public:
 	bool checkAlreadyFollow();
 };
 
+
+/*
+* ParabolaBulletを使うAI
+*/
+class ParabolaAI :
+	public NormalAI
+{
+public:
+	static const char* BRAIN_NAME;
+	const char* getBrainName() const { return this->BRAIN_NAME; }
+
+	ParabolaAI();
+
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+
+	void bulletTargetPoint(int& x, int& y);
+};
+
+
 /*
 * ParabolaBulletを使うAI
 */
@@ -277,6 +309,11 @@ class FollowParabolaAI :
 public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
+
+	FollowParabolaAI();
+
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+
 	void bulletTargetPoint(int& x, int& y);
 };
 
@@ -287,16 +324,26 @@ public:
 class ValkiriaAI :
 	public FollowNormalAI
 {
+private:
+
+	const int SLASH_REACH = 1200;
+
 public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
 
+	ValkiriaAI();
+
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+
 	int slashOrder();
 	int bulletOrder() { return 0; }
 	void moveOrder(int& right, int& left, int& up, int& down);
+	int jumpOrder();
 
-	// 追跡対象の近くにいるか判定
-	bool checkAlreadyFollow();
+	// 攻撃対象を変更する必要があるならtrueでアピールする。
+	bool needSearchTarget() const;
+
 };
 
 
@@ -312,6 +359,11 @@ private:
 public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
+
+	FlightAI();
+
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+
 	void moveOrder(int& right, int& left, int& up, int& down);
 };
 
@@ -328,6 +380,11 @@ private:
 public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
+
+	FollowFlightAI();
+
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+
 	void moveOrder(int& right, int& left, int& up, int& down);
 };
 
@@ -341,6 +398,10 @@ class BulletOnlyAI :
 public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
+
+	BulletOnlyAI();
+
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
 
 	int slashOrder() { return 0; }
 };
@@ -356,16 +417,27 @@ public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
 
+	SlashOnlyAI();
+
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+
 	int bulletOrder() { return 0; }
 };
 
 
+/*
+* 斜方投射だけのNormalAI
+*/
 class ParabolaOnlyAI :
 	public ParabolaAI
 {
 public:
 	static const char* BRAIN_NAME;
 	const char* getBrainName() const { return this->BRAIN_NAME; }
+
+	ParabolaOnlyAI();
+
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
 
 	int slashOrder() { return 0; }
 };

--- a/Character.cpp
+++ b/Character.cpp
@@ -169,6 +169,7 @@ Character::Character(int hp, int x, int y, int groupId) {
 	m_y = y;
 
 	m_leftDirection = true;
+	m_freeze = false;
 
 	m_characterInfo = nullptr;
 	m_attackInfo = nullptr;

--- a/Character.h
+++ b/Character.h
@@ -186,6 +186,9 @@ protected:
 	// 左を向いている
 	bool m_leftDirection;
 
+	// 一時的に動けない状態（ハートのスキル発動など）
+	bool m_freeze;
+
 	// キャラの情報
 	CharacterInfo* m_characterInfo;
 
@@ -218,6 +221,7 @@ public:
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline bool getLeftDirection() const { return m_leftDirection; }
+	inline int getFreeze() const { return m_freeze; }
 	FaceGraphHandle* getFaceHandle() const { return m_faceHandle; }
 	inline CharacterGraphHandle* getCharacterGraphHandle() const { return m_graphHandle; }
 	inline AttackInfo* getAttackInfo() const { return m_attackInfo; }
@@ -229,6 +233,7 @@ public:
 	inline void setY(int y) { m_y = y; }
 	inline void setId(int id) { m_id = id; }
 	inline void setGroupId(int id) { m_groupId = id; }
+	inline void setFreeze(bool freeze) { m_freeze = freeze; }
 	// キャラの向き変更は、画像の反転も行う
 	void setLeftDirection(bool leftDirection);
 	inline void setDuplicationFlag(bool flag) { m_duplicationFlag = flag; }

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -147,6 +147,9 @@ void CharacterAction::setCharacterY(int y) {
 void CharacterAction::setCharacterLeftDirection(bool leftDirection) {
 	m_character_p->setLeftDirection(leftDirection);
 }
+void CharacterAction::setCharacterFreeze(bool freeze) {
+	m_character_p->setFreeze(freeze);
+}
 
 // ƒ_ƒ[ƒW
 void CharacterAction::damage(int vx, int vy, int damageValue) {

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -175,6 +175,7 @@ public:
 	void setCharacterX(int x);
 	void setCharacterY(int y);
 	void setCharacterLeftDirection(bool leftDirection);
+	void setCharacterFreeze(bool freeze);
 
 	// 行動前の処理 毎フレーム行う
 	virtual void init() = 0;

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -181,6 +181,9 @@ void CharacterController::setCharacterX(int x) {
 void CharacterController::setCharacterY(int y) {
 	m_characterAction->setCharacterY(y);
 }
+void CharacterController::setCharacterFreeze(bool freeze) {
+	m_characterAction->setCharacterFreeze(freeze);
+}
 
 // s“®‘O‚Ìˆ—
 void CharacterController::init() {
@@ -363,7 +366,7 @@ Object* NormalController::slashAttack() {
 
 	// UŒ‚–Ú•W
 	int targetX = 0, targetY = 0;
-	m_brain->bulletTargetPoint(targetX, targetY);
+	m_brain->slashTargetPoint(targetX, targetY);
 
 	// –½—ß
 	int order = 0;

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -95,6 +95,7 @@ public:
 	// キャラクターのセッタ
 	void setCharacterX(int x);
 	void setCharacterY(int y);
+	void setCharacterFreeze(bool freeze);
 
 	// 行動前の処理 毎フレーム行う
 	void init();

--- a/World.cpp
+++ b/World.cpp
@@ -187,6 +187,16 @@ World::World(const World* original) {
 	m_backGroundColor = original->getBackGroundColor();
 }
 
+// スキル発動
+void World::setSkillFlag(bool skillFlag) { 
+	m_skillFlag = skillFlag;
+	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
+		if (m_characterControllers[i]->getAction()->getCharacter()->getName() == "ハート") {
+			m_characterControllers[i]->setCharacterFreeze(skillFlag);
+		}
+	}
+}
+
 // ストーリーやイベントによる追加キャラクター
 void World::addCharacter(CharacterLoader* characterLoader) {
 	pair<vector<Character*>, vector<CharacterController*> > p = characterLoader->getCharacters(m_camera, m_soundPlayer_p, m_areaNum);

--- a/World.h
+++ b/World.h
@@ -106,7 +106,7 @@ public:
 	inline SoundPlayer* getSoundPlayer() const { return m_soundPlayer_p; }
 
 	// セッタ
-	inline void setSkillFlag(bool skillFlag) { m_skillFlag = skillFlag; }
+	void setSkillFlag(bool skillFlag);
 	inline void setFocusId(int id) { m_focusId = id; }
 
 	// ストーリーやイベントによる追加


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
issuesの #88 #91 #69 を解決する。

まず、ゲームが落ちる原因はスキル発動時に一部Brainのコピーが適切に行われていなかったこと。

具体的には、ParabolaOnlyAIの大砲がスキル発動後NormalAIになってしまい、斬撃をしようとして落ちることなどが起きる。

また、ヴァルキリアの屈伸バグも同様でValkiriaAIがコピーされていなかったことが原因。

加えて、ヴァルキリアのAIをより賢く改善する。

そして、スキル発動時はハートを追跡しないように変更。(Action::freeze変数を使用)

# やったこと
うまくコピーできていなかったBrainの派生クラスにコンストラクタとcreateCopy関数を追加。

ヴァルキリアが高い敵にはジャンプしてから斬撃することや、斬撃するタイミングの変更が改善点。

その他、Brain.cpp、Brain.h のリファクタリング

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
実際にプレイして確認

# 懸念点
記入欄
