### PR TITLE
Api: プレイヤーがやられたときの処理を実装

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -119,6 +119,7 @@ OpMovie::OpMovie(SoundPlayer* soundPlayer_p):
 	m_titleBlue = new GraphHandles((path + "title/" + "titleBlue").c_str(), 1, m_ex);
 	m_titleOrange = new GraphHandles((path + "title/" + "titleOrange").c_str(), 1, m_ex);
 	m_titleHeart = new GraphHandles((path + "title/" + "heart").c_str(), 1, m_ex);
+	m_heartHide = new GraphHandles((path + "title/" + "ハート隠し").c_str(), 2, m_ex);
 	// キャラ
 	m_archive = new GraphHandles((path + "アーカイブ").c_str(), 1, m_ex);
 	m_aigis = new GraphHandles((path + "アイギス").c_str(), 1, m_ex);
@@ -143,26 +144,27 @@ OpMovie::OpMovie(SoundPlayer* soundPlayer_p):
 	m_tank = new GraphHandles((path + "棒タンク").c_str(), 1, m_ex);
 
 	// 表示する順にpush
-	characterQueue.push(make_pair(m_koharu, 30));
-	characterQueue.push(make_pair(m_assault, 30));
-	characterQueue.push(make_pair(m_msadi, 30));
-	characterQueue.push(make_pair(m_exlucina, 30));
-	characterQueue.push(make_pair(m_yuri, 30));
-	characterQueue.push(make_pair(m_titius, 30));
-	characterQueue.push(make_pair(m_tank, 30));
-	characterQueue.push(make_pair(m_chocola, 30));
-	characterQueue.push(make_pair(m_vermelia, 30));
-	characterQueue.push(make_pair(m_french, 30));
-	characterQueue.push(make_pair(m_courir, 30));
-	characterQueue.push(make_pair(m_cornein, 30));
-	characterQueue.push(make_pair(m_aigis, 30));
-	characterQueue.push(make_pair(m_elnino, 30));
-	characterQueue.push(make_pair(m_onyx, 30));
-	characterQueue.push(make_pair(m_fred, 30));
-	characterQueue.push(make_pair(m_mascara, 30));
-	characterQueue.push(make_pair(m_rabbi, 30));
-	characterQueue.push(make_pair(m_archive, 30));
-	characterQueue.push(make_pair(m_siesta, 30));
+	const int CHARA_TIME = 32;
+	characterQueue.push(make_pair(m_koharu, CHARA_TIME));
+	characterQueue.push(make_pair(m_assault, CHARA_TIME));
+	characterQueue.push(make_pair(m_msadi, CHARA_TIME));
+	characterQueue.push(make_pair(m_exlucina, CHARA_TIME));
+	characterQueue.push(make_pair(m_yuri, CHARA_TIME));
+	characterQueue.push(make_pair(m_titius, CHARA_TIME));
+	characterQueue.push(make_pair(m_tank, CHARA_TIME));
+	characterQueue.push(make_pair(m_chocola, CHARA_TIME));
+	characterQueue.push(make_pair(m_vermelia, CHARA_TIME));
+	characterQueue.push(make_pair(m_french, CHARA_TIME));
+	characterQueue.push(make_pair(m_courir, CHARA_TIME));
+	characterQueue.push(make_pair(m_cornein, CHARA_TIME));
+	characterQueue.push(make_pair(m_aigis, CHARA_TIME));
+	characterQueue.push(make_pair(m_elnino, CHARA_TIME));
+	characterQueue.push(make_pair(m_onyx, CHARA_TIME));
+	characterQueue.push(make_pair(m_fred, CHARA_TIME));
+	characterQueue.push(make_pair(m_mascara, CHARA_TIME));
+	characterQueue.push(make_pair(m_rabbi, CHARA_TIME));
+	characterQueue.push(make_pair(m_archive, CHARA_TIME));
+	characterQueue.push(make_pair(m_siesta, CHARA_TIME));
 
 	// 最初の画像
 	m_animation = new Animation(GAME_WIDE / 2, GAME_HEIGHT / 2, 120, m_titleH);
