### PR TITLE
Api: スキル終了時にゲームが落ちるバグの修正

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -551,7 +551,7 @@ bool HeartSkill::play() {
 		else {
 			// ƒXƒLƒ‹I—¹
 			for (unsigned int i = 0; i < m_duplicationId.size(); i++) {
-				m_world_p->popCharacter(m_duplicationId[i]);
+				m_world_p->popCharacterController(m_duplicationId[i]);
 				m_world_p->eraseRecorder();
 			}
 			return true;

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -73,7 +73,7 @@ void ConversationDrawer::draw() {
 	if (!animeOnly) {
 		// 会話終了時
 		if (m_conversation->getFinishCnt() > 0) {
-			int finishCnt = m_conversation->getFinishCnt() * 8 * m_exY;
+			int finishCnt = (int)(m_conversation->getFinishCnt() * 8 * m_exY);
 			if ((Y1 + finishCnt) <= (GAME_HEIGHT - EDGE_DOWN - finishCnt)) { 
 				// フキダシ
 				DrawExtendGraph(EDGE_X, Y1 + finishCnt, GAME_WIDE - EDGE_X, GAME_HEIGHT - EDGE_DOWN - finishCnt, m_frameHandle, TRUE);
@@ -81,7 +81,7 @@ void ConversationDrawer::draw() {
 		}
 		// 会話開始時
 		else if (m_conversation->getStartCnt() > 0) {
-			int startCnt = m_conversation->getStartCnt() * 8 * m_exY;
+			int startCnt = (int)(m_conversation->getStartCnt() * 8 * m_exY);
 			if ((Y1 + startCnt) <= (GAME_HEIGHT - EDGE_DOWN - startCnt)) { 
 				// フキダシ
 				DrawExtendGraph(EDGE_X, Y1 + startCnt, GAME_WIDE - EDGE_X, GAME_HEIGHT - EDGE_DOWN - startCnt, m_frameHandle, TRUE);

--- a/World.cpp
+++ b/World.cpp
@@ -262,7 +262,7 @@ void World::pushCharacter(Character* character, CharacterController* controller)
 	m_characterControllers.push_back(controller);
 }
 
-void World::popCharacter(int id) {
+void World::popCharacterController(int id) {
 	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
 		if (m_characterControllers[i]->getAction()->getCharacter()->getName() == "ハート") {
 			continue;
@@ -271,23 +271,6 @@ void World::popCharacter(int id) {
 			delete m_characterControllers[i];
 			m_characterControllers[i] = m_characterControllers.back();
 			m_characterControllers.pop_back();
-			i--;
-		}
-	}
-	for (unsigned int i = 0; i < m_characters.size(); i++) {
-		if (m_characters[i]->getName() == "ハート") {
-			continue;
-		}
-		if (m_characters[i]->getId() == id) {
-			for (unsigned int j = 0; j < m_characterControllers.size(); j++) {
-				if (m_characterControllers[j]->getBrain()->getTargetId() == id) {
-					m_characterControllers[j]->setTarget(nullptr);
-				}
-			}
-			//m_characters[i]->setHp(0);
-			delete m_characters[i];
-			m_characters[i] = m_characters.back();
-			m_characters.pop_back();
 			i--;
 		}
 	}
@@ -507,7 +490,9 @@ vector<const CharacterAction*> World::getActions() const {
 	vector<const CharacterAction*> actions;
 	size_t size = m_characterControllers.size();
 	for (unsigned int i = 0; i < size; i++) {
-		actions.push_back(m_characterControllers[i]->getAction());
+		if (m_characterControllers[i]->getAction()->getCharacter()->getHp() > 0) {
+			actions.push_back(m_characterControllers[i]->getAction());
+		}
 	}
 	return actions;
 }
@@ -551,7 +536,7 @@ void World::battle() {
 	}
 
 	// HP0のキャラコントローラ削除
-	cleanCharacterController();
+	// cleanCharacterController();
 
 	// deleteFlagがtrueのオブジェクトを削除する。
 	deleteObject(m_stageObjects);
@@ -576,18 +561,6 @@ void World::battle() {
 	// アニメーションの更新
 	updateAnimation();
 
-}
-
-// ＨＰ０のキャラコントローラ削除
-void World::cleanCharacterController() {
-	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
-		if (m_characterControllers[i]->getAction()->getCharacter()->getHp() == 0) {
-			delete m_characterControllers[i];
-			m_characterControllers[i] = m_characterControllers.back();
-			m_characterControllers.pop_back();
-			i--;
-		}
-	}
 }
 
 // キャラの更新（攻撃対象の変更）
@@ -717,6 +690,10 @@ void World::controlCharacter() {
 	size_t size = m_characterControllers.size();
 	for (unsigned int i = 0; i < size; i++) {
 		CharacterController* controller = m_characterControllers[i];
+
+		// HPが0ならスキップ
+		if (controller->getAction()->getCharacter()->getHp() == 0) { continue; }
+
 		// 行動前の処理
 		controller->init();
 

--- a/World.h
+++ b/World.h
@@ -172,7 +172,7 @@ public:
 	inline void setConversation(Conversation* conversation){ m_conversation_p = conversation; }
 	inline void setMovie(Movie* movie) { m_movie_p = movie; }
 	void pushCharacter(Character* character, CharacterController* controller);
-	void popCharacter(int id);
+	void popCharacterController(int id);
 	void createRecorder();
 	void initRecorder();
 	void eraseRecorder();
@@ -186,9 +186,6 @@ private:
 
 	// アニメーションの更新
 	void updateAnimation();
-
-	// ＨＰ０のキャラ削除
-	void cleanCharacterController();
 
 	// キャラの更新（攻撃対象の変更）
 	void updateCharacter();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

#111 の解決

原因はスキル終了時に複製のハートのCharacterを削除していたこと。これによって残っている弾画像がdeleteされ表示できなくなる。

また、HPが0になったキャラはControllerを削除していたが、これだと主要キャラの最後の状態がセーブできなくなるので単純にHP0のキャラはcontrol()と描画を実行しないだけに変更。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
