### PR TITLE
敵が落とすアイテム実装

### DIFF
--- a/Debug.cpp
+++ b/Debug.cpp
@@ -13,6 +13,7 @@
 #include "Story.h"
 #include "Brain.h"
 #include "Sound.h"
+#include "Item.h"
 #include "DxLib.h"
 
 /*
@@ -43,6 +44,10 @@ void debugObjects(int x, int y, int color, std::vector<Object*> objects) {
 void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "areaNum=%d, CharacterSum=%d, ControllerSum=%d", m_areaNum, m_characters.size(), m_characterControllers.size(), m_camera->getEx());
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "itemSum=%d", m_itemVector.size());
+	if (m_itemVector.size() > 0) {
+		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "itemY=%d", m_itemVector[0]->getY());
+	}
 	//debugObjects(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, m_attackObjects);
 	//m_characterControllers[0]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
 	//if (m_movie_p != nullptr) {

--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="Game.cpp" />
     <ClCompile Include="GameDrawer.cpp" />
     <ClCompile Include="GraphHandle.cpp" />
+    <ClCompile Include="Item.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Object.cpp" />
     <ClCompile Include="ObjectDrawer.cpp" />
@@ -202,6 +203,7 @@
     <ClInclude Include="Game.h" />
     <ClInclude Include="GameDrawer.h" />
     <ClInclude Include="GraphHandle.h" />
+    <ClInclude Include="Item.h" />
     <ClInclude Include="Object.h" />
     <ClInclude Include="ObjectDrawer.h" />
     <ClInclude Include="ObjectLoader.h" />

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClCompile Include="Title.cpp">
       <Filter>ソース ファイル\pages</Filter>
     </ClCompile>
+    <ClCompile Include="Item.cpp">
+      <Filter>ソース ファイル\Domain</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">
@@ -226,6 +229,9 @@
     </ClInclude>
     <ClInclude Include="Title.h">
       <Filter>ヘッダー ファイル\pages</Filter>
+    </ClInclude>
+    <ClInclude Include="Item.h">
+      <Filter>ヘッダー ファイル\Domain</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Item.cpp
+++ b/Item.cpp
@@ -18,8 +18,9 @@ Item::Item(const char* itemName, int x, int y) {
 	m_vy = 0;
 	m_grand = false;
 	m_sound = LoadSoundMem(("sound/item/" + m_itemName + ".wav").c_str());
-	m_handles = new GraphHandles(("picture/item/" + m_itemName).c_str(), 1, 1.0, 0.0, true);
+	m_handles = new GraphHandles(("picture/item/" + m_itemName).c_str(), 1, 0.05, 0.0, true);
 	m_animation = new Animation(m_x, m_y, 10, m_handles);
+	m_deleteFlag = false;
 }
 
 // デストラクタ
@@ -29,9 +30,40 @@ Item::~Item() {
 	delete m_animation;
 }
 
+// コピー
+void Item::setParam(Item* item) {
+	item->setGrand(m_grand);
+	item->setAnimation(m_animation->createCopy());
+}
+
+void Item::setY(int y) {
+	int wide = 0, height = 0;
+	getGraphSize(&wide, &height);
+	m_y = y - (height / 2);
+	m_animation->setY(m_y);
+}
+
+// 取得済みかつ効果音が再生中じゃないなら削除してもらう
+bool Item::getDeleteFlag() const { 
+	return m_deleteFlag;
+}
+
 // アイテムの大きさ
 void Item::getGraphSize(int* wide, int* height) const {
+	double ex = m_animation->getHandle()->getEx();
 	GetGraphSize(m_animation->getHandle()->getHandle(), wide, height);
+	*wide = (int)(*wide * ex);
+	*height = (int)(*height * ex);
+}
+
+// 座標
+void Item::getPoint(int* x1, int* y1, int* x2, int* y2) {
+	int wide = 0, height = 0;
+	getGraphSize(&wide, &height);
+	*x1 = m_x - (wide / 2);
+	*y1 = m_y - (height / 2);
+	*x2 = *x1 + wide;
+	*y2 = *y1 + height;
 }
 
 // 毎フレームの初期化処理
@@ -54,14 +86,39 @@ void Item::action() {
 		// 着地してる
 		m_vy = 0;
 	}
-	else {
-		// 重力
-		m_y += 1;
-	}
 	
 	// 移動
 	m_x += m_vx;
 	m_y += m_vy;
+	m_animation->setX(m_x);
+	m_animation->setY(m_y);
+
+	// 重力
+	m_vy += 1;
+
+}
+
+// プレイヤーとの当たり判定
+bool Item::atariCharacter(Character* player) {
+
+	// キャラの座標
+	int cx1 = player->getX();
+	int cy1 = player->getY();
+	int cx2 = cx1 + player->getWide();
+	int cy2 = cy1 + player->getHeight();
+	
+	// このアイテムの座標
+	int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+	getPoint(&x1, &y1, &x2, &y2);
+
+	// 当たったか判定
+	if (x2 > cx1 && x1 < cx2 && y2 > cy1 && y1 < cy2) {
+		arrangePlayer(player);
+		m_deleteFlag = true;
+		return true;
+	}
+
+	return false;
 
 }
 
@@ -73,6 +130,13 @@ CureItem::CureItem(const char* itemName, int x, int y, int cureValue):
 	Item(itemName, x, y)
 {
 	m_cureValue = cureValue;
+}
+
+// スキル発動用
+Item* CureItem::createCopy() {
+	CureItem* item = new CureItem(m_itemName.c_str(), m_x, m_y, m_cureValue);
+	setParam(item);
+	return item;
 }
 
 // プレイヤーに対するアクション

--- a/Item.cpp
+++ b/Item.cpp
@@ -1,0 +1,82 @@
+#include "Animation.h"
+#include "Character.h"
+#include "GraphHandle.h"
+#include "Item.h"
+#include "DxLib.h"
+
+using namespace std;
+
+
+/*
+* アイテム
+*/
+Item::Item(const char* itemName, int x, int y) {
+	m_itemName = itemName;
+	m_x = x;
+	m_y = y;
+	m_vx = 0;
+	m_vy = 0;
+	m_grand = false;
+	m_sound = LoadSoundMem(("sound/item/" + m_itemName + ".wav").c_str());
+	m_handles = new GraphHandles(("picture/item/" + m_itemName).c_str(), 1, 1.0, 0.0, true);
+	m_animation = new Animation(m_x, m_y, 10, m_handles);
+}
+
+// デストラクタ
+Item::~Item() {
+	DeleteSoundMem(m_sound);
+	delete m_handles;
+	delete m_animation;
+}
+
+// アイテムの大きさ
+void Item::getGraphSize(int* wide, int* height) const {
+	GetGraphSize(m_animation->getHandle()->getHandle(), wide, height);
+}
+
+// 毎フレームの初期化処理
+void Item::init() {
+	m_grand = false;
+}
+
+// 動き 毎フレーム呼ぶ
+void Item::action() {
+
+	// アニメをリセット
+	if (m_animation->getFinishFlag()) {
+		m_animation->init();
+	}
+
+	// アニメを動かす
+	m_animation->count();
+
+	if (m_grand) {
+		// 着地してる
+		m_vy = 0;
+	}
+	else {
+		// 重力
+		m_y += 1;
+	}
+	
+	// 移動
+	m_x += m_vx;
+	m_y += m_vy;
+
+}
+
+
+/*
+* 体力回復アイテム
+*/
+CureItem::CureItem(const char* itemName, int x, int y, int cureValue):
+	Item(itemName, x, y)
+{
+	m_cureValue = cureValue;
+}
+
+// プレイヤーに対するアクション
+void CureItem::arrangePlayer(Character* player) {
+	// HP回復
+	player->setHp(player->getHp() + m_cureValue);
+}