@@ -180,6 +182,7 @@ OpMovie::~OpMovie() {
 	delete m_titleBlue;
 	delete m_titleOrange;
 	delete m_titleHeart;
+	delete m_heartHide;
 	// キャラ
 	delete m_archive;
 	delete m_aigis;
@@ -225,9 +228,12 @@ void OpMovie::play() {
 	else if (m_cnt < 440 && m_animation->getFinishFlag()) {
 		m_animation->changeGraph(m_title, 30);
 	}
-	else if (m_cnt < 600 && m_cnt >= 440) {
+	else if (m_cnt == 440) {
+		m_animation->changeGraph(m_heartHide, 60);
+	}
+	else if (m_cnt < 600 && m_cnt >= 560) {
 		m_animation->changeGraph(m_titleHeart, 60);
-		m_animation->setX(m_animation->getX() + (int)(8 * m_ex));
+		m_animation->setX(m_animation->getX() + (int)(15 * m_ex));
 	}
 	else if (m_cnt < 690 && m_cnt >= 600) {
 		m_animation->setX(GAME_WIDE / 2);
@@ -241,14 +247,14 @@ void OpMovie::play() {
 	else if (m_cnt < 700 && m_cnt >= 690) {
 		m_animation->changeGraph(m_titleOrange, 60);
 	}
-	else if (m_cnt >= 2130 && m_cnt < 2740) {
+	else if (m_cnt >= 2130 && !characterQueue.empty()) {
 		if (m_animation->getFinishFlag() && !characterQueue.empty()) {
 			GraphHandles* next = characterQueue.front().first;
 			m_animation->changeGraph(next, characterQueue.front().second / next->getSize());
 			characterQueue.pop();
 		}
 	}
-	else if (m_cnt == 2760) {
+	if (m_animation->getFinishFlag() && characterQueue.empty()) {
 		m_animation->changeGraph(m_heart);
 	}
 

--- a/Animation.h
+++ b/Animation.h
@@ -117,6 +117,7 @@ private:
 	GraphHandles* m_titleBlue;
 	GraphHandles* m_titleOrange;
 	GraphHandles* m_titleHeart;
+	GraphHandles* m_heartHide;
 	// ƒLƒƒƒ‰
 	GraphHandles* m_archive;
 	GraphHandles* m_aigis;

--- a/Event.h
+++ b/Event.h
@@ -14,9 +14,9 @@ class Movie;
 
 
 enum class EVENT_RESULT {
-	NOW,
-	SUCCESS,
-	FAILURE
+	NOW,			// 進行中
+	SUCCESS,		// クリア
+	FAILURE			// 失敗
 };
 
 
@@ -58,7 +58,10 @@ public:
 	virtual EVENT_RESULT play() = 0;
 
 	// ハートのスキル発動が可能かどうか
-	virtual bool skillAble() = 0;
+	virtual bool skillAble() { return true; }
+
+	// クリア時に前のセーブポイントへ戻る必要があるか
+	virtual bool needBackPrevSave() { return false; }
 
 	// セッタ
 	virtual void setWorld(World* world) { m_world_p = world; }
@@ -88,6 +91,9 @@ private:
 	// イベントの進捗(EventElementのインデックス)
 	int m_nowElement;
 
+	// 前のセーブポイントへ戻る要求
+	bool m_backPrevSaveFlag;
+
 public:
 	Event(int eventNum, World* world, SoundPlayer* soundPlayer);
 	~Event();
@@ -103,6 +109,11 @@ public:
 
 	// Worldを設定しなおす
 	void setWorld(World* world);
+
+	bool getBackPrevSaveFlag() const { return m_backPrevSaveFlag; }
+
+	// 前のセーブポイントへ戻ったことを教えてもらう
+	void doneBackPrevSave() { m_backPrevSaveFlag = false; }
 
 private:
 	void createFire(std::vector<std::string> param, World* world, SoundPlayer* soundPlayer);
@@ -235,9 +246,6 @@ public:
 	// プレイ
 	EVENT_RESULT play();
 
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return true; }
-
 	// 世界を設定しなおす
 	void setWorld(World* world);
 };
@@ -259,9 +267,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return true; }
 };
 
 // 会話イベント
@@ -281,6 +286,9 @@ public:
 
 	// ハートのスキル発動が可能かどうか
 	bool skillAble() { return false; }
+
+	// セッタ
+	void setWorld(World* world);
 };
 
 // ムービーイベント
@@ -303,6 +311,24 @@ public:
 
 	// ハートのスキル発動が可能かどうか
 	bool skillAble() { return false; }
+};
+
+// 特定のエリアでプレイヤーがやられるイベント
+class PlayerDeadEvent :
+	public EventElement
+{
+private:
+	
+	int m_areaNum;
+
+public:
+	PlayerDeadEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// クリア時に前のセーブポイントへ戻る必要があるか
+	bool needBackPrevSave() { return true; }
 };
 
 #endif

--- a/Game.cpp
+++ b/Game.cpp
@@ -274,8 +274,15 @@ bool GameData::loadCommon(int* soundVolume, int* gameWide, int* gameHeight) {
 	return true;
 }
 
+// セーブデータ削除
+void GameData::removeSaveData() {
+	string fileName = m_saveFilePath;
+	remove((fileName + "intData.dat").c_str());
+	remove((fileName + "strData.dat").c_str());
+}
+
 // 自身のデータをWorldにデータ反映させる
-void GameData::asignWorld(World* world) {
+void GameData::asignWorld(World* world, bool playerHpReset) {
 	size_t size = m_characterData.size();
 	for (unsigned int i = 0; i < size; i++) {
 		world->asignedCharacterData(m_characterData[i]->name(), m_characterData[i]);
@@ -283,6 +290,9 @@ void GameData::asignWorld(World* world) {
 	size = m_doorData.size();
 	for (unsigned int i = 0; i < size; i++) {
 		world->asignedDoorData(m_doorData[i]);
+	}
+	if (playerHpReset) {
+		world->playerHpReset();
 	}
 }
 
@@ -311,13 +321,6 @@ void GameData::updateStory(Story* story) {
 	objectLoader->saveDoorData(m_doorData);
 }
 
-// セーブデータ削除
-void GameData::removeSaveData() {
-	string fileName = m_saveFilePath;
-	remove((fileName + "intData.dat").c_str());
-	remove((fileName + "strData.dat").c_str());
-}
-
 
 /*
 * ゲーム本体
@@ -341,7 +344,7 @@ Game::Game(const char* saveFilePath) {
 	m_gameData->updateStory(m_story);
 
 	// データを世界に反映
-	m_gameData->asignWorld(m_world);
+	m_gameData->asignWorld(m_world, true);
 
 	// スキル
 	m_skill = nullptr;
@@ -470,7 +473,7 @@ void Game::backPrevSave() {
 	delete m_world;
 	// 以前のAreaNumでロード
 	m_world = new World(-1, m_gameData->getAreaNum(), m_soundPlayer);
-	m_gameData->asignWorld(m_world);
+	m_gameData->asignWorld(m_world, true);
 	m_story->setWorld(m_world);
 }
 

--- a/Game.h
+++ b/Game.h
@@ -265,6 +265,9 @@ private:
 	// 一時停止画面
 	GamePause* m_gamePause;
 
+	// ゲームの再起動（タイトルへ戻る）を要求
+	bool m_rebootFlag;
+
 public:
 	Game(const char* saveFilePath = "savedata/test/");
 	~Game();
@@ -273,12 +276,16 @@ public:
 	World* getWorld() const { return m_world; }
 	HeartSkill* getSkill() const { return m_skill; }
 	GamePause* getGamePause() const { return m_gamePause; }
+	bool getRebootFlag() const { return m_rebootFlag; }
 
 	// デバッグ
 	void debug(int x, int y, int color) const;
 
 	// ゲームをプレイする
 	bool play();
+
+	// セーブデータをロード（前のセーブポイントへ戻る）
+	void backPrevSave();
 };
 
 #endif

--- a/Game.h
+++ b/Game.h
@@ -177,17 +177,17 @@ public:
 	inline void setStoryNum(int storyNum) { m_storyNum = storyNum; }
 	inline void setSoundVolume(int soundVolume) { m_soundVolume = soundVolume; }
 
+	// セーブデータ削除
+	void removeSaveData();
+
 	// 自身のデータをWorldにデータ反映させる
-	void asignWorld(World* world);
+	void asignWorld(World* world, bool playerHpReset = false);
 
 	// Worldのデータを自身に反映させる
 	void asignedWorld(const World* world);
 
 	// ストーリーが進んだ時にセーブデータを更新する
 	void updateStory(Story* story);
-
-	// セーブデータ削除
-	void removeSaveData();
 
 };
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -81,10 +81,18 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		/////メイン////
 		if (gamePlay) {
 			if (game->play()) {
+				//InitGraphが実行されたのでDrawerも作り直し
 				delete gameDrawer;
 				gameDrawer = new GameDrawer(game);
 			}
-			gameDrawer->draw();
+			if (game->getRebootFlag()) {
+				// ゲームを再起動、タイトルへ戻る
+				delete game;
+				gamePlay = false;
+				SetMouseDispFlag(MOUSE_DISP);//マウス表示
+				title = new Title();
+			}
+			else{ gameDrawer->draw(); }
 		}
 		else {
 			Title::TITLE_RESULT result = title->play();

--- a/Story.cpp
+++ b/Story.cpp
@@ -68,7 +68,12 @@ bool Story::play() {
 	else {
 		// イベント進行中
 		EVENT_RESULT result = m_nowEvent->play();
-		// イベント終了
+		
+		// イベント失敗
+		if (result == EVENT_RESULT::FAILURE) {
+			// mustのイベントならタイトルへ戻る
+		}
+		// 成功または失敗したのでイベント終了
 		if (result != EVENT_RESULT::NOW) {
 			delete m_nowEvent;
 			m_nowEvent = nullptr;
@@ -122,4 +127,14 @@ void Story::setWorld(World* world) {
 	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
 		m_subEvent[i]->setWorld(m_world_p);
 	}
+}
+
+// 前のセーブポイントへ戻る必要があるか
+bool Story::getBackPrevSaveFlag() const {
+	return m_nowEvent != nullptr ? m_nowEvent->getBackPrevSaveFlag() : false;
+}
+
+// 前のセーブポイントへ戻ったことを教えてもらう
+void Story::doneBackPrevSave() {
+	m_nowEvent->doneBackPrevSave();
 }

--- a/Story.h
+++ b/Story.h
@@ -53,9 +53,13 @@ public:
 	inline CharacterLoader* getCharacterLoader() const { return m_characterLoader; }
 	inline ObjectLoader* getObjectLoader() const { return m_objectLoader; }
 	inline const World* getWorld() const { return m_world_p; }
+	bool getBackPrevSaveFlag() const;
 
 	// セッタ
 	void setWorld(World* world);
+
+	// 前のセーブポイントへ戻ったことを教えてもらう
+	void doneBackPrevSave();
 };
 
 

--- a/Text.cpp
+++ b/Text.cpp
@@ -95,7 +95,6 @@ Conversation::Conversation(int textNum, World* world, SoundPlayer* soundPlayer) 
 	ostringstream oss;
 	oss << "data/text/text" << textNum << ".txt";
 	m_fp = FileRead_open(oss.str().c_str());
-	loadNextBlock();
 
 }
 
@@ -147,6 +146,10 @@ bool Conversation::play() {
 			loadNextBlock();
 		}
 		return false;
+	}
+
+	if (m_text == "") {
+		loadNextBlock();
 	}
 
 	// プレイヤーからのアクション（スペースキー入力）
@@ -291,4 +294,11 @@ void Conversation::setNextText(const int size, char* buff) {
 void Conversation::setSpeakerGraph(const char* faceName) {
 	Character* c = m_world_p->getCharacterWithName(m_speakerName);
 	m_speakerGraph = c->getFaceHandle()->getGraphHandle(faceName);
+}
+
+// セッタ
+void Conversation::setWorld(World* world) {
+	m_world_p = world;
+	m_speakerName = "ハート";
+	setSpeakerGraph("通常");
 }

--- a/Text.h
+++ b/Text.h
@@ -140,6 +140,9 @@ public:
 	}
 	inline int getAnimeBright() const { return m_eventAnime->getBright(); }
 
+	// セッタ
+	void setWorld(World* world);
+
 	// 今アニメ再生中か
 	bool animePlayNow() const { return m_eventAnime == nullptr ? false : !m_eventAnime->getFinishAnime(); }
 

--- a/World.cpp
+++ b/World.cpp
@@ -105,6 +105,14 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) {
 	m_stageObjects = data.getObjects();
 	m_doorObjects = data.getDoorObjects();
 	data.getBackGround(m_backGroundGraph, m_backGroundColor);
+
+	// プレイヤーをセット
+	for (unsigned int i = 0; i < m_characters.size(); i++) {
+		if (m_playerId == m_characters[i]->getId()) {
+			m_player = m_characters[i];
+			break;
+		}
+	}
 }
 
 World::~World() {
@@ -155,6 +163,7 @@ World::World(const World* original) {
 		Character* copy;
 		copy = original->getCharacters()[i]->createCopy();
 		m_characters.push_back(copy);
+		if (copy->getId() == m_playerId) { m_player = copy; }
 	}
 	// コントローラをコピー
 	for (unsigned int i = 0; i < original->getCharacterControllers().size(); i++) {
@@ -451,13 +460,9 @@ void World::setPlayerOnDoor(int from) {
 		}
 	}
 	// プレイヤー
-	for (unsigned int i = 0; i < m_characters.size(); i++) {
-		if (m_playerId == m_characters[i]->getId()) {
-			m_characters[i]->setX(doorX1);
-			m_characters[i]->setY(doorY2 - m_characters[i]->getHeight());
-			break;
-		}
-	}
+	m_player->setX(doorX1);
+	m_player->setY(doorY2 - m_player->getHeight());
+
 	// プレイヤーの仲間
 	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
 		const Character* follow = m_characterControllers[i]->getBrain()->getFollow();
@@ -514,10 +519,12 @@ vector<const Animation*> World::getConstAnimations() const {
 	return allAnimations;
 }
 
-// 戦わせる
+/*
+*  戦わせる
+*/
 void World::battle() {
-	// 画面暗転中
-	if (m_brightValue != 255) {
+	// 画面暗転中 エリア移動かプレイヤーやられ時
+	if (m_brightValue != 255 || playerDead()) {
 		m_brightValue = max(0, m_brightValue - 10);
 		return;
 	}
@@ -696,7 +703,7 @@ void World::controlCharacter() {
 			atariCharacterAndDoor(controller, m_doorObjects);
 		}
 
-		// 操作
+		// 操作 originalのハートはフリーズ
 		if (!m_duplicationFlag || m_characterControllers[i]->getAction()->getCharacter()->getId() != m_playerId) {
 			controller->control();
 		}
@@ -709,7 +716,7 @@ void World::controlCharacter() {
 		Object* slashAttack = controller->slashAttack();
 		if (slashAttack != nullptr) { m_attackObjects.push_back(slashAttack); }
 
-		// 反映
+		// 反映 originalのハートはフリーズ
 		if (!m_duplicationFlag || m_characterControllers[i]->getAction()->getCharacter()->getId() != m_playerId) {
 			controller->action();
 		}
@@ -851,4 +858,9 @@ void World::cameraPointInit() {
 			break;
 		}
 	}
+}
+
+// プレイヤーのHPが0ならtrue
+bool World::playerDead() {
+	return m_player->getHp() <= 0;
 }

--- a/World.cpp
+++ b/World.cpp
@@ -864,3 +864,8 @@ void World::cameraPointInit() {
 bool World::playerDead() {
 	return m_player->getHp() <= 0;
 }
+
+// ƒvƒŒƒCƒ„[‚ÌHP‚ðMAX‚É‚·‚é
+void World::playerHpReset() {
+	m_player->setHp(m_player->getMaxHp());
+}

--- a/World.h
+++ b/World.h
@@ -58,6 +58,9 @@ private:
 	// 世界に存在するキャラクター Worldがデリートする
 	std::vector<Character*> m_characters;
 
+	// プレイヤー 毎回for文でID検索しない用
+	Character* m_player;
+
 	// 戦闘のためにキャラを動かすコントローラ Worldがデリートする
 	std::vector<CharacterController*> m_characterControllers;
 
@@ -142,6 +145,9 @@ public:
 
 	// カメラの位置をリセット
 	void cameraPointInit();
+
+	// プレイヤーのHPが0ならtrue
+	bool playerDead();
 
 	/*
 	* イベント用

--- a/World.h
+++ b/World.h
@@ -149,6 +149,9 @@ public:
 	// プレイヤーのHPが0ならtrue
 	bool playerDead();
 
+	// プレイヤーのHPをMAXにする
+	void playerHpReset();
+
 	/*
 	* イベント用
 	*/


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
プレイヤーがやられた時の処理を実装する。

2パターンある。
- やられて普通にゲームオーバー
- やられることが前提のイベントで、やられることでストーリーが進む

普通にゲームオーバーになる場合はタイトルへ戻る。

やられてストーリーが進む場合、以前のセーブポイントまで戻されてストーリーが次へ進む。

# やったこと
- タイトルへ戻る処理を追加
- PlayerDeadEventクラスを追加
- やられて前のセーブポイントからやり直すorタイトルからセーブデータをロードしたときはプレイヤーのHPがMAXになる仕様にした。

また、以下の変更もある。
- 新しいセーブデータで始める際、GameクラスのコンストラクタでGameData::save()を呼び出し初期セーブデータを保存する。
- Conversationクラスはコンストラクタで一度loadNextBlock()を呼んでいたが、これだとEventElementが作成された際に一度呼ばれ、BGMの変更処理が実行されることがあるので呼ばないことにする。代わりに、play()内でm_text==""のときにloadNextBlock()を呼び出す処理を追加。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
テストプレイで確認

# 懸念点
将来的にオプション画面からタイトルに戻れるようにする。
