### PR TITLE
Api: アニメイベントとナレーション、匿名のセリフ機能追加

### DIFF
--- a/Animation.h
+++ b/Animation.h
@@ -37,6 +37,7 @@ public:
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline bool getFinishFlag() const { return m_finishFlag; }
+	inline int getCnt() const { return m_cnt; }
 
 	// ƒZƒbƒ^
 	inline void setX(int x) { m_x = x; }

--- a/AnimationDrawer.cpp
+++ b/AnimationDrawer.cpp
@@ -4,7 +4,7 @@
 #include "GraphHandle.h"
 
 
-AnimationDrawer::AnimationDrawer(Animation* animation) {
+AnimationDrawer::AnimationDrawer(const Animation* animation) {
 	m_animation = animation;
 }
 

--- a/AnimationDrawer.h
+++ b/AnimationDrawer.h
@@ -8,7 +8,7 @@ class AnimationDrawer {
 private:
 	const Animation* m_animation;
 public:
-	AnimationDrawer(Animation* animation);
+	AnimationDrawer(const Animation* animation);
 
 	inline void setAnimation(const Animation* animation) { m_animation = animation; };
 

--- a/Define.h
+++ b/Define.h
@@ -9,14 +9,6 @@ static int WINDOW = TRUE;
 static int MOUSE_DISP = TRUE;
 
 //‰æ–Ê‚Ì‘å‚«‚³
-//#define GAME_WIDE 3840
-//#define GAME_HEIGHT 2160
-//#define GAME_WIDE 2560
-//#define GAME_HEIGHT 1600
-//#define GAME_WIDE 2560
-//#define GAME_HEIGHT 1440
-//#define GAME_WIDE 1920
-//#define GAME_HEIGHT 1080
 #define GAME_WIDE_MAX 3840
 #define GAME_HEIGHT_MAX 2160
 #define GAME_WIDE_MIN 640

--- a/Text.h
+++ b/Text.h
@@ -6,12 +6,50 @@
 #include <vector>
 
 
+class Animation;
 class SoundPlayer;
 class World;
 class GraphHandle;
 class GraphHandles;
 
 
+/*
+* イベント中に挿入される画像
+*/
+class EventAnime {
+
+private:
+
+	// アニメのスピード
+	int m_speed = 5;
+
+	// 挿絵
+	GraphHandles* m_handles;
+	Animation* m_animation;
+
+	bool m_finishFlag;
+
+public:
+
+	EventAnime(const char* filePath, int sum, int speed = -1);
+
+	~EventAnime();
+
+	// ゲッタ
+	const Animation* getAnime() const { return m_animation; }
+
+	// アニメの再生が終わったか
+	bool getFinishAnime() const;
+
+	// falseの間は操作不可
+	void play();
+
+};
+
+
+/*
+* 会話イベント
+*/
 class Conversation {
 private:
 
@@ -32,12 +70,20 @@ private:
 	// ファイルポインタ
 	int m_fp;
 
+	// 世界
 	World* m_world_p;
 
+	// 世界のサウンドプレイヤー
 	SoundPlayer* m_soundPlayer_p;
+
+	// アニメイベント
+	EventAnime* m_eventAnime;
 
 	// 発言者の名前
 	std::string m_speakerName;
+
+	// 発言者の顔画像がない
+	bool m_noFace;
 
 	// 発言者の顔画像
 	GraphHandles* m_speakerGraph;
@@ -66,17 +112,25 @@ public:
 	inline std::string getFullText() const { return m_text; }
 	int getTextSize() const;
 	GraphHandle* getGraph() const;
+	inline bool getNoFace() const { return m_noFace; }
 	inline 	std::string getSpeakerName() const { return m_speakerName; }
 	inline int getFinishCnt() const { return m_finishCnt; }
 	inline bool getFinishFlag() const { return m_finishFlag; }
 	inline int getTextNow() const { return m_textNow; }
 	inline int getCnt() const { return m_cnt; }
+	inline const Animation* getAnime() const { 
+		if (m_eventAnime == nullptr) { return nullptr; }
+		return m_eventAnime->getAnime();
+	}
+
+	// 今アニメ再生中か
+	bool animePlayNow() const { return m_eventAnime == nullptr ? false : !m_eventAnime->getFinishAnime(); }
 
 	// 会話を行う
 	bool play();
 
 private:
-	void setNextText();
+	void loadNextBlock();
 	void setSpeakerGraph(const char* faceName);
 };
 

--- a/TextDrawer.h
+++ b/TextDrawer.h
@@ -3,6 +3,7 @@
 
 
 class Conversation;
+class AnimationDrawer;
 
 
 class ConversationDrawer {
@@ -10,6 +11,9 @@ private:
 	
 	// 会話
 	const Conversation* m_conversation;
+
+	// アニメイベント用
+	AnimationDrawer* m_animationDrawer;
 
 	// テキストやフォントのサイズの倍率
 	double m_exX;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
以下の新機能を実装
- TextEvent中にアニメを再生すること
- 名前と顔画像が存在しないナレーションのセリフ
- 発言者が不明で顔画像が存在しない???のセリフ

# やったこと
txtファイルに以下の形式で記述するとアニメイベントやナレーション、匿名のセリフを差し込めるようにした。

```
# 普通のセリフ(前からあった記述法)
<発言者の名前>
<発言者の表情の名前>
<セリフ>

# アニメスタートのブロック
@eventStart
<ファイル名(拡張子省略、picture/event/までのパスは省略)>
<画像の枚数>
<アニメの再生スピード(省略可能)>

# アニメの挿絵の表示を終了するブロック(自動的に次のセリフブロックを読み込む)
@eventEnd

# ナレーション
@null
<セリフ>

# 匿名
???
<セリフ>
```

## 補足
@eventStartと@eventEndの間のセリフは再生中ずっと挿絵が表示され続ける。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
テストプレイで確認
<img width="1436" alt="20231126" src="https://github.com/kuriuminoki/DuplicationHeart/assets/92528385/7b52ddf1-19c4-468b-b19e-d394ac82f99c">


# 懸念点
記入欄
