### PR TITLE
タイトルへ戻る機能実装

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -350,7 +350,7 @@ Game::Game(const char* saveFilePath) {
 	m_skill = nullptr;
 
 	// 一時停止画面
-	m_gamePause = nullptr;
+	m_battleOption = nullptr;
 
 	// ゲームの再起動（タイトルへ戻る）を要求
 	m_rebootFlag = false;
@@ -371,19 +371,23 @@ bool Game::play() {
 
 	// 一時停止
 	if (controlQ() == 1) {
-		if (m_gamePause == nullptr) {
-			m_gamePause = new GamePause(m_soundPlayer);
+		if (m_battleOption == nullptr) {
+			m_battleOption = new BattleOption(m_soundPlayer);
 			// ここで音楽も止める
 			m_soundPlayer->stopBGM();
 		}
 		else {
-			delete m_gamePause;
-			m_gamePause = nullptr;
+			delete m_battleOption;
+			m_battleOption = nullptr;
 			m_soundPlayer->playBGM();
 		}
 	}
-	if (m_gamePause != nullptr) {
-		m_gamePause->play();
+	if (m_battleOption != nullptr) {
+		m_battleOption->play();
+		if (m_battleOption->getTitleFlag()) {
+			// タイトルへ戻る
+			m_rebootFlag = true;
+		}
 		return false;
 	}
 

--- a/Game.h
+++ b/Game.h
@@ -8,7 +8,7 @@ class SoundPlayer;
 class World;
 class Story;
 class Character;
-class GamePause;
+class BattleOption;
 
 
 // キャラのセーブデータ
@@ -263,7 +263,7 @@ private:
 	HeartSkill* m_skill;
 
 	// 一時停止画面
-	GamePause* m_gamePause;
+	BattleOption* m_battleOption;
 
 	// ゲームの再起動（タイトルへ戻る）を要求
 	bool m_rebootFlag;
@@ -275,7 +275,7 @@ public:
 	// ゲッタ
 	World* getWorld() const { return m_world; }
 	HeartSkill* getSkill() const { return m_skill; }
-	GamePause* getGamePause() const { return m_gamePause; }
+	BattleOption* getGamePause() const { return m_battleOption; }
 	bool getRebootFlag() const { return m_rebootFlag; }
 
 	// デバッグ

--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -135,6 +135,47 @@ void GamePause::draw() const {
 }
 
 
+/*
+* ゲーム中に開くオプション画面 タイトルに戻るボタンやチュートリアルがある
+*/
+BattleOption::BattleOption(SoundPlayer* soundPlayer):
+	GamePause(soundPlayer)
+{
+	getGameEx(m_exX, m_exY);
+	m_fontSize = (int)(50 * m_exX);
+	m_font = CreateFontToHandle(nullptr, m_fontSize, 3);
+
+	int x = (int)(TITLE_X1 * m_exX);
+	int y = (int)(TITLE_Y1 * m_exY);
+	int wide = (int)((TITLE_X2 - TITLE_X1) * m_exX);
+	int height = (int)((TITLE_Y2 - TITLE_Y1) * m_exY);
+	m_titleButton = new Button("Back to the title", x, y, wide, height, GRAY, RED, m_font, BLACK);
+	m_titleFlag = false;
+}
+BattleOption::~BattleOption() {
+	DeleteFontToHandle(m_font);
+}
+
+void BattleOption::play() {
+
+	GamePause::play();
+
+	if (leftClick() == 1) {
+		if (m_titleButton->overlap(m_handX, m_handY)) {
+			m_titleFlag = true;
+		}
+	}
+
+}
+
+void BattleOption::draw() const {
+
+	GamePause::draw();
+
+	m_titleButton->draw(m_handX, m_handY);
+
+}
+
 
 /*
 * タイトル画面からいけるオプション画面　GamePauseの機能＋解像度の変更もできる。
@@ -158,6 +199,9 @@ TitleOption::TitleOption(SoundPlayer* soundPlayer) :
 
 TitleOption::~TitleOption() {
 	DeleteFontToHandle(m_font);
+	delete m_leftButton;
+	delete m_rightButton;
+	delete m_tmpApplyButton;
 }
 
 void TitleOption::play() {
@@ -203,5 +247,6 @@ void TitleOption::draw() const {
 	int x1 = m_gameWideController->getLeftX();
 	int y1 = (int)((HEIGHT_Y2 + 300) * m_exY);
 	DrawBox(x1, y1, x1 + (int)(TMP[m_nowTmpIndex][0] * m_exX) / 20, y1 + (int)(TMP[m_nowTmpIndex][1] * m_exY) / 20, LIGHT_BLUE, TRUE);
+	DrawBox(x1, y1, x1 + (int)(GAME_WIDE * m_exX) / 20, y1 + (int)(GAME_HEIGHT * m_exY) / 20, RED, FALSE);
 
 }

--- a/PausePage.h
+++ b/PausePage.h
@@ -62,7 +62,9 @@ public:
 };
 
 
-// ポーズ画面
+/*
+* オプション画面
+*/
 class GamePause {
 protected:
 
@@ -93,6 +95,46 @@ public:
 	void play();
 
 	void draw() const;
+};
+
+
+/*
+* ゲーム中に開くオプション画面 タイトルに戻るボタンやチュートリアルがある
+*/
+class BattleOption :
+	public GamePause
+{
+private:
+
+    // フォント
+	int m_font;
+	int m_fontSize;
+
+	// 1920を基準としたGAME_WIDEの倍率
+	double m_exX;
+	// 1080を基準としたGAME_HEIGHTの倍率
+	double m_exY;
+
+	// ボタンの座標
+	const int TITLE_X1 = 100;
+	const int TITLE_Y1 = 800;
+	const int TITLE_X2 = 600;
+	const int TITLE_Y2 = 1000;
+
+	// タイトルへ戻るボタン
+	Button* m_titleButton;
+	bool m_titleFlag;
+
+public:
+	BattleOption(SoundPlayer* soundPlayer);
+	~BattleOption();
+
+	void play();
+
+	void draw() const;
+
+	// ゲッタ
+	bool getTitleFlag() { return m_titleFlag; }
 };
 
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
一時停止画面からタイトルへ戻る機能を追加

# やったこと
音量調節機能を持つGamePauseクラスを継承したBattleOptionクラスを実装。

BattleOptionクラスはタイトルへ戻るボタンを持っている。

Gameクラスは一時停止画面としてGamePauseではなくBattleOptionを使う。

# やらないこと
将来的にはBattleOptionクラスに、操作方法のチュートリアルを表示する機能を追加予定

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
テストプレイで確認

# 懸念点
記入欄
