### PR TITLE
Ui: HPバーの表示改良

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -166,6 +166,7 @@ Character::Character(int hp, int x, int y, int groupId) {
 
 	m_hp = hp;
 	m_prevHp = m_hp;
+	m_dispHpCnt = 0;
 	m_x = x;
 	m_y = y;
 
@@ -238,6 +239,7 @@ void Character::setLeftDirection(bool leftDirection) {
 // HPŒ¸­
 void Character::damageHp(int value) {
 	m_hp = max(0, m_hp - value);
+	m_dispHpCnt = 60;
 }
 
 // ˆÚ“®‚·‚éiÀ•W‚ğ“®‚©‚·j

--- a/Character.cpp
+++ b/Character.cpp
@@ -165,6 +165,7 @@ Character::Character(int hp, int x, int y, int groupId) {
 	m_groupId = groupId;
 
 	m_hp = hp;
+	m_prevHp = m_hp;
 	m_x = x;
 	m_y = y;
 
@@ -202,6 +203,7 @@ void Character::setParam(Character* character) {
 	character->setId(m_id);
 	character->setLeftDirection(m_leftDirection);
 	character->setHp(m_hp);
+	character->setPrevHp(m_prevHp);
 	character->getCharacterGraphHandle()->setGraph(getGraphHandle());
 }
 
@@ -295,6 +297,7 @@ Heart::Heart(const char* name, int hp, int x, int y, int groupId) :
 	m_attackInfo = new AttackInfo(name, m_characterInfo->handleEx());
 
 	m_hp = m_characterInfo->maxHp();
+	m_prevHp = m_hp;
 
 	// 各画像のロード
 	m_graphHandle = new CharacterGraphHandle(name, m_characterInfo->handleEx());
@@ -314,6 +317,7 @@ Heart::Heart(const char* name, int hp, int x, int y, int groupId, AttackInfo* at
 	m_attackInfo = attackInfo;
 	m_characterInfo = new CharacterInfo(name);
 	m_hp = m_characterInfo->maxHp();
+	m_prevHp = m_hp;
 	// 各画像のロード
 	m_graphHandle = new CharacterGraphHandle(name, m_characterInfo->handleEx());
 	m_faceHandle = new FaceGraphHandle(name, 1.0);

--- a/Character.h
+++ b/Character.h
@@ -183,6 +183,9 @@ protected:
 	// ダメージを受ける前の体力
 	int m_prevHp;
 
+	// HPバーを表示する残り時間
+	int m_dispHpCnt;
+
 	// X座標、Y座標
 	int m_x, m_y;
 
@@ -222,6 +225,7 @@ public:
 	inline int getGroupId() const { return m_groupId; }
 	inline int getHp() const { return m_hp; }
 	inline int getPrevHp() const { return m_prevHp; }
+	inline int getDispHpCnt() const { return m_dispHpCnt; }
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline bool getLeftDirection() const { return m_leftDirection; }
@@ -232,8 +236,11 @@ public:
 	inline CharacterInfo* getCharacterInfo() const { return m_characterInfo; }
 
 	// セッタ
-	inline void setHp(int hp) { m_hp = (hp > m_characterInfo->maxHp()) ? m_characterInfo->maxHp() : hp; }
-	inline void setPrevHp(int prevHp){ m_prevHp = (prevHp < m_hp) ? m_hp : prevHp; }
+	inline void setHp(int hp) { m_hp = (hp > m_characterInfo->maxHp()) ? m_characterInfo->maxHp() : hp; m_prevHp = m_hp; }
+	inline void setPrevHp(int prevHp) { 
+		m_prevHp = (prevHp < m_hp) ? m_hp : prevHp;
+		if (m_prevHp == m_hp && m_dispHpCnt > 0) { m_dispHpCnt--; }
+	}
 	inline void setX(int x) { m_x = x; }
 	inline void setY(int y) { m_y = y; }
 	inline void setId(int id) { m_id = id; }

--- a/Character.h
+++ b/Character.h
@@ -180,6 +180,9 @@ protected:
 	// 残り体力
 	int m_hp;
 
+	// ダメージを受ける前の体力
+	int m_prevHp;
+
 	// X座標、Y座標
 	int m_x, m_y;
 
@@ -218,6 +221,7 @@ public:
 	inline int getId() const { return m_id; }
 	inline int getGroupId() const { return m_groupId; }
 	inline int getHp() const { return m_hp; }
+	inline int getPrevHp() const { return m_prevHp; }
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline bool getLeftDirection() const { return m_leftDirection; }
@@ -229,6 +233,7 @@ public:
 
 	// セッタ
 	inline void setHp(int hp) { m_hp = (hp > m_characterInfo->maxHp()) ? m_characterInfo->maxHp() : hp; }
+	inline void setPrevHp(int prevHp){ m_prevHp = (prevHp < m_hp) ? m_hp : prevHp; }
 	inline void setX(int x) { m_x = x; }
 	inline void setY(int y) { m_y = y; }
 	inline void setId(int id) { m_id = id; }

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -151,6 +151,23 @@ void CharacterAction::setCharacterFreeze(bool freeze) {
 	m_character_p->setFreeze(freeze);
 }
 
+// 行動前の処理 毎フレーム行う
+void CharacterAction::init() {
+	// いったん全方向に動けるようにする
+	m_rightLock = false;
+	m_leftLock = false;
+	m_upLock = false;
+	m_downLock = false;
+
+	// いったん宙に浮かせる
+	m_grand = false;
+	m_grandRightSlope = false;
+	m_grandLeftSlope = false;
+
+	// prevHpをhpに追いつかせる
+	m_character_p->setPrevHp(m_character_p->getPrevHp() - 1);
+}
+
 // ダメージ
 void CharacterAction::damage(int vx, int vy, int damageValue) {
 	m_damageCnt = DAMAGE_TIME;
@@ -329,20 +346,6 @@ CharacterAction* StickAction::createCopy(vector<Character*> characters) {
 		}
 	}
 	return res;
-}
-
-// 行動前の処理
-void StickAction::init() {
-	// いったん全方向に動けるようにする
-	m_rightLock = false;
-	m_leftLock = false;
-	m_upLock = false;
-	m_downLock = false;
-
-	// いったん宙に浮かせる
-	m_grand = false;
-	m_grandRightSlope = false;
-	m_grandLeftSlope = false;
 }
 
 void StickAction::action() {
@@ -832,20 +835,6 @@ void FlightAction::switchHandle() {
 	afterChangeGraph(wide, height, afterWide, afterHeight);
 
 	m_character_p->setLeftDirection(m_character_p->getLeftDirection());
-}
-
-//行動前の処理 毎フレーム行う
-void FlightAction::init() {
-	// いったん全方向に動けるようにする
-	m_rightLock = false;
-	m_leftLock = false;
-	m_upLock = false;
-	m_downLock = false;
-
-	// いったん宙に浮かせる
-	m_grand = false;
-	m_grandRightSlope = false;
-	m_grandLeftSlope = false;
 }
 
 // 物理演算 毎フレーム行う

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -178,7 +178,7 @@ public:
 	void setCharacterFreeze(bool freeze);
 
 	// 行動前の処理 毎フレーム行う
-	virtual void init() = 0;
+	virtual void init();
 
 	// 物理演算 毎フレーム行う
 	virtual void action() = 0;
@@ -252,9 +252,6 @@ public:
 	CharacterAction* createCopy(std::vector<Character*> characters);
 
 	void debug(int x, int y, int color) const;
-
-	//行動前の処理 毎フレーム行う
-	void init();
 
 	// 物理演算 毎フレーム行う
 	void action();
@@ -330,9 +327,6 @@ public:
 	CharacterAction* createCopy(std::vector<Character*> characters);
 
 	void debug(int x, int y, int color) const;
-
-	//行動前の処理 毎フレーム行う
-	void init();
 
 	// 物理演算 毎フレーム行う
 	void action();

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -7,15 +7,18 @@
 
 
 // 体力バーを表示
-void drawHpBar(int x1, int y1, int x2, int y2, int hp, int maxHp, int damageColor, int hpColor) {
+void drawHpBar(int x1, int y1, int x2, int y2, int hp, int prevHp, int maxHp, int damageColor, int prevHpColor, int hpColor) {
 	int wide = x2 - x1;
-	int damage = wide * (maxHp - hp) / maxHp;
-	DrawBox(x1, y1, x1 + damage, y2, damageColor, TRUE);
-	DrawBox(x1 + damage, y1, x2, y2, hpColor, TRUE);
+	int prev = wide * prevHp / maxHp;
+	int remain = wide * hp / maxHp;
+	DrawBox(x1, y1, x1 + remain, y2, hpColor, TRUE);
+	DrawBox(x1 + remain, y1, x1 + prev, y2, prevHpColor, TRUE);
+	DrawBox(x1 + prev, y1, x2, y2, damageColor, TRUE);
 }
 
 int CharacterDrawer::HP_COLOR = GetColor(0, 255, 0);
-int CharacterDrawer::DAMAGE_COLOR = GetColor(255, 0, 0);
+int CharacterDrawer::PREV_HP_COLOR = GetColor(255, 0, 0);
+int CharacterDrawer::DAMAGE_COLOR = GetColor(0, 0, 0);
 
 CharacterDrawer::CharacterDrawer(const CharacterAction* const characterAction) {
 	m_characterAction = characterAction;
@@ -42,7 +45,7 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int bright) {
 	// カメラで調整
 	camera->setCamera(&x, &y, &ex);
 
-	// 描画
+	// 描画 ダメージ状態なら点滅
 	if (m_characterAction->getState() == CHARACTER_STATE::DAMAGE && ++m_cnt / 2 % 2 == 1) {
 		int dark = max(0, bright - 100);
 		SetDrawBright(dark, dark, dark);
@@ -62,5 +65,5 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int bright) {
 	int height = (int)(HP_BAR_HEIGHT * camera->getEx());
 	y -= (int)(10 * camera->getEx());
 	// 体力の描画
-	//drawHpBar(x - wide, y - height, x + wide, y, character->getHp(), character->getMaxHp(), DAMAGE_COLOR, HP_COLOR);
+	drawHpBar(x - wide, y - height, x + wide, y, character->getHp(), character->getPrevHp(), character->getMaxHp(), DAMAGE_COLOR, PREV_HP_COLOR, HP_COLOR);
 }

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -3,6 +3,7 @@
 #include "Character.h"
 #include "CharacterAction.h"
 #include "GraphHandle.h"
+#include "Define.h"
 #include "DxLib.h"
 
 
@@ -23,6 +24,7 @@ int CharacterDrawer::DAMAGE_COLOR = GetColor(0, 0, 0);
 CharacterDrawer::CharacterDrawer(const CharacterAction* const characterAction) {
 	m_characterAction = characterAction;
 	m_cnt = 0;
+	getGameEx(m_exX, m_exY);
 }
 
 // キャラを描画する
@@ -56,14 +58,38 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int bright) {
 		graphHandle->draw(x, y, ex);
 	}
 
-	// 体力バーの座標をカメラで調整
-	x = character->getX() + (character->getWide() / 2);
-	y = character->getY();
-	ex = graphHandle->getEx();
-	camera->setCamera(&x, &y, &ex);
-	int wide = (int)(HP_BAR_WIDE / 2 * camera->getEx());
-	int height = (int)(HP_BAR_HEIGHT * camera->getEx());
-	y -= (int)(10 * camera->getEx());
+	// 体力バー
+	if (character->getDispHpCnt() > 0 && character->getName() != "ハート") {
+		// 座標をカメラで調整
+		x = character->getX() + (character->getWide() / 2);
+		y = character->getY();
+		ex = graphHandle->getEx();
+		camera->setCamera(&x, &y, &ex);
+		int wide = (int)(HP_BAR_WIDE / 2 * camera->getEx());
+		int height = (int)(HP_BAR_HEIGHT * camera->getEx());
+		y -= (int)(10 * camera->getEx());
+		// 体力の描画
+		drawHpBar(x - wide, y - height, x + wide, y, character->getHp(), character->getPrevHp(), character->getMaxHp(), DAMAGE_COLOR, PREV_HP_COLOR, HP_COLOR);
+	}
+}
+
+void CharacterDrawer::drawPlayerHpBar(const Character* player) {
+
+	// 座標
+	int x, y, wide, height;
+
+	x = 30;
+	y = 30;
+	wide = 300;
+	height = 50;
+
+	// 解像度変更に対応
+	x = (int)(x * m_exX);
+	y = (int)(y * m_exY);
+	wide = (int)(wide * m_exX);
+	height = (int)(height * m_exY);
+
 	// 体力の描画
-	drawHpBar(x - wide, y - height, x + wide, y, character->getHp(), character->getPrevHp(), character->getMaxHp(), DAMAGE_COLOR, PREV_HP_COLOR, HP_COLOR);
+	drawHpBar(x, y, x + wide, y + height, player->getHp(), player->getPrevHp(), player->getMaxHp(), DAMAGE_COLOR, PREV_HP_COLOR, HP_COLOR);
+
 }

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -3,10 +3,15 @@
 
 class Camera;
 class CharacterAction;
+class Character;
+
+// 体力バーを表示
+void drawHpBar(int x1, int y1, int x2, int y2, int hp, int prevHp, int maxHp, int damageColor, int prevHpColor, int hpColor);
 
 // CharacterActionを見てキャラを描画する
 class CharacterDrawer {
 private:
+
 	// キャラの動きの情報 const関数しか呼ばない
 	const CharacterAction* m_characterAction;
 
@@ -19,13 +24,22 @@ private:
 	// 点滅用
 	int m_cnt;
 
+	// 1920を基準としたGAME_WIDEの倍率
+	double m_exX;
+	// 1080を基準としたGAME_HEIGHTの倍率
+	double m_exY;
+
 public:
+
 	CharacterDrawer(const CharacterAction* const characterAction);
 
 	// セッタ
 	void setCharacterAction(const CharacterAction* action) { m_characterAction = action; }
 
 	void drawCharacter(const Camera* const camera, int bright = 255);
+
+	void drawPlayerHpBar(const Character* player);
+
 };
 
 #endif

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -13,6 +13,7 @@ private:
 	const int HP_BAR_WIDE = 200;
 	const int HP_BAR_HEIGHT = 20;
 	static int HP_COLOR;
+	static int PREV_HP_COLOR;
 	static int DAMAGE_COLOR;
 
 	// “_–Å—p

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -3,6 +3,7 @@
 #include "Camera.h"
 #include "CharacterDrawer.h"
 #include "CharacterAction.h"
+#include "Character.h"
 #include "ObjectDrawer.h"
 #include "AnimationDrawer.h"
 #include "Animation.h"
@@ -121,6 +122,15 @@ void WorldDrawer::draw() {
 		m_animationDrawer->drawAnimation(camera);
 	}
 
+	// ハートの情報
+	size = m_world->getCharacters().size();
+	for (unsigned int i = 0; i < size; i++) {
+		if (m_world->getCharacters()[i]->getName() == "ハート") {
+			m_characterDrawer->drawPlayerHpBar(m_world->getCharacters()[i]);
+		}
+	}
+
+	// ターゲット
 	m_targetDrawer.setEx(camera->getEx());
 	m_targetDrawer.draw();
 	SetDrawBright(255, 255, 255);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#42 の解決

# やったこと
ダメージを受けた時、HPが減った分のダメージが赤色、すでに減っていた分が黒色で表示されるよう変更

ダメージを受けた時に一定時間だけHPバーが表示されるよう変更

ハートのHPバーだけ画面左上に常に表示されるよう変更

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
<img width="1439" alt="hpBar" src="https://github.com/kuriuminoki/DuplicationHeart/assets/92528385/aa78be54-16ba-4c25-9d6e-b9988f157ed0">

また、解像度を変更しても問題なく表示されていた。

# 懸念点
記入欄
