### PR TITLE
Api: エリア移動禁止イベントとチャプター選択機能追加

### DIFF
--- a/Event.cpp
+++ b/Event.cpp
@@ -107,7 +107,10 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	string param0 = param[0];
 	EventElement* element = nullptr;
 
-	if (param0 == "ChangeBrain") {
+	if (param0 == "LockArea") {
+		element = new LockAreaEvent(world, param);
+	}
+	else if (param0 == "ChangeBrain") {
 		element = new ChangeBrainEvent(world, param);
 	}
 	else if (param0 == "ChangeGroup") {
@@ -264,6 +267,16 @@ EventElement::~EventElement() {
 
 }
 
+// エリア移動を禁止する
+LockAreaEvent::LockAreaEvent(World* world, std::vector<std::string> param):
+	EventElement(world)
+{
+	m_lock = param[1] == "1" ? true : false;
+}
+EVENT_RESULT LockAreaEvent::play() {
+	m_world_p->setAreaLock(m_lock);
+	return EVENT_RESULT::SUCCESS;
+}
 
 // キャラのBrainを変更する
 ChangeBrainEvent::ChangeBrainEvent(World* world, vector<string> param) :

--- a/Event.h
+++ b/Event.h
@@ -221,6 +221,22 @@ public:
 /*
 * EventElementの派生クラス
 */
+// エリア移動を禁止する
+class LockAreaEvent :
+	public EventElement
+{
+private:
+
+	// 禁止ならtrue
+	bool m_lock;
+
+public:
+	LockAreaEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+};
 // キャラのAIを変える
 class ChangeBrainEvent :
 	public EventElement

--- a/Game.cpp
+++ b/Game.cpp
@@ -600,6 +600,9 @@ HeartSkill::~HeartSkill() {
 		m_world_p->eraseRecorder();
 	}
 	DeleteSoundMem(m_sound);
+	if (m_duplicationWorld != nullptr) {
+		delete m_duplicationWorld;
+	}
 }
 
 // スキル終了時にtrue
@@ -628,6 +631,7 @@ bool HeartSkill::play() {
 			// 最後のループはもとのWorldに操作記録をコピーして、そのWorldでbattle
 			copyRecord(m_duplicationWorld, m_world_p);
 			delete m_duplicationWorld;
+			m_duplicationWorld = nullptr;
 		}
 		else { 
 			return true;

--- a/Game.h
+++ b/Game.h
@@ -246,8 +246,14 @@ public:
 	inline World* getWorld() const { return m_loopNow < m_loopNum ? m_duplicationWorld : m_world_p; }
 	inline double getCnt() const { return ((double)DUPLICATION_TIME / 60.0) - ((double)m_cnt / 60.0); }
 
-	// スキル進行中
+	// スキル進行中 スキル終了時にtrue
 	bool play();
+
+	// 戦わせる（操作記録をするという言い方が正しい）
+	void battle();
+
+	// 操作記録が終わったかどうかの判定
+	bool finishRecordFlag();
 
 private:
 	// 世界のコピーを作る コピーの変更はオリジナルに影響しない

--- a/Game.h
+++ b/Game.h
@@ -155,17 +155,22 @@ private:
 	// 今やっているストーリー
 	int m_storyNum;
 
+	// 最新の未クリアストーリー
+	int m_latestStoryNum;
+
 	// 音量
 	int m_soundVolume;
 
 public:
 	GameData();
 	GameData(const char* saveFilePath);
+	GameData(const char* saveFilePath, int storyNum);
 	~GameData();
 
 	// セーブとロード
 	bool save();
 	bool load();
+	bool saveChapter();
 	// 全セーブデータ共通
 	bool saveCommon(int soundVolume, int gameWide, int gameHeight);
 	bool loadCommon(int* soundVolume, int* gameWide, int* gameHeight);
@@ -179,6 +184,7 @@ public:
 	inline int getDoorSum() const { return (int)m_doorData.size(); }
 	inline int getFrom(int i) const { return m_doorData[i]->from(); }
 	inline int getTo(int i) const { return m_doorData[i]->to(); }
+	inline int getLatestStoryNum() const { return m_latestStoryNum; }
 
 	// セッタ
 	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }
@@ -280,7 +286,7 @@ private:
 	bool m_rebootFlag;
 
 public:
-	Game(const char* saveFilePath = "savedata/test/");
+	Game(const char* saveFilePath = "savedata/test/", int storyNum = -1);
 	~Game();
 
 	// ゲッタ

--- a/Main.cpp
+++ b/Main.cpp
@@ -99,7 +99,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 			Title::TITLE_RESULT result = title->play();
 			title->draw();
 			if (result == Title::START) {
-				game = new Game(title->useSaveFile());
+				game = new Game(title->useSaveFile(), title->startStoryNum());
 				gameDrawer = new GameDrawer(game);
 				delete title;
 				gamePlay = true;

--- a/Object.cpp
+++ b/Object.cpp
@@ -900,7 +900,7 @@ void SlashObject::setSlashParam(SlashObject* object) {
 Object* DoorObject::createCopy() {
 	DoorObject* res = new DoorObject(m_x1, m_y1, m_x2, m_y2, m_fileName.c_str(), m_areaNum);
 	setParam(res);
-	res->setText(m_text);
+	res->setText(m_text.c_str());
 	return res;
 }
 

--- a/Object.h
+++ b/Object.h
@@ -104,6 +104,9 @@ public:
 	// テキストを返す ないならnullptr
 	virtual inline std::string getText() const { return ""; }
 
+	// テキストをセット
+	virtual inline void setText(const char* text) {  }
+
 	// オブジェクト描画（画像がないときに使う）
 	virtual void drawObject(int x1, int y1, int x2, int y2) const {};
 
@@ -438,7 +441,7 @@ public:
 	const char* getFileName() const { return m_fileName.c_str(); }
 
 	// セッタ
-	inline void setText(std::string text) { m_text = text; }
+	inline void setText(const char* text) { m_text = text; }
 
 	// キャラとの当たり判定
 	virtual bool atari(CharacterController* characterController);

--- a/Story.cpp
+++ b/Story.cpp
@@ -54,6 +54,9 @@ Story::~Story() {
 	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
 		delete m_subEvent[i];
 	}
+	if (m_nowEvent != nullptr) {
+		delete m_nowEvent;
+	}
 	delete m_characterLoader;
 	delete m_objectLoader;
 }

--- a/Title.cpp
+++ b/Title.cpp
@@ -47,7 +47,7 @@ SelectSaveData::SelectSaveData() {
 		m_dataInitButton[i] = new Button("削除", (int)(650 * exX), (int)(300 * exY + (i * 150 * exY)), (int)(100 * exX), (int)(100 * exY), LIGHT_RED, RED, m_font, BLACK);
 		int latestStoryNum = m_gameData[i]->getLatestStoryNum();
 		if (latestStoryNum > 1) {
-			m_startStoryNum[i] = new ControlBar(800, 350 + (i * 150), 1000, 400 + (i * 150), 1, latestStoryNum, latestStoryNum, "チャプター");
+			m_startStoryNum[i] = new ControlBar(900, 350 + (i * 150), 1600, 400 + (i * 150), 1, latestStoryNum, latestStoryNum, "チャプター");
 		}
 		else {
 			m_startStoryNum[i] = nullptr;
@@ -99,6 +99,8 @@ bool SelectSaveData::play(int handX, int handY) {
 					// セーブデータ削除
 					m_gameData[i]->removeSaveData();
 					m_dataButton[i]->setString("New Game");
+					delete m_startStoryNum[i];
+					m_startStoryNum[i] = nullptr;
 				}
 				m_initCnt = 0;
 				m_dataInitButton[i]->setColor(LIGHT_RED);

--- a/Title.cpp
+++ b/Title.cpp
@@ -45,6 +45,13 @@ SelectSaveData::SelectSaveData() {
 		}
 		m_dataButton[i] = new Button(text, (int)(100 * exX), (int)(300 * exY + (i * 150 * exY)), (int)(500 * exX), (int)(100 * exY), WHITE, GRAY2, m_font, BLACK);
 		m_dataInitButton[i] = new Button("削除", (int)(650 * exX), (int)(300 * exY + (i * 150 * exY)), (int)(100 * exX), (int)(100 * exY), LIGHT_RED, RED, m_font, BLACK);
+		int latestStoryNum = m_gameData[i]->getLatestStoryNum();
+		if (latestStoryNum > 1) {
+			m_startStoryNum[i] = new ControlBar(800, 350 + (i * 150), 1000, 400 + (i * 150), 1, latestStoryNum, latestStoryNum, "チャプター");
+		}
+		else {
+			m_startStoryNum[i] = nullptr;
+		}
 	}
 
 }
@@ -55,6 +62,7 @@ SelectSaveData::~SelectSaveData() {
 		delete m_gameData[i];
 		delete m_dataButton[i];
 		delete m_dataInitButton[i];
+		delete m_startStoryNum[i];
 	}
 }
 
@@ -100,6 +108,9 @@ bool SelectSaveData::play(int handX, int handY) {
 			m_initCnt = 0;
 			m_dataInitButton[i]->setColor(LIGHT_RED);
 		}
+		if (m_startStoryNum[i] != nullptr) {
+			m_startStoryNum[i]->play(handX, handY);
+		}
 	}
 
 	return false;