--- a/Item.h
+++ b/Item.h
@@ -1,0 +1,98 @@
+#ifndef ITEM_H_INCLUDED
+#define ITEM_H_INCLUDED
+
+
+#include <string>
+
+
+class Animation;
+class Character;
+class GraphHandles;
+
+
+/*
+* アイテム
+*/
+class Item {
+protected:
+
+	// 座標
+	int m_x, m_y;
+
+	// 速度
+	int m_vx, m_vy;
+
+	// 着地している
+	bool m_grand;
+
+	// アイテム名　画像ロード用
+	std::string m_itemName;
+
+	// 画像
+	GraphHandles* m_handles;
+
+	// アニメーション
+	Animation* m_animation;
+
+	// 効果音
+	int m_sound;
+
+public:
+
+	// コンストラクタ
+	Item(const char* itemName, int x, int y);
+
+	// デストラクタ
+	~Item();
+
+	// ゲッタ
+	inline int getX() const { return m_x; }
+	inline int getY() const { return m_y; }
+	inline int getVx() const { return m_vx; }
+	inline int getVy() const { return m_vy; }
+	inline const char* getItemName() const { return m_itemName.c_str(); }
+	inline bool getGrand() const { return m_grand; }
+	inline int getSound() const { return m_sound; }
+	inline const Animation* getAnimation() const { return m_animation; }
+
+	// セッタ
+	inline void setGrand(bool grand) { m_grand = grand; }
+
+	// アイテムの大きさ
+	void getGraphSize(int* wide, int* height) const;
+
+	// 毎フレームの初期化処理
+	void init();
+
+	// 動き 毎フレーム呼ぶ
+	void action();
+
+	// プレイヤーに対するアクション
+	virtual void arrangePlayer(Character* player) {  }
+
+};
+
+
+/*
+* 回復アイテム
+*/
+class CureItem :
+	public Item
+{
+private:
+
+	// HPの回復量
+	int m_cureValue;
+
+public:
+
+	// コンストラクタ
+	CureItem(const char* itemName, int x, int y, int cureValue);
+
+	// プレイヤーに対するアクション
+	void arrangePlayer(Character* player);
+
+};
+
+
+#endif

