### PR TITLE
存在しない顔画像のロード時の回避

### DIFF
--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -273,7 +273,11 @@ FaceGraphHandle::FaceGraphHandle(const char* characterName, double drawEx) {
 	CsvReader reader("data/faceGraph.csv");
 	// キャラ名でデータを検索
 	map<string, string> data = reader.findOne("name", characterName);
-	if (data.size() == 0) { data = reader.findOne("name", "テスト"); }
+	// 見つからなかったらテストで再検索
+	if (data.size() == 0) { 
+		characterName = "テスト";
+		data = reader.findOne("name", characterName);
+	}
 
 	// ロード
 	const char* dir = "picture/face/";


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#90 の解決

# やったこと
存在しない顔画像をロードしようとしたらテスト画像を代わりにロードする処理のつもりだったが、キャラ名の指定をテストにしていなかったため修正。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
ログで確認

# 懸念点
記入欄
