### PR TITLE
Api: 特定のキャラの近くに行くことが条件のFire＆キャラがやられた時のエフェクト追加

### DIFF
--- a/Camera.cpp
+++ b/Camera.cpp
@@ -1,5 +1,6 @@
 #include "Camera.h"
 #include "Define.h"
+#include "DxLib.h"
 
 
 Camera::Camera() :
@@ -18,6 +19,8 @@ Camera::Camera(int x, int y, double ex, int speed) {
 	m_maxSpeed = speed == 0 ? CAMERA_SPEED_DEFAULT : speed;
 	m_centerX = GAME_WIDE / 2;
 	m_centerY = GAME_HEIGHT / 2;
+	m_shakingWidth = 0;
+	m_shakingTime = 0;
 }
 
 Camera::Camera(const Camera* original) {
@@ -30,6 +33,8 @@ Camera::Camera(const Camera* original) {
 	m_maxSpeed = original->getMaxSpeed();
 	m_centerX = GAME_WIDE / 2;
 	m_centerY = GAME_HEIGHT / 2;
+	m_shakingWidth = original->getShakingWidth();
+	m_shakingTime = original->getShakingTime();
 }
 
 // カメラの移動 目標地点が近いほど鈍感になる
@@ -76,4 +81,18 @@ void Camera::getMouse(int* x, int* y) const {
 	// m_xとm_yは画面中央に対応するWorldの座標
 	*x = m_x + dx;
 	*y = m_y + dy;
+}
+
+// カメラを揺らす
+void Camera::shakingStart(int width, int time) {
+	m_shakingWidth = width;
+	m_shakingTime = time;
+}
+
+// カメラを揺らす
+void Camera::shaking() {
+	if (m_shakingTime == 0) { return; }
+	m_x += GetRand(m_shakingWidth * 2) - m_shakingWidth;
+	m_y += GetRand(m_shakingWidth * 2) - m_shakingWidth;
+	m_shakingTime--;
 }

--- a/Camera.h
+++ b/Camera.h
@@ -23,6 +23,12 @@ private:
 	// 画面中心の座標
 	int m_centerX, m_centerY;
 
+	// 画面の揺れ幅
+	int m_shakingWidth;
+
+	// 揺れる残り時間
+	int m_shakingTime;
+
 public:
 	Camera();
 	Camera(int x, int y, double ex, int speed=0);
@@ -37,6 +43,8 @@ public:
 	inline double getEx() const { return m_ex; }
 	inline int getSpeed() const { return m_speed; }
 	inline int getMaxSpeed() const { return m_maxSpeed; }
+	inline int getShakingWidth() const { return m_shakingWidth; }
+	inline int getShakingTime() const { return m_shakingTime; }
 
 	// セッタ
 	inline void setPoint(int x, int y) { m_x = x; m_y = y; }
@@ -56,6 +64,12 @@ public:
 
 	// マウスの位置を取得
 	void getMouse(int* x, int* y) const;
+
+	// カメラを揺らし始める
+	void shakingStart(int width, int time);
+
+	// カメラを揺らす
+	void shaking();
 };
 
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -89,6 +89,9 @@ void Event::createFire(vector<string> param, World* world, SoundPlayer* soundPla
 	if (param0 == "CharacterPoint") {
 		fire = new CharacterPointFire(world, param);
 	}
+	else if (param0 == "CharacterNear") {
+		fire = new CharacterNearFire(world, param);
+	}
 	else if (param0 == "Auto") {
 		fire = new AutoFire(world);
 	}
@@ -192,12 +195,12 @@ CharacterPointFire::CharacterPointFire(World* world, std::vector<std::string> pa
 	EventFire(world)
 {
 	m_param = param;
-	m_character_p = m_world_p->getCharacterWithName(param[1]);
-	m_areaNum = stoi(param[2]);
-	m_x = stoi(param[3]);
-	m_y = stoi(param[4]);
-	m_dx = stoi(param[5]);
-	m_dy = stoi(param[6]);
+	m_character_p = m_world_p->getCharacterWithName(m_param[1]);
+	m_areaNum = stoi(m_param[2]);
+	m_x = stoi(m_param[3]);
+	m_y = stoi(m_param[4]);
+	m_dx = stoi(m_param[5]);
+	m_dy = stoi(m_param[6]);
 }
 bool CharacterPointFire::fire() {
 	// 特定のキャラが指定した場所にいるか判定
@@ -210,6 +213,40 @@ bool CharacterPointFire::fire() {
 	return false;
 }
 void CharacterPointFire::setWorld(World* world) {
+	EventFire::setWorld(world);
+	m_character_p = m_world_p->getCharacterWithName(m_param[1]);
+}
+
+
+// 特定のキャラが特定のキャラの近くにいる
+CharacterNearFire::CharacterNearFire(World* world, std::vector<std::string> param) :
+	EventFire(world)
+{
+	m_param = param;
+	m_character_p = m_world_p->getCharacterWithName(m_param[1]);
+	m_target_p = m_world_p->getCharacterWithName(m_param[2]);
+	m_dx = stoi(param[3]);
+	m_dy = stoi(param[4]);
+
+	m_areaNum = m_world_p->getAreaNum();
+}
+bool CharacterNearFire::fire() {
+	// 特定のキャラが指定した場所にいるか判定
+	if (m_world_p->getAreaNum() != m_areaNum) { 
+		m_areaNum = m_world_p->getAreaNum();
+		m_target_p = m_world_p->getCharacterWithName(m_param[2]);
+	}
+	if (m_target_p == nullptr) { return false; }
+	int x = m_character_p->getCenterX();
+	int y = m_character_p->getY() + m_character_p->getHeight();
+	int targetX = m_target_p->getCenterX();
+	int targetY = m_target_p->getY() + m_target_p->getHeight();
+	if (x > targetX - m_dx && x < targetX + m_dx && y > targetY - m_dy && y < targetY + m_dy) {
+		return true;
+	}
+	return false;
+}
+void CharacterNearFire::setWorld(World* world) {
 	EventFire::setWorld(world);
 	m_character_p = m_world_p->getCharacterWithName(m_param[1]);
 }

--- a/Event.h
+++ b/Event.h
@@ -157,6 +157,35 @@ public:
 	void setWorld(World* world);
 };
 
+// 特定のキャラが特定のキャラの近くにいる
+class CharacterNearFire :
+	public	EventFire
+{
+private:
+	// パラメータ
+	std::vector<std::string> m_param;
+
+	// キャラ
+	Character* m_character_p;
+
+	// 今いるエリア番号　エリア移動を知る用
+	int m_areaNum;
+
+	// 子のキャラの近くに行くのが条件
+	Character* m_target_p;
+
+	// 座標のずれの許容
+	int m_dx, m_dy;
+
+public:
+	CharacterNearFire(World* world, std::vector<std::string> param);
+
+	bool fire();
+
+	// 世界を設定しなおす
+	void setWorld(World* world);
+};
+
 // 勝手に発火
 class AutoFire :
 	public EventFire

--- a/Game.cpp
+++ b/Game.cpp
@@ -21,6 +21,8 @@ using namespace std;
 const int FINISH_STORY = 10;
 // エリア0でデバッグするときはtrueにする
 const bool TEST_MODE = false;
+// スキルが発動可能になるストーリー番号
+const int SKILL_USEABLE_STORY = 1;
 
 
 /*
@@ -413,7 +415,7 @@ bool Game::play() {
 	}
 
 	// スキル発動 Fキーかつスキル未発動状態かつ発動可能なイベント中（もしくはイベント中でない）かつエリア移動中でない
-	if (m_gameData->getStoryNum() >= 4) { // ストーリーの最初は発動できない
+	if (m_gameData->getStoryNum() >= SKILL_USEABLE_STORY) { // ストーリーの最初は発動できない
 		if (controlF() == 1 && m_skill == nullptr) { // Fキーで発動、ただしスキル身発動時
 			if (m_story->skillAble() && m_world->getBrightValue() == 255) { // 特定のイベント時やエリア移動中はダメ
 				if (m_world->getCharacterWithName("ハート")->getHp() > 0) {

--- a/Main.cpp
+++ b/Main.cpp
@@ -60,8 +60,8 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	//SetMousePoint(320, 240);//マウスカーソルの初期位置
 	
 	// 画像の拡大処理方式
-	//SetDrawMode(DX_DRAWMODE_BILINEAR);
-	SetDrawMode(DX_DRAWMODE_NEAREST);
+	SetDrawMode(DX_DRAWMODE_BILINEAR);
+	//SetDrawMode(DX_DRAWMODE_NEAREST);
 	SetFullScreenScalingMode(DX_DRAWMODE_NEAREST);
 
 	// ゲーム本体

--- a/World.cpp
+++ b/World.cpp
@@ -129,6 +129,8 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) :
 		}
 	}
 
+	m_camera->setEx(m_cameraMaxEx);
+
 }
 
 World::World(const World* original) :
@@ -178,6 +180,8 @@ World::World(const World* original) :
 	}
 	m_backGroundGraph = original->getBackGroundGraph();
 	m_backGroundColor = original->getBackGroundColor();
+
+	m_camera->setEx(m_cameraMaxEx);
 
 }
 
@@ -592,7 +596,7 @@ void World::updateCamera() {
 	// キャラとカメラの距離の最大
 	int max_dx = 0, max_dy = 0;
 	// 画面内に入れようとする距離の最大　これより離れたキャラは無視
-	const int MAX_DISABLE = 2000;
+	const int MAX_DISABLE = 3000;
 	for (unsigned int i = 0; i < size; i++) {
 		// 今フォーカスしているキャラの座標に合わせる
 		if (m_focusId == m_characters[i]->getId()) {
@@ -628,7 +632,7 @@ void World::updateCamera() {
 		if (nowEx > m_cameraMinEx && (max_dx > nowWide || max_dy > nowHeight)) {
 			// 縮小
 			double d = double(max(max_dx - nowWide, max_dy - nowHeight));
-			m_camera->setEx(nowEx - min(0.08, d / 100000));
+			m_camera->setEx(nowEx - min(0.1, d / 100000));
 		}
 		else if (nowEx < m_cameraMaxEx && (max_dx < nowWide && max_dy < nowHeight)) {
 			// 拡大

--- a/World.cpp
+++ b/World.cpp
@@ -15,6 +15,7 @@
 #include "CharacterLoader.h"
 #include "ObjectLoader.h"
 #include "Game.h"
+#include "GraphHandle.h"
 #include "DxLib.h"
 #include <algorithm>
 
@@ -131,6 +132,9 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) :
 
 	m_camera->setEx(m_cameraMaxEx);
 
+	m_characterDeadGraph = new GraphHandles("picture/effect/dead", 5, 1.0, 0, true);
+	m_characterDeadSound = LoadSoundMem("sound/battle/dead.wav");
+
 }
 
 World::World(const World* original) :
@@ -144,6 +148,8 @@ World::World(const World* original) :
 	m_focusId = original->getFocusId();
 	m_playerId = original->getPlayerId();
 	m_soundPlayer_p = original->getSoundPlayer();
+	m_characterDeadGraph = original->getCharacterDeadGraph();
+	m_characterDeadSound = original->getCharacterDeadSound();
 	// キャラをコピー
 	for (unsigned int i = 0; i < original->getCharacters().size(); i++) {
 		Character* copy;
@@ -212,6 +218,8 @@ World::~World() {
 	// 背景
 	if (!m_duplicationFlag) {
 		DeleteGraph(m_backGroundGraph);
+		delete m_characterDeadGraph;
+		DeleteSoundMem(m_characterDeadSound);
 	}
 }
 
@@ -546,7 +554,7 @@ void World::battle() {
 	// 画面暗転中 エリア移動かプレイヤーやられ時
 	if (m_brightValue != 255 || playerDead()) {
 		m_brightValue = max(0, m_brightValue - 10);
-		return;
+		if (!playerDead()) { return; }
 	}
 
 	// HP0のキャラコントローラ削除
@@ -591,19 +599,21 @@ void World::updateCharacter() {
 
 // カメラの更新
 void World::updateCamera() {
-	size_t size = m_characters.size();
-	int x = 0, y = 0;
-	// キャラとカメラの距離の最大
+
+	// カメラを揺らす
+	m_camera->shaking();
+
+	// キャラとカメラの距離の最大値を調べる
 	int max_dx = 0, max_dy = 0;
 	// 画面内に入れようとする距離の最大　これより離れたキャラは無視
 	const int MAX_DISABLE = 3000;
+	size_t size = m_characters.size();
 	for (unsigned int i = 0; i < size; i++) {
 		// 今フォーカスしているキャラの座標に合わせる
 		if (m_focusId == m_characters[i]->getId()) {
-			x = m_characters[i]->getCenterX();
-			y = m_characters[i]->getCenterY();
-			m_camera->setGPoint(x, y);
+			m_camera->setGPoint(m_characters[i]->getCenterX(), m_characters[i]->getCenterY());
 		}
+		// フォーカスしているキャラ以外なら距離を調べる
 		else if (m_characters[i]->getHp() > 0) {
 			int dx = abs(m_camera->getX() - m_characters[i]->getX()) + m_characters[i]->getWide();
 			if (dx < MAX_DISABLE) {
@@ -612,7 +622,8 @@ void World::updateCamera() {
 			}
 		}
 	}
-	// カメラはゆっくり動く
+
+	// カメラを目標位置へ近づける
 	m_camera->move();
 
 	// カメラの拡大・縮小
@@ -668,6 +679,11 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 			int soundHandle = objects[i]->getSoundHandle();
 			int panPal = adjustPanSound(x, m_camera->getX());
 			m_soundPlayer_p->pushSoundQueue(soundHandle, panPal);
+			if (controller->getAction()->getCharacter()->getHp() == 0) {
+				m_animations.push_back(new Animation(x, y, 3, m_characterDeadGraph));
+				m_camera->shakingStart(20, 20);
+				m_soundPlayer_p->pushSoundQueue(m_characterDeadSound, panPal);
+			}
 		}
 		// deleteFlagがtrueなら削除する
 		if (objects[i]->getDeleteFlag()) {

--- a/World.h
+++ b/World.h
@@ -6,21 +6,22 @@
 #include <string>
 
 
-class CharacterController;
-class CharacterAction;
-class Character;
-class Object;
-class DoorObject;
-class Camera;
 class Animation;
-class SoundPlayer;
-class Conversation;
 class Brain;
-class CharacterLoader;
-class ObjectLoader;
+class Camera;
+class Character;
+class CharacterAction;
+class CharacterController;
 class CharacterData;
+class CharacterLoader;
+class Conversation;
 class DoorData;
+class DoorObject;
+class GraphHandles;
 class Movie;
+class Object;
+class ObjectLoader;
+class SoundPlayer;
 
 
 class World {
@@ -85,6 +86,12 @@ private:
 	// エフェクト等のアニメーション Worldがデリートする
 	std::vector<Animation*> m_animations;
 
+	// キャラがやられた時のエフェクト画像
+	GraphHandles* m_characterDeadGraph;
+
+	// キャラがやられた時の効果音
+	int m_characterDeadSound;
+
 	// 背景
 	int m_backGroundGraph;
 	int m_backGroundColor;
@@ -119,6 +126,8 @@ public:
 	inline SoundPlayer* getSoundPlayer() const { return m_soundPlayer_p; }
 	inline double getCameraMaxEx() const { return m_cameraMaxEx; }
 	inline double getCameraMinEx() const { return m_cameraMinEx; }
+	inline GraphHandles* getCharacterDeadGraph() const { return m_characterDeadGraph; }
+	inline int getCharacterDeadSound() const { return m_characterDeadSound; }
 
 	// セッタ
 	void setSkillFlag(bool skillFlag);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
既存のCharacterPointFireだと特定のキャラの近くへ行くことを条件にするようcsvファイルに記述するのが面倒。（その目標キャラの座法を知っておかないと書けないため）

新しく追加するCharacterNearFireは目標のキャラ名を記述するだけでよい。

また、キャラがやられた時のエフェクトを追加する。具体的には以下の3つ
- 効果音
- 画面が揺れる
- エフェクトの画像

そして、仕様変更が1つ
- エリア移動時の画面暗転中はキャラが動かないが、プレイヤーがやられた時の画面暗転中はキャラが動く。すなわちプレイヤーがやられた時のエフェクトがちゃんと再生されて見える。

# やったこと
指定したキャラが今のエリアに存在するとは限らない。しかし、毎フレームWorldからキャラがいるかを検索するのは非効率なのでエリア番号をFireが保持しておき、Worldのエリア番号と異なるときのみ検索する。

Cameraクラスを編集し、カメラを揺らす機能を追加。

Worldクラスはキャラがやられた時のエフェクト画像と効果音を保持しており、キャラが攻撃を受けた時HPが０ならそれらを使う。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
テストプレイで確認

スキル発動にも問題ないことを確認

# 懸念点
記入欄
