### PR TITLE
Api: areaNum周りのバグ修正(ドアに入った瞬間areaNumが変わらないように変更)

### DIFF
--- a/Debug.cpp
+++ b/Debug.cpp
@@ -21,9 +21,12 @@
 // Gameクラスのデバッグ
 void Game::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**GAME**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "StoryNum=%d, soundVolume=%d", m_gameData->getStoryNum(), m_soundPlayer->getVolume());
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "StoryNum=%d, doorSum=%d", m_gameData->getStoryNum(), m_gameData->getDoorSum());
+	for (int i = 0; i < m_gameData->getDoorSum(); i++) {
+		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE + ((i + 1) * DRAW_FORMAT_STRING_SIZE), color, "from=%d, to=%d", m_gameData->getFrom(i), m_gameData->getTo(i));
+	}
 	//m_story->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
-	//m_world->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
+	m_world->debug(1000, y + DRAW_FORMAT_STRING_SIZE * 3, color);
 }
 
 
@@ -39,12 +42,12 @@ void debugObjects(int x, int y, int color, std::vector<Object*> objects) {
 // Worldクラスのデバッグ
 void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "CharacterSum=%d, ControllerSum=%d, cameraEx=%f", m_characters.size(), m_characterControllers.size(), m_camera->getEx());
-	debugObjects(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, m_attackObjects);
-	m_characterControllers[0]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
-	if (m_movie_p != nullptr) {
-		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "Movie: cnt=%d", m_movie_p->getCnt());
-	}
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "areaNum=%d, CharacterSum=%d, ControllerSum=%d", m_areaNum, m_characters.size(), m_characterControllers.size(), m_camera->getEx());
+	//debugObjects(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, m_attackObjects);
+	//m_characterControllers[0]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
+	//if (m_movie_p != nullptr) {
+	//	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "Movie: cnt=%d", m_movie_p->getCnt());
+	//}
 }
 
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -16,6 +16,13 @@
 
 using namespace std;
 
+
+// どこまで
+const int FINISH_STORY = 10;
+// エリア0でデバッグするときはtrueにする
+const bool TEST_MODE = false;
+
+
 /*
 * キャラのデータ
 */
@@ -151,8 +158,6 @@ GameData::GameData() {
 	m_areaNum = 1;
 	m_storyNum = 1;
 
-	// エリア0でデバッグするときはtrueにする
-	const bool TEST_MODE = false;
 	if (TEST_MODE) {
 		m_areaNum = 0;
 		m_storyNum = 0;
@@ -401,7 +406,7 @@ bool Game::play() {
 	}
 
 	// これ以上ストーリーを進ませない（テスト用）
-	if (m_gameData->getStoryNum() == 5 || m_gameData->getStoryNum() == 0) {
+	if (m_gameData->getStoryNum() == FINISH_STORY || m_gameData->getStoryNum() == 0) {
 		m_world->battle();
 		m_soundPlayer->play();
 		return false;
@@ -463,8 +468,8 @@ bool Game::play() {
 
 	// エリア移動
 	if (m_world->getBrightValue() == 0) {
-		int fromAreaNum = m_gameData->getAreaNum();
-		int toAreaNum = m_world->getAreaNum();
+		int fromAreaNum = m_world->getAreaNum();
+		int toAreaNum = m_world->getNextAreaNum();
 		m_gameData->asignedWorld(m_world, false);
 		delete m_world;
 		InitGraph();
@@ -475,6 +480,7 @@ bool Game::play() {
 		m_gameData->setAreaNum(toAreaNum);
 		return true;
 	}
+
 	return false;
 }
 

--- a/Game.h
+++ b/Game.h
@@ -176,6 +176,9 @@ public:
 	inline int getStoryNum() const { return m_storyNum; }
 	inline int getSoundVolume() const { return m_soundVolume; }
 	inline const char* getSaveFilePath() const { return m_saveFilePath.c_str(); }
+	inline int getDoorSum() const { return (int)m_doorData.size(); }
+	inline int getFrom(int i) const { return m_doorData[i]->from(); }
+	inline int getTo(int i) const { return m_doorData[i]->to(); }
 
 	// ƒZƒbƒ^
 	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }

--- a/World.cpp
+++ b/World.cpp
@@ -107,6 +107,7 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) :
 
 	// 主人公のスタート地点
 	m_areaNum = toAreaNum;
+	m_nextAreaNum = m_areaNum;
 
 	// エリアをロード
 	const AreaReader data(fromAreaNum, toAreaNum, m_soundPlayer_p);
@@ -686,7 +687,7 @@ void World::atariCharacterAndDoor(CharacterController* controller, vector<Object
 		// 当たり判定をここで行う
 		if (objects[i]->atari(controller) && controller->getActionKey()) {
 			// 当たった場合 エリア移動が発生
-			m_areaNum = objects[i]->getAreaNum();
+			m_nextAreaNum = objects[i]->getAreaNum();
 			// 画面を暗転
 			m_brightValue--;
 		}

--- a/World.h
+++ b/World.h
@@ -55,6 +55,7 @@ private:
 
 	// いま世界のどのエリアにいるか（メモリ節約のためプレイヤーの付近のみを読み込む）
 	int m_areaNum;
+	int m_nextAreaNum;
 
 	// 描画用のカメラ Worldがデリートする
 	Camera* m_camera;
@@ -99,6 +100,7 @@ public:
 	inline int getPlayerId() const { return m_playerId; }
 	inline int getBrightValue() const { return m_brightValue; }
 	inline int getAreaNum() const { return m_areaNum; }
+	inline int getNextAreaNum() const { return m_nextAreaNum; }
 	inline const Camera* getCamera() const { return m_camera; }
 	std::vector<CharacterController*> getCharacterControllers() const;
 	std::vector<const CharacterAction*> getActions() const;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り。

エリア移動した瞬間にWorld::m_areaNumが変わるせいで、ドアのfromが誤って設定されてしまうことがある。

具体的には、エリア移動した瞬間にareaNumが変わり、その瞬間に次のFireが予期せず発火しEventがクリアされストーリーが進むとセーブされareaNumのデータが書き換わり、エリア移動によるセーブが直後に行われるが変更後のareaNumが使われfromの値がセーブされる。（ややこしい、結局エリア移動した瞬間にWorld::m_areaNumが変わるのが問題。そのせいで予期せずイベントが発火したりセーブデータがおかしくなる。）

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
