### PR TITLE
Api: テキストイベントの機能を多数追加

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -304,6 +304,8 @@ Heart::Heart(const char* name, int hp, int x, int y, int groupId) :
 	// 各画像のロード
 	m_graphHandle = new CharacterGraphHandle(name, m_characterInfo->handleEx());
 	m_faceHandle = new FaceGraphHandle(name, 1.0);
+	// 画像の反転
+	setLeftDirection(m_leftDirection);
 
 	m_bulletColor = WHITE;
 
@@ -323,6 +325,8 @@ Heart::Heart(const char* name, int hp, int x, int y, int groupId, AttackInfo* at
 	// 各画像のロード
 	m_graphHandle = new CharacterGraphHandle(name, m_characterInfo->handleEx());
 	m_faceHandle = new FaceGraphHandle(name, 1.0);
+	// 画像の反転
+	setLeftDirection(m_leftDirection);
 
 	m_bulletColor = WHITE;
 

--- a/CharacterLoader.cpp
+++ b/CharacterLoader.cpp
@@ -58,6 +58,7 @@ pair<vector<Character*>, vector<CharacterController*> > CharacterLoader::getChar
 		if (playerFlag && m_playerId == -1 && character != nullptr) {
 			m_playerId = character->getId();
 			m_playerCharacter_p = character;
+			m_playerCharacter_p->setLeftDirection(false); // プレイヤーだけ右向き
 		}
 
 		// アクションを作成

--- a/Event.cpp
+++ b/Event.cpp
@@ -79,6 +79,9 @@ void Event::createFire(vector<string> param, World* world, SoundPlayer* soundPla
 	if (param0 == "CharacterPoint") {
 		fire = new CharacterPointFire(world, param);
 	}
+	else if (param0 == "Auto") {
+		fire = new AutoFire(world);
+	}
 
 	if (fire != nullptr) { m_eventFire.push_back(fire); }
 }

--- a/Event.h
+++ b/Event.h
@@ -142,6 +142,22 @@ public:
 	void setWorld(World* world);
 };
 