@@ -111,6 +122,9 @@ void SelectSaveData::draw(int handX, int handY) {
 	for (int i = 0; i < GAME_DATA_SUM; i++) {
 		m_dataButton[i]->draw(handX, handY);
 		m_dataInitButton[i]->draw(handX, handY);
+		if (m_startStoryNum[i] != nullptr) {
+			m_startStoryNum[i]->draw(handX, handY);
+		}
 	}
 
 }
@@ -119,6 +133,13 @@ void SelectSaveData::draw(int handX, int handY) {
 const char* SelectSaveData::useDirName() {
 	if (m_useSaveDataIndex == NOT_DECIDE_DATA) { return ""; }
 	return m_gameData[m_useSaveDataIndex]->getSaveFilePath();
+}
+
+// 始めるチャプター
+int SelectSaveData::startStoryNum() {
+	if (m_useSaveDataIndex == NOT_DECIDE_DATA || m_startStoryNum[m_useSaveDataIndex] == nullptr) { return -1; }
+	int storyNum = m_startStoryNum[m_useSaveDataIndex]->getNowValue();
+	return storyNum == m_gameData[m_useSaveDataIndex]->getLatestStoryNum() ? -1 : storyNum;
 }
 
 // 全セーブデータ共通のデータをセーブ(タイトル画面のオプション用)

--- a/Title.h
+++ b/Title.h
@@ -8,6 +8,7 @@ class TitleOption;
 class OpMovie;
 class AnimationDrawer;
 class GameData;
+class ControlBar;
 
 
 /*
@@ -38,6 +39,9 @@ private:
 	// 使用するセーブデータのインデックス
 	int m_useSaveDataIndex;
 
+	// 開始するチャプター番号
+	ControlBar* m_startStoryNum[GAME_DATA_SUM];
+
 public:
 
 	SelectSaveData();
@@ -57,6 +61,9 @@ public:
 
 	// 使用するセーブデータのディレクトリ名
 	const char* useDirName();
+
+	// 始めるチャプター 指定がないなら-1
+	int startStoryNum();
 
 	// 全セーブデータ共通のデータをセーブ(タイトル画面のオプション用)
 	void saveCommon(int soundVolume);
@@ -128,6 +135,11 @@ public:
 	// 使用するセーブデータのフォルダ名
 	inline const char* useSaveFile() { 
 		return m_selectSaveData->useDirName();
+	}
+
+	// 始めるチャプター番号 指定がないなら-1
+	inline int startStoryNum() {
+		return m_selectSaveData->startStoryNum();
 	}
 
 };

--- a/World.cpp
+++ b/World.cpp
@@ -95,6 +95,8 @@ World::World() {
 	m_cameraMaxEx *= m_exX;
 	m_cameraMinEx *= m_exX;
 
+	m_areaLock = false;
+
 }
 
 /*
@@ -861,11 +863,15 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 //  Battle：キャラクターと扉オブジェクトの当たり判定
 void World::atariCharacterAndDoor(CharacterController* controller, vector<Object*>& objects) {
 
-	// スキル発動中は扉は入れない
+	// スキル発動中は扉に入れない
 	if (m_skillFlag) { return; }
 
 	// 壁や床オブジェクトの処理 (当たり判定と動き)
 	for (unsigned int i = 0; i < objects.size(); i++) {
+		if (m_areaLock) {
+			objects[i]->setText("");
+			continue;
+		}
 		// 当たり判定をここで行う
 		if (objects[i]->atari(controller) && controller->getActionKey()) {
 			// 当たった場合 エリア移動が発生

--- a/World.h
+++ b/World.h
@@ -59,6 +59,9 @@ private:
 	int m_areaNum;
 	int m_nextAreaNum;
 
+	// エリア移動が禁止されているならtrue
+	bool m_areaLock;
+
 	// 描画用のカメラ Worldがデリートする
 	Camera* m_camera;
 
@@ -152,6 +155,7 @@ public:
 	inline void setFocusId(int id) { m_focusId = id; }
 	inline void setConversation(Conversation* conversation) { m_conversation_p = conversation; }
 	inline void setMovie(Movie* movie) { m_movie_p = movie; }
+	inline void setAreaLock(bool lock) { m_areaLock = lock; }
 
 	// ID指定でBrain変更
 	void setBrainWithId(int id, Brain* brain);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要

## エリア移動禁止イベント
Worldにm_lockAreaフィールドを追加し、LockAreaEventでオンオフ切り替えられる。

## チャプター選択機能
チャプターをクリアする（storyNumが増える）たびにセーブデータのバックアップを取る。そしてセーブデータ選択画面で呼び出せるようにする。

前のチャプターを選んで遊んでも、最新のセーブデータに上書きはされず、バックアップのみアップデートされていく。最新のデータに追いついたら、最新のデータにも更新をかけていく。

## バグ修正
スキル発動時はストーリー進行しないが、レコーダの記録が終わった後は進行してほしい（プレイヤーがやられるイベントが発動中に条件達成しても無効になるため）ので、記録がおわっあとの最終ループではStory::playを呼び出すようにする。

また、メモリリークが起きていたので修正。（GameがStoryとSkillと一時停止画面をdeleteしていない。など）

**一時停止画面からいつでもタイトルへ戻れるので、メモリリークに注意。**

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
テストプレイで確認。

スキル発動、タイトルへ戻る機能にも問題なし。

# 懸念点
他にもメモリリークしていないか不安。いつか全チェックしたい。