--- a/Item.h
+++ b/Item.h
@@ -37,6 +37,9 @@ protected:
 	// 効果音
 	int m_sound;
 
+	// 取得済み
+	bool m_deleteFlag;
+
 public:
 
 	// コンストラクタ
@@ -44,6 +47,12 @@ public:
 
 	// デストラクタ
 	~Item();
+
+	// スキル発動用
+	virtual Item* createCopy() = 0;
+
+	// コピー
+	void setParam(Item* item);
 
 	// ゲッタ
 	inline int getX() const { return m_x; }
@@ -54,12 +63,20 @@ public:
 	inline bool getGrand() const { return m_grand; }
 	inline int getSound() const { return m_sound; }
 	inline const Animation* getAnimation() const { return m_animation; }
+	
+	// 取得済みかつ効果音が再生中じゃないなら削除してもらう
+	bool getDeleteFlag() const;
 
 	// セッタ
 	inline void setGrand(bool grand) { m_grand = grand; }
+	void setY(int y);
+	void setAnimation(Animation* animation) { delete m_animation; m_animation = animation; }
 
 	// アイテムの大きさ
 	void getGraphSize(int* wide, int* height) const;
+
+	// 座標
+	void getPoint(int* x1, int* y1, int* x2, int* y2);
 
 	// 毎フレームの初期化処理
 	void init();
@@ -67,9 +84,13 @@ public:
 	// 動き 毎フレーム呼ぶ
 	void action();
 
+	// プレイヤーとの当たり判定
+	bool atariCharacter(Character* player);
+
+private:
+
 	// プレイヤーに対するアクション
 	virtual void arrangePlayer(Character* player) {  }
-
 };
 
 
@@ -88,6 +109,12 @@ public:
 
 	// コンストラクタ
 	CureItem(const char* itemName, int x, int y, int cureValue);
+
+	// スキル発動用
+	Item* createCopy();
+
+	// セッタ
+	inline void setCureValue(int cureValue) { m_cureValue = cureValue; }
 
 	// プレイヤーに対するアクション
 	void arrangePlayer(Character* player);

--- a/Main.cpp
+++ b/Main.cpp
@@ -60,8 +60,8 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	//SetMousePoint(320, 240);//マウスカーソルの初期位置
 	
 	// 画像の拡大処理方式
