### PR TITLE
Api: NormalAIのバグ修正

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -250,7 +250,7 @@ void NormalAI::moveOrder(int& right, int& left, int& up, int& down) {
 		}
 		else {
 			// ƒ‰ƒ“ƒ_ƒ€‚Éİ’è
-			m_gx = GetRand(200) - 400;
+			m_gx = GetRand(400) - 200;
 			m_gx += x;
 		}
 		if (abs(x - m_gx) < 50) { m_gx = x; }
@@ -782,7 +782,7 @@ void FlightAI::moveOrder(int& right, int& left, int& up, int& down) {
 		}
 		else {
 			// ƒ‰ƒ“ƒ_ƒ€‚Éİ’è
-			m_gx = x + (GetRand(200) - 400);
+			m_gx = x + (GetRand(400) - 200);
 			m_gy = y + (GetRand(200) - 100);
 		}
 		if (abs(x - m_gx) < 50) { m_gx = x; }
@@ -841,7 +841,7 @@ void FollowFlightAI::moveOrder(int& right, int& left, int& up, int& down) {
 		}
 		else {
 			// ƒ‰ƒ“ƒ_ƒ€‚Éİ’è
-			m_gx = x + (GetRand(200) - 400);
+			m_gx = x + (GetRand(400) - 200);
 			m_gy = y + (GetRand(200) - 100);
 		}
 		if (abs(x - m_gx) < 50) { m_gx = x; }

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -235,8 +235,10 @@ CharacterController* NormalController::createCopy(std::vector<Character*> charac
 void NormalController::control() {
 	// ダメージのレコード（もし記録と現状が違えば以降のレコードを削除）
 	if (m_damageRecorder != nullptr) {
+		// 現状
 		bool flag = (m_characterAction->getState() == CHARACTER_STATE::DAMAGE);
 		if (m_damageRecorder->existRecord()) {
+			// 記録と比較
 			if ((bool)m_damageRecorder->checkInput() != flag) {
 				m_stickRecorder->discardRecord();
 				m_jumpRecorder->discardRecord();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
targetがいないとき左方向にしか移動しないことを発見。GetRand関数の扱いにミスがあったため修正。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
