### PR TITLE
Api: Infoの変更とセーブデータで管理する機能追加

### DIFF
--- a/Character.h
+++ b/Character.h
@@ -3,6 +3,7 @@
 
 
 #include<string>
+#include<map>
 
 class Object;
 class GraphHandle;
@@ -49,7 +50,7 @@ public:
 
 	~CharacterInfo();
 
-	// ゲッタのみを持つ
+	// ゲッタのみを持つ、セッタは持たない
 	inline std::string name() const { return m_name; }
 	inline int maxHp() const { return m_maxHp; }
 	inline double handleEx() const { return m_handleEx; }
@@ -59,6 +60,14 @@ public:
 	inline int jumpSound() const { return m_jumpSound; }
 	inline int passiveSound() const { return m_passiveSound; }
 	inline int landSound() const { return m_landSound; }
+
+	// バージョン変更
+	void changeVersion(int version);
+
+private:
+
+	void setParam(std::map<std::string, std::string>& data);
+
 };
 
 
@@ -135,7 +144,7 @@ public:
 
 	~AttackInfo();
 	
-	// ゲッタのみを持つ
+	// ゲッタのみを持つ、セッタは持たない
 	int bulletHp() const { return m_bulletHp; }
 	int bulletDamage() const { return m_bulletDamage; }
 	int bulletRx() const { return m_bulletRx; }
@@ -159,6 +168,14 @@ public:
 	int slashSoundHandle() const { return m_slashSoundHandle; }
 	int bulletStartSoundeHandle() const { return m_bulletStartSoundHandle; }
 	int slashStartSoundHandle() const { return m_slashStartSoundHandle; }
+
+	// バージョン変更
+	void changeVersion(const char* characterName, int version);
+
+private:
+
+	void setParam(std::map<std::string, std::string>& data);
+
 };
 
 
@@ -176,6 +193,9 @@ protected:
 
 	// グループID 味方識別用
 	int m_groupId;
+
+	// Infoのバージョン
+	int m_version;
 
 	// 残り体力
 	int m_hp;
@@ -223,6 +243,7 @@ public:
 	// ゲッタ
 	inline int getId() const { return m_id; }
 	inline int getGroupId() const { return m_groupId; }
+	inline int getVersion() const { return m_version; }
 	inline int getHp() const { return m_hp; }
 	inline int getPrevHp() const { return m_prevHp; }
 	inline int getDispHpCnt() const { return m_dispHpCnt; }
@@ -265,6 +286,9 @@ public:
 	inline int getBulletRapid() const { return m_attackInfo->bulletRapid(); }
 	inline int getSlashCountSum() const { return m_attackInfo->slashCountSum(); }
 	inline int getSlashInterval() const { return m_attackInfo->slashInterval(); }