-	SetDrawMode(DX_DRAWMODE_BILINEAR);
-	//SetDrawMode(DX_DRAWMODE_NEAREST);
+	//SetDrawMode(DX_DRAWMODE_BILINEAR);
+	SetDrawMode(DX_DRAWMODE_NEAREST);
 	SetFullScreenScalingMode(DX_DRAWMODE_NEAREST);
 
 	// ゲーム本体

--- a/Object.cpp
+++ b/Object.cpp
@@ -440,7 +440,7 @@ bool TriangleObject::atari(CharacterController* characterController) {
 bool TriangleObject::atariDropBox(int x1, int y1, int x2, int y2, int vx, int vy) {
 	int y = getY((x1 + x2) / 2);
 	// –„‚Ü‚Á‚Ä‚¢‚é
-	if (x2 > m_x1 && x1 < m_x2 && y2 > m_y2 && y < m_y1) {
+	if (x2 > m_x1 && x1 < m_x2 && y2 > y && y1 < m_y2) {
 		return true;
 	}
 	// ã‚©‚çÕ“Ë‚µ‚Ä‚«‚½

--- a/Object.cpp
+++ b/Object.cpp
@@ -61,6 +61,19 @@ void Object::decreaseHp(int damageValue) {
 	m_damageCnt = DAMAGE_CNT_SUM;
 }
 
+// 単純に四角の落下物と衝突しているか
+bool Object::atariDropBox(int x1, int y1, int x2, int y2, int vx, int vy) {
+	// 埋まっている
+	if (x2 > m_x1 && x1 < m_x2 && y2 > m_y1 && y1 < m_y2) {
+		return true;
+	}
+	// 上から衝突してきた
+	if (x2 + vx > m_x1 && x1 + vx < m_x2 && y2 < m_y1 && y2 + vy > m_y1) {
+		return true;
+	}
+	return false;
+}
+
 // アニメーション作成
 Animation* BulletObject::createAnimation(int x, int y, int flameCnt) {
 	if (m_effectHandles_p == nullptr) {
@@ -419,6 +432,20 @@ bool TriangleObject::atari(CharacterController* characterController) {
 				characterController->setCharacterX(m_x1 - characterWide);
 			}
 		}
+	}
+	return false;
+}
+
+// 単純に四角の落下物と衝突しているか
+bool TriangleObject::atariDropBox(int x1, int y1, int x2, int y2, int vx, int vy) {
+	int y = getY((x1 + x2) / 2);
+	// 埋まっている
+	if (x2 > m_x1 && x1 < m_x2 && y2 > m_y2 && y < m_y1) {
+		return true;
+	}
+	// 上から衝突してきた
+	if (x2 + vx > m_x1 && x1 + vx < m_x2 && y2 < y && y2 + vy > y) {
+		return true;
 	}
 	return false;
 }

--- a/Object.h
+++ b/Object.h
@@ -77,6 +77,9 @@ public:
 	void setEffectHandles(GraphHandles* effectHandles_p) { m_effectHandles_p = effectHandles_p; }
 	void setSoundHandle(int soundHandle_p) { m_soundHandle_p = soundHandle_p; }
 
+	// 座標XにおけるY1座標（傾きから算出する）
+	virtual int getY(int x) const { return m_y1; }
+
 	// HPを減らす
 	void decreaseHp(int damageValue);
 
@@ -106,6 +109,9 @@ public:
 
 	// キャラとの当たり判定
 	virtual bool atari(CharacterController* characterController) = 0;
+
+	// 単純に四角の落下物と衝突しているか
+	virtual bool atariDropBox(int x1, int y1, int x2, int y2, int vx, int vy);
 
 	// キャラがオブジェクトに入り込んでいるときの処理
 	virtual void penetration(CharacterController* characterController) {};
@@ -182,9 +188,8 @@ private:
 	// 左向きに下がっている坂
 	bool m_leftDown;
 
-	// 座標XにおけるY座標（傾きから算出する）
-	int getY(int x) const;
 public:
+
 	TriangleObject(int x1, int y1, int x2, int y2, const char* fileName, int color, bool leftDown, int hp = -1);
 
 	~TriangleObject();
@@ -193,12 +198,18 @@ public:
 
 	void debug(int x, int y, int color) const;
 
+	// 座標XにおけるY1座標（傾きから算出する）
+	int getY(int x) const;
+
 	// オブジェクト描画（画像がないときに使う）
 	void drawObject(int x1, int y1, int x2, int y2) const;
 
 	// キャラとの当たり判定
 	// 当たっているならキャラを操作する。
 	bool atari(CharacterController* characterController);
+
+	// 単純に四角の落下物と衝突しているか
+	bool atariDropBox(int x1, int y1, int x2, int y2, int vx, int vy);
 
 	// キャラがオブジェクトに入り込んでいるときの処理
 	void penetration(CharacterController* characterController);

--- a/World.cpp
+++ b/World.cpp
@@ -841,7 +841,7 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 				m_animations.push_back(new Animation(x, y, 3, m_characterDeadGraph));
 				m_camera->shakingStart(20, 20);
 				m_soundPlayer_p->pushSoundQueue(m_characterDeadSound, panPal);
-				if (!m_duplicationFlag && character->getGroupId() != m_player->getGroupId() && GetRand(100) < 100) {
+				if (!m_duplicationFlag && character->getGroupId() != m_player->getGroupId() && GetRand(100) < 20) {
 					// スキル発動中でなければ確率でアイテムが落ちる
 					m_itemVector.push_back(new CureItem("cure", x, y, 50));
 				}

--- a/World.h
+++ b/World.h
@@ -102,6 +102,9 @@ public:
 	World(const World* original);
 	~World();
 
+	//デバッグ
+	void debug(int x, int y, int color) const;
+
 	// ゲッタ
 	inline int getFocusId() const { return m_focusId; }
 	inline int getPlayerId() const { return m_playerId; }
@@ -109,16 +112,12 @@ public:
 	inline int getAreaNum() const { return m_areaNum; }
 	inline int getNextAreaNum() const { return m_nextAreaNum; }
 	inline const Camera* getCamera() const { return m_camera; }
-	std::vector<CharacterController*> getCharacterControllers() const;
-	std::vector<const CharacterAction*> getActions() const;
-	std::vector<Character*> getCharacters() const;
-	std::vector<Object*> getStageObjects() const;
-	std::vector<Object*> getDoorObjects() const;
-	std::vector<Object*> getAttackObjects() const;
-	std::vector<Animation*> getAnimations() const;
-	std::vector<const Object*> getFrontObjects() const;
-	std::vector<const Object*> getBackObjects() const;
-	std::vector<const Animation*> getConstAnimations() const;
+	std::vector<CharacterController*> getCharacterControllers() const { return m_characterControllers; }
+	std::vector<Character*> getCharacters() const { return m_characters; }
+	std::vector<Object*> getStageObjects() const { return m_stageObjects; }
+	std::vector<Object*> getDoorObjects() const { return m_doorObjects; }
+	std::vector<Object*> getAttackObjects() const { return m_attackObjects; }
+	std::vector<Animation*> getAnimations() const { return m_animations; }
 	inline const int getBackGroundGraph() const { return m_backGroundGraph; }
 	inline const int getBackGroundColor() const { return m_backGroundColor; }
 	inline const Conversation* getConversation() const { return m_conversation_p; }
@@ -129,16 +128,73 @@ public:
 	inline GraphHandles* getCharacterDeadGraph() const { return m_characterDeadGraph; }
 	inline int getCharacterDeadSound() const { return m_characterDeadSound; }
 
-	// セッタ
-	void setSkillFlag(bool skillFlag);
-	inline void setFocusId(int id) { m_focusId = id; }
+	// Drawer用のゲッタ
+	std::vector<const CharacterAction*> getActions() const;
+	std::vector<const Object*> getFrontObjects() const;
+	std::vector<const Object*> getBackObjects() const;
+	std::vector<const Animation*> getConstAnimations() const;
 
-	// ストーリーやイベントによる追加
+	// 名前でキャラ検索
+	Character* getCharacterWithName(std::string characterName) const;
+
+	// 名前でコントローラ検索
+	CharacterController* getControllerWithName(std::string characterName) const;
+
+	// IDでキャラ検索
+	Character* getCharacterWithId(int id) const;
+
+	// セッタ
+	inline void setFocusId(int id) { m_focusId = id; }
+	inline void setConversation(Conversation* conversation) { m_conversation_p = conversation; }
+	inline void setMovie(Movie* movie) { m_movie_p = movie; }
+
+	// ID指定でBrain変更
+	void setBrainWithId(int id, Brain* brain);
+
+	// ストーリーによるキャラ追加
 	void addCharacter(CharacterLoader* characterLoader);
+
+	// ストーリーによるオブジェクト追加
 	void addObject(ObjectLoader* objectLoader);
 
-	//デバッグ
-	void debug(int x, int y, int color) const;
+	// プレイヤーのHPが0ならtrue
+	bool playerDead();
+
+	// プレイヤーのHPをMAXにする
+	void playerHpReset();
+
+	// スキル発動：ハートをFreezeにする
+	void setSkillFlag(bool skillFlag);
+
+	// スキル発動：複製のハート追加用
+	void pushCharacter(Character* character, CharacterController* controller);
+
+	// スキル発動：複製のハート削除用
+	void popCharacterController(int id);
+
+	// スキル発動：レコーダを作成し使用を開始
+	void createRecorder();
+
+	// スキル発動：レコーダの時間を最初に戻す
+	void initRecorder();
+
+	// スキル発動：レコーダの使用をやめて削除する
+	void eraseRecorder();
+
+	// データ管理：キャラの状態を変更する いないなら作成する
+	void asignedCharacterData(const char* name, CharacterData* data);
+
+	// データ管理：キャラの状態を教える
+	void asignCharacterData(const char* name, CharacterData* data, int fromAreaNum, bool notCharacterPoint) const;
+
+	// データ管理：Doorの状態を変更する いないなら作成する
+	void asignedDoorData(DoorData* data);
+
+	// データ管理：Doorの状態を教える
+	void asignDoorData(std::vector<DoorData*>& data, int fromAreaNum) const;
+
+	// データ管理：プレイヤーとその仲間をドアの前に移動
+	void setPlayerOnDoor(int from);
 
 	// キャラに戦わせる
 	void battle();
@@ -149,76 +205,44 @@ public:
 	// ムービーを流す
 	void moviePlay();
 
-	// キャラの状態を変更する いないなら作成する
-	void asignedCharacterData(const char* name, CharacterData* data);
+private:
 
-	// キャラの状態を教える
-	void asignCharacterData(const char* name, CharacterData* data, int fromAreaNum, bool notCharacterPoint) const;
-
-	// Doorの状態を変更する いないなら作成する
-	void asignedDoorData(DoorData* data);
-
-	// Doorの状態を教える
-	void asignDoorData(std::vector<DoorData*>& data, int fromAreaNum) const;
-
-	// プレイヤーとその仲間をドアの前に移動
-	void setPlayerOnDoor(int from);
-
-	// カメラの位置をリセット
+	// データ管理：カメラの位置をリセット
 	void cameraPointInit();
 
-	// プレイヤーのHPが0ならtrue
-	bool playerDead();
+	// データ管理：キャラのセーブデータを自身に反映させる
+	void asignedCharacter(Character* character, CharacterData* data, bool changePosition);
 
-	// プレイヤーのHPをMAXにする
-	void playerHpReset();
+	// データ管理：コントローラ1個の情報を世界に反映
+	CharacterController* createControllerWithData(const Character* character, CharacterData* data);
 
-	/*
-	* イベント用
-	*/
-	Character* getCharacterWithName(std::string characterName) const;
-	CharacterController* getControllerWithName(std::string characterName) const;
-	Character* getCharacterWithId(int id) const;
-	void setBrainWithId(int id, Brain* brain);
-	inline void setConversation(Conversation* conversation){ m_conversation_p = conversation; }
-	inline void setMovie(Movie* movie) { m_movie_p = movie; }
-	void pushCharacter(Character* character, CharacterController* controller);
-	void popCharacterController(int id);
-	void createRecorder();
-	void initRecorder();
-	void eraseRecorder();
-
-private:
-	// キャラクターとオブジェクトの当たり判定
-	void atariCharacterAndObject(CharacterController* controller, std::vector<Object*>& objects);
-
-	// キャラクターと扉の当たり判定
-	void atariCharacterAndDoor(CharacterController* controller, std::vector<Object*>& objects);
-
-	// アニメーションの更新
-	void updateAnimation();
-
-	// キャラの更新（攻撃対象の変更）
-	void updateCharacter();
-
-	// カメラの更新
+	// Battle：カメラの更新
 	void updateCamera();
 
-	// キャラクターの動き
+	// Battle：アニメーションの更新
+	void updateAnimation();
+
+	// Battle：キャラの更新（攻撃対象の変更）
+	void updateCharacter();
+
+	// Battle：キャラクターの動き
 	void controlCharacter();
 
-	// オブジェクトの動き
+	// Battle：オブジェクトの動き
 	void controlObject();
 
-	// 壁や床<->攻撃の当たり判定
+	// Battle：キャラクターとオブジェクトの当たり判定
+	void atariCharacterAndObject(CharacterController* controller, std::vector<Object*>& objects);
+
+	// Battle：キャラクターと扉の当たり判定
+	void atariCharacterAndDoor(CharacterController* controller, std::vector<Object*>& objects);
+
+	// Battle：壁や床<->攻撃の当たり判定
 	void atariStageAndAttack();
 
-	// 攻撃<->攻撃の当たり判定
+	// Battle：攻撃<->攻撃の当たり判定
 	void atariAttackAndAttack();
 
-	// キャラのセーブデータを自身に反映させる
-	void asignedCharacter(Character* character, CharacterData* data, bool changePosition);
-	CharacterController* createControllerWithData(const Character* character, CharacterData* data);
 };
 
 #endif

--- a/World.h
+++ b/World.h
@@ -18,6 +18,7 @@ class Conversation;
 class DoorData;
 class DoorObject;
 class GraphHandles;
+class Item;
 class Movie;
 class Object;
 class ObjectLoader;
@@ -86,6 +87,9 @@ private:
 	// エフェクト等のアニメーション Worldがデリートする
 	std::vector<Animation*> m_animations;
 
+	// エリアに落ちているアイテム
+	std::vector<Item*> m_itemVector;
+
 	// キャラがやられた時のエフェクト画像
 	GraphHandles* m_characterDeadGraph;
 
@@ -118,6 +122,7 @@ public:
 	std::vector<Object*> getDoorObjects() const { return m_doorObjects; }
 	std::vector<Object*> getAttackObjects() const { return m_attackObjects; }
 	std::vector<Animation*> getAnimations() const { return m_animations; }
+	std::vector<Item*> getItemVector() const { return m_itemVector; }
 	inline const int getBackGroundGraph() const { return m_backGroundGraph; }
 	inline const int getBackGroundColor() const { return m_backGroundColor; }
 	inline const Conversation* getConversation() const { return m_conversation_p; }
@@ -230,6 +235,9 @@ private:
 
 	// Battle：オブジェクトの動き
 	void controlObject();
+
+	// Battle：アイテムの動き
+	void controlItem();
 
 	// Battle：キャラクターとオブジェクトの当たり判定
 	void atariCharacterAndObject(CharacterController* controller, std::vector<Object*>& objects);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
敵を倒すと確率でアイテムを落とすようにする。

アイテム
- HPを回復
- スキル発動のエネルギーをためる（予定）
- 収集アイテム

# やったこと
Itemクラスを実装。縦方向の落下のみする。BoxとTriangleと当たり判定がある。キャラはプレイヤーのみ当たり判定がある。

CureItemクラスはItemクラスを継承する。プレイヤーが当たるとプレイヤーのHPが回復する。

Worldクラスのリファクタリングをする。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