+// Ÿè‚É”­‰Î
+class AutoFire :
+	public EventFire
+{
+public:
+
+	AutoFire(World* world_p) :
+		EventFire(world_p)
+	{
+
+	}
+
+	bool fire() { return true; }
+
+};
+
 
 /*
 * EventElement‚Ì”h¶ƒNƒ‰ƒX

--- a/Story.cpp
+++ b/Story.cpp
@@ -42,6 +42,9 @@ Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer) {
 	for (unsigned int i = 0; i < objectData.size(); i++) {
 		m_objectLoader->addObject(objectData[i]);
 	}
+
+	// イベントの発火確認
+	checkFire();
 }
 
 Story::~Story() {
@@ -60,22 +63,7 @@ bool Story::play() {
 		// 普通に世界を動かす
 		m_world_p->battle();
 		// イベントの発火確認
-		for (unsigned int i = 0; i < m_mustEvent.size(); i++) {
-			if (m_mustEvent[i]->fire()) {
-				m_nowEvent = m_mustEvent[i];
-				m_mustEvent[i] = m_mustEvent.back();
-				m_mustEvent.pop_back();
-				i--;
-			}
-		}
-		for (unsigned int i = 0; i < m_subEvent.size(); i++) {
-			if (m_subEvent[i]->fire()) {
-				m_nowEvent = m_subEvent[i];
-				m_subEvent[i] = m_subEvent.back();
-				m_subEvent.pop_back();
-				i--;
-			}
-		}
+		checkFire();
 	}
 	else {
 		// イベント進行中
@@ -92,6 +80,26 @@ bool Story::play() {
 		return true;
 	}
 	return false;
+}
+
+// イベントの発火確認
+void Story::checkFire() {
+	for (unsigned int i = 0; i < m_mustEvent.size(); i++) {
+		if (m_mustEvent[i]->fire()) {
+			m_nowEvent = m_mustEvent[i];
+			m_mustEvent[i] = m_mustEvent.back();
+			m_mustEvent.pop_back();
+			i--;
+		}
+	}
+	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
+		if (m_subEvent[i]->fire()) {
+			m_nowEvent = m_subEvent[i];
+			m_subEvent[i] = m_subEvent.back();
+			m_subEvent.pop_back();
+			i--;
+		}
+	}
 }
 
 // ハートのスキル発動が可能かどうか

--- a/Story.h
+++ b/Story.h
@@ -42,6 +42,9 @@ public:
 
 	bool play();
 
+	// イベントの発火確認
+	void checkFire();
+
 	// ハートのスキル発動が可能かどうか
 	bool skillAble();
 

--- a/Text.h
+++ b/Text.h
@@ -27,6 +27,12 @@ private:
 	GraphHandles* m_handles;
 	Animation* m_animation;
 
+	// 画像の明るさ
+	int m_bright;
+
+	// 暗くなっていく方向 明るくなるならfalse
+	bool m_toDark;
+
 	bool m_finishFlag;
 
 public:
@@ -36,7 +42,14 @@ public:
 	~EventAnime();
 
 	// ゲッタ
-	const Animation* getAnime() const { return m_animation; }
+	inline const bool getToDark() const { return m_toDark; }
+	inline const int getBright() const { return m_bright; }
+	inline const Animation* getAnime() const { return m_animation; }
+
+	// セッタ
+	inline void setToDark(bool toDark) { m_toDark = toDark; }
+	inline void setBright(int bright) { m_bright = bright; }
+	inline void setFinishFlag(bool flag) { m_finishFlag = flag; }
 
 	// アニメの再生が終わったか
 	bool getFinishAnime() const;
@@ -103,6 +116,9 @@ private:
 	// 決定効果音
 	int m_nextSound;
 
+	// BGMを変更しても戻せるよう
+	std::string m_originalBgmPath;
+
 public:
 	Conversation(int textNum, World* world, SoundPlayer* soundPlayer);
 	~Conversation();
@@ -122,6 +138,7 @@ public:
 		if (m_eventAnime == nullptr) { return nullptr; }
 		return m_eventAnime->getAnime();
 	}
+	inline int getAnimeBright() const { return m_eventAnime->getBright(); }
 
 	// 今アニメ再生中か
 	bool animePlayNow() const { return m_eventAnime == nullptr ? false : !m_eventAnime->getFinishAnime(); }
@@ -131,6 +148,7 @@ public:
 
 private:
 	void loadNextBlock();
+	void setNextText(const int size, char* buff);
 	void setSpeakerGraph(const char* faceName);
 };
 

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -41,9 +41,12 @@ void ConversationDrawer::draw() {
 	// アニメ
 	const Animation* anime = m_conversation->getAnime();
 	if (anime != nullptr) {
+		int bright = m_conversation->getAnimeBright();
+		SetDrawBright(bright, bright, bright);
 		m_animationDrawer->setAnimation(anime);
 		m_animationDrawer->drawAnimation();
 		if (m_conversation->animePlayNow()) { return; }
+		SetDrawBright(255, 255, 255);
 	}
 
 	string text = m_conversation->getText();
@@ -86,27 +89,43 @@ void ConversationDrawer::draw() {
 		// 名前
 		DrawStringToHandle(x, GAME_HEIGHT - EDGE_DOWN - (int)(NAME_SIZE * m_exX) - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
 		// セリフ
-		while (now < text.size()) {
-			int next = now + min(MAX_TEXT_LEN, (int)text.size() - now);
-			string disp = text.substr(now, next - now);
-			DrawStringToHandle(x, Y1 + TEXT_GRAPH_EDGE + (i * ((int)(TEXT_SIZE * m_exX) + CHAR_EDGE)), disp.c_str(), BLACK, m_textHandle);
-			now = next;
-			i++;
-		}
+		drawText(x, Y1 + TEXT_GRAPH_EDGE, (int)(TEXT_SIZE * m_exX) + CHAR_EDGE, text, BLACK, m_textHandle);
 	}
 	else { // 顔画像がある場合
 		// 名前
 		DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE + graphSize + (int)(NAME_SIZE * m_exX), GAME_HEIGHT - EDGE_DOWN - (int)(NAME_SIZE * m_exX) - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
 		// セリフ
-		while (now < text.size()) { 
-			int next = now + min(MAX_TEXT_LEN, (int)text.size() - now);
-			string disp = text.substr(now, next - now);
-			DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize, Y1 + TEXT_GRAPH_EDGE + (i * ((int)(TEXT_SIZE * m_exX) + CHAR_EDGE)), disp.c_str(), BLACK, m_textHandle);
-			now = next;
-			i++;
-		}
+		drawText(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize, Y1 + TEXT_GRAPH_EDGE, (int)(TEXT_SIZE * m_exX) + CHAR_EDGE, text, BLACK, m_textHandle);
 		// キャラの顔画像
 		graph->draw(EDGE_X + TEXT_GRAPH_EDGE + graphSize / 2, Y1 + TEXT_GRAPH_EDGE + graphSize / 2, m_exX);
 	}
 
+}
+
+void ConversationDrawer::drawText(int x, int y,int height, std::string text, int color, int font) {
+	int now = 0;
+	int i = 0;
+	int size = (int)(text.size());
+	// セリフ
+	while (now < size) {
+
+		// 次は何文字目まで表示するか
+		int next = now + min(MAX_TEXT_LEN, (int)text.size() - now);
+
+		string disp = text.substr(now, next - now);
+		size_t br = disp.find("｜");
+		if (br != string::npos) {
+			disp = disp.substr(0, br);
+			now += (int)br + 2;
+		}
+		else {
+			now = next;
+		}
+
+		// セリフを描画
+		DrawStringToHandle(x, y + (i * height), disp.c_str(), BLACK, m_textHandle);
+
+		// 次の行
+		i++;
+	}
 }

--- a/TextDrawer.h
+++ b/TextDrawer.h
@@ -2,6 +2,8 @@
 #define TEXT_DRAWER_H_INCLUDED
 
 
+#include <string>
+
 class Conversation;
 class AnimationDrawer;
 
@@ -40,6 +42,8 @@ public:
 	void setConversation(const Conversation* conversation) { m_conversation = conversation; }
 
 	void draw();
+
+	void drawText(int x, int y, int height, std::string text, int color, int font);
 };
 
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
以下の機能を追加する。
- 挿絵を暗転・明転しながら表示する
- 挿絵をセットするだけで自動的に次のセリフへ移行する
- 発言者の情報はそのままに、セリフだけを変更する
- BGMの変更・戻す・ストップ
- 任意の位置でセリフの改行
- イベントの発火確認をStoryクラスのコンストラクタでも一回行い、イベント開始直前に一瞬Worldが画面に表示される違和感を排除
- AutoFireクラス実装、自動的に発火するクラス
- #98 の解決（また、プレイヤーの初期方向だけ右向き、その他のキャラは左向きに設定）

# やったこと
差分を参照

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
テストプレイで確認

# 懸念点
記入欄
