### PR TITLE
Ui: テキストイベントでクリック要求の画像表示バグを修正

### DIFF
--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -115,8 +115,8 @@ void ConversationDrawer::draw() {
 	}
 	
 	bool textFinish = m_conversation->finishText() && m_conversation->getFinishCnt() == 0 && m_conversation->getStartCnt() == 0;
-	bool eventFinish = anime != nullptr && m_conversation->getEventAnime()->getAnime()->getFinishFlag() && m_conversation->getEventAnime()->getFinishAnimeEvent();
-	if (textFinish || eventFinish) {
+	bool eventFinish = !(m_conversation->animePlayNow()) || (m_conversation->getEventAnime()->getAnime()->getFinishFlag());
+	if (textFinish &&eventFinish) {
 		int dy = (int)(((m_conversation->getCnt() / 3) % 20 - 10) * m_exY);
 		m_conversation->getTextFinishGraph()->draw(GAME_WIDE - EDGE_X - (int)(100 * m_exX), GAME_HEIGHT - EDGE_DOWN - (int)(50 * m_exY) + dy - TEXT_GRAPH_EDGE, m_conversation->getTextFinishGraph()->getEx());
 	}


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り if分の条件を変えるだけ

挿絵を表示するだけ・セリフの表示のときは要求画像を表示

アニメ再生中・自動的に次のセリフへ行くときは非表示

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