+
+	// Infoのバージョンを変更する
+	void changeInfoVersion(int version);
 
 	// 画像の情報を取得
 	int getCenterX() const;

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -54,6 +54,8 @@ CharacterAction::CharacterAction(Character* character, SoundPlayer* soundPlayer_
 
 	//初期状態
 	m_state = CHARACTER_STATE::STAND;
+	m_characterVersion = character->getVersion();
+	m_characterMoveSpeed = character->getMoveSpeed();
 	m_grand = false;
 	m_runCnt = -1;
 	m_squat = false;
@@ -92,6 +94,8 @@ CharacterAction::CharacterAction() :
 
 void CharacterAction::setParam(CharacterAction* action) {
 	action->setState(m_state);
+	action->setCharacterVersion(m_characterVersion);
+	action->setCharacterMoveSpeed(m_characterMoveSpeed);
 	action->setSimpleGrand(m_grand);
 	action->setGrandLeftSlope(m_grandLeftSlope);
 	action->setGrandRightSlope(m_grandRightSlope);
@@ -166,6 +170,16 @@ void CharacterAction::init() {
 
 	// prevHpをhpに追いつかせる
 	m_character_p->setPrevHp(m_character_p->getPrevHp() - 1);
+
+	// キャラのバージョンが変化した場合
+	if (m_characterVersion != m_character_p->getVersion()) {
+		if (m_moveLeft) { m_vx += m_characterMoveSpeed; m_vx -= m_character_p->getMoveSpeed(); }
+		if (m_moveRight) { m_vx -= m_characterMoveSpeed; m_vx += m_character_p->getMoveSpeed(); }
+		if (m_moveUp) { m_vy += m_characterMoveSpeed; m_vy -= m_character_p->getMoveSpeed(); }
+		if (m_moveDown) { m_vy -= m_characterMoveSpeed; m_vy += m_character_p->getMoveSpeed(); }
+		m_characterVersion = m_character_p->getVersion();
+		m_characterMoveSpeed = m_character_p->getMoveSpeed();
+	}
 }
 
 // ダメージ
@@ -235,6 +249,28 @@ void CharacterAction::setSquat(bool squat) {
 		// しゃがめない状態
 		m_squat = false;
 	}
+}
+
+// 歩き始める
+void CharacterAction::startMoveLeft() {
+	// 左へ歩き始める
+	m_moveLeft = true;
+	m_vx -= m_character_p->getMoveSpeed();
+}
+void CharacterAction::startMoveRight() {
+	// 右へ歩き始める
+	m_moveRight = true;
+	m_vx += m_character_p->getMoveSpeed();
+}
+void CharacterAction::startMoveUp() {
+	// 上へ歩き始める
+	m_moveUp = true;
+	m_vy -= m_character_p->getMoveSpeed();
+}
+void CharacterAction::startMoveDown() {
+	// 下へ歩き始める
+	m_moveDown = true;
+	m_vy += m_character_p->getMoveSpeed();
 }
 
 // 歩くのをやめる
@@ -545,13 +581,11 @@ void StickAction::walk(bool right, bool left) {
 
 	// 右へ歩き始める
 	if (!m_rightLock && !m_moveRight && !m_moveLeft && right && (!left || !m_character_p->getLeftDirection()) && !m_squat) { // 右へ歩く
-		m_vx += m_character_p->getMoveSpeed();
-		m_moveRight = true;
+		startMoveRight();
 	}
 	// 左へ歩き始める
 	if (!m_leftLock && !m_moveRight && !m_moveLeft && left && (!right || m_character_p->getLeftDirection()) && !m_squat) { // 左へ歩く
-		m_vx -= m_character_p->getMoveSpeed();
-		m_moveLeft = true;
+		startMoveLeft();
 	}
 	// アニメーション用にカウント
 	if (m_moveLeft || m_moveRight) {
@@ -932,31 +966,25 @@ void FlightAction::walk(bool right, bool left, bool up, bool down) {
 	}
 	// 右へ歩き始める
 	if (!m_rightLock && !m_moveRight && !m_moveLeft && right && (!left || !m_character_p->getLeftDirection()) && !m_squat) { // 右へ歩く
-		m_vx += m_character_p->getMoveSpeed();
-		m_moveRight = true;
+		startMoveRight();
 		if(m_grand){
-			m_vy -= m_character_p->getMoveSpeed();
-			m_moveUp = true;
+			startMoveUp();
 		}
 	}
 	// 左へ歩き始める
 	if (!m_leftLock && !m_moveRight && !m_moveLeft && left && (!right || m_character_p->getLeftDirection()) && !m_squat) { // 左へ歩く
-		m_vx -= m_character_p->getMoveSpeed();
-		m_moveLeft = true;
+		startMoveLeft();
 		if (m_grand) {
-			m_vy -= m_character_p->getMoveSpeed();
-			m_moveUp = true;
+			startMoveUp();
 		}
 	}
 	// 上へ歩き始める
 	if (!m_upLock && !m_moveDown && !m_moveUp && up && !down) { // 上へ歩く
-		m_vy -= m_character_p->getMoveSpeed();
-		m_moveUp = true;
+		startMoveUp();
 	}
 	// 下へ歩き始める
 	if (!m_downLock && !m_moveUp && !m_moveDown && down && !up) { // 下へ歩く
-		m_vy += m_character_p->getMoveSpeed();
-		m_moveDown = true;
+		startMoveDown();
 	}
 	// アニメーション用にカウント
 	if (m_moveLeft || m_moveRight) {

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -36,6 +36,10 @@ protected:
 	// 動かすキャラクター
 	Character* m_character_p;
 
+	// キャラのバージョン イベントでrunSpeedの変更した場合に対処するため
+	int m_characterVersion;
+	int m_characterMoveSpeed;
+
 	// キャラが地面にいる
 	bool m_grand;
 
@@ -140,6 +144,8 @@ public:
 
 	// セッタ
 	void setState(CHARACTER_STATE state);
+	inline void setCharacterVersion(int version) { m_characterVersion = version; }
+	inline void setCharacterMoveSpeed(int moveSpeed) { m_characterMoveSpeed = moveSpeed; }
 	inline void setSimpleGrand(bool grand) { m_grand = grand; }
 	virtual void setGrand(bool grand);
 	void setRightLock(bool lock);
@@ -209,6 +215,12 @@ public:
 
 	// 今攻撃可能状態
 	bool ableAttack() const;
+
+	// 歩き始める
+	void startMoveLeft();
+	void startMoveRight();
+	void startMoveUp();
+	void startMoveDown();
 
 	// 歩くのをやめる
 	void stopMoveLeft();

--- a/Event.cpp
+++ b/Event.cpp
@@ -97,6 +97,9 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	else if (param0 == "ChangeGroup") {
 		element = new ChangeGroupEvent(world, param);
 	}
+	else if (param0 == "ChangeInfoVersionEvent") {
+		element = new ChangeInfoVersionEvent(world, param);
+	}
 	else if (param0 == "DeadCharacter") {
 		element = new DeadCharacterEvent(world, param);
 	}
@@ -267,6 +270,24 @@ EVENT_RESULT ChangeGroupEvent::play() {
 	return EVENT_RESULT::SUCCESS;
 }
 void ChangeGroupEvent::setWorld(World* world) {
+	EventElement::setWorld(world);
+	m_character_p = m_world_p->getCharacterWithName(m_param[2]);
+}
+
+// キャラのversionを変更する
+ChangeInfoVersionEvent::ChangeInfoVersionEvent(World* world, std::vector<string> param) :
+	EventElement(world)
+{
+	m_param = param;
+	m_version = stoi(param[1]);
+	m_character_p = m_world_p->getCharacterWithName(param[2]);
+}
+EVENT_RESULT ChangeInfoVersionEvent::play() {
+	// 対象のキャラのGroupIdを変更する
+	m_character_p->changeInfoVersion(m_version);
+	return EVENT_RESULT::SUCCESS;
+}
+void ChangeInfoVersionEvent::setWorld(World* world) {
 	EventElement::setWorld(world);
 	m_character_p = m_world_p->getCharacterWithName(m_param[2]);
 }

--- a/Event.h
+++ b/Event.h
@@ -228,6 +228,33 @@ public:
 	void setWorld(World* world);
 };
 
+// キャラのversionを変える
+class ChangeInfoVersionEvent :
+	public EventElement
+{
+private:
+
+	// パラメータ
+	std::vector<std::string> m_param;
+
+	int m_version;
+
+	// 対象のキャラ
+	Character* m_character_p;
+
+public:
+	ChangeInfoVersionEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
+	// 世界を設定しなおす
+	void setWorld(World* world);
+};
+
 // 特定のキャラのHPが0になるまで戦う
 class DeadCharacterEvent :
 	public EventElement

--- a/Game.cpp
+++ b/Game.cpp
@@ -20,6 +20,7 @@ using namespace std;
 * キャラのデータ
 */
 CharacterData::CharacterData(const char* name) {
+	m_version = 1;
 	m_name = name;
 	m_hp = -1;
 	// id=-1はデータなしを意味する
@@ -37,6 +38,7 @@ CharacterData::CharacterData(const char* name) {
 
 // セーブ
 void CharacterData::save(FILE* intFp, FILE* strFp) {
+	fwrite(&m_version, sizeof(m_version), 1, intFp);
 	fwrite(&m_hp, sizeof(m_hp), 1, intFp);
 	fwrite(&m_id, sizeof(m_id), 1, intFp);
 	fwrite(&m_groupId, sizeof(m_groupId), 1, intFp);
@@ -55,6 +57,7 @@ void CharacterData::save(FILE* intFp, FILE* strFp) {
 
 // ロード
 void CharacterData::load(FILE* intFp, FILE* strFp) {
+	fread(&m_version, sizeof(m_version), 1, intFp);
 	fread(&m_hp, sizeof(m_hp), 1, intFp);
 	fread(&m_id, sizeof(m_id), 1, intFp);
 	fread(&m_groupId, sizeof(m_groupId), 1, intFp);

--- a/Game.h
+++ b/Game.h
@@ -18,6 +18,9 @@ private:
 	// 名前
 	std::string m_name;
 
+	// Infoのバージョン
+	int m_version;
+
 	// HP
 	int m_hp;
 
@@ -60,6 +63,7 @@ public:
 
 	// ゲッタ
 	inline const char* name() const { return m_name.c_str(); }
+	inline const int version() const { return m_version; }
 	inline int hp() const { return m_hp; }
 	inline int id() const { return m_id; }
 	inline int groupId() const { return m_groupId; }
@@ -74,6 +78,7 @@ public:
 	inline std::string controllerName() const { return m_controllerName; }
 
 	// セッタ
+	inline void setVersion(int version) { m_version = version; }
 	inline void setHp(int hp) { m_hp = hp; }
 	inline void setId(int id) { m_id = id; }
 	inline void setGroupId(int groupId) { m_groupId = groupId; }

--- a/World.cpp
+++ b/World.cpp
@@ -311,6 +311,7 @@ void World::eraseRecorder() {
 
 // ƒLƒƒƒ‰1‘Ì‚Ìî•ñ‚ð¢ŠE‚É”½‰f
 void World::asignedCharacter(Character* character, CharacterData* data) {
+	character->changeInfoVersion(data->version());
 	if (data->id() != -1) {
 		// ‚±‚ÌƒQ[ƒ€‚Å‰“oê‚¶‚á‚È‚¢
 		character->setHp(data->hp());
@@ -385,6 +386,7 @@ void World::asignCharacterData(const char* name, CharacterData* data, int fromAr
 	for (unsigned i = 0; i < size; i++) {
 		if (m_characterControllers[i]->getAction()->getCharacter()->getName() == name) {
 			const Character* c = m_characterControllers[i]->getAction()->getCharacter();
+			data->setVersion(c->getVersion());
 			data->setHp(c->getHp());
 			data->setId(c->getId());
 			data->setGroupId(c->getGroupId());


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
ストーリー進行に伴って登場キャラの性能が変化する機能を追加する。

# やったこと
Characterクラスにversionを追加。CharacterDataにも連携し、セーブ・ロードできる。

Characterクラスはversionを変更することでCharacterInfoとAttackInfoをロードしなおす。

例えばハートに対して`version = 2`にすると、csvファイルからname == "v2:ハート"に一致するデータを読み込む。

該当するデータがないならname == "ハート"を読み込む。

なお、画像や音関連は変更されない。

本機能追加に伴い、以下の機能も追加した。
- ChangeInfoVersionEventクラスを追加、イベントでキャラのバージョンを変更できる。
- CharacterActionクラスに変更を加えた。
  - バージョンと歩くスピードを保存しておき、 歩いているときにChangeInfoVersionEventで歩くスピードが変わった場合、いったん前の歩くスピードでvx、vyを相殺した後新しいスピードを反映する処理を行う。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
テストプレイで確認

# 懸念点
記入欄
