### PR TITLE
Api: スキル発動時の表示バグ修正＆斬撃攻撃のレコードがうまくいっていないバグ修正

### DIFF
--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -390,7 +390,7 @@ Object* NormalController::slashAttack() {
 			order = m_brain->slashOrder();
 			m_slashRecorder->writeRecord(order);
 			// UŒ‚–Ú•W‚ğ‘‚«‚İ
-			m_bulletRecorder->setGoal(
+			m_slashRecorder->setGoal(
 				targetX - m_characterAction->getCharacter()->getCenterX(),
 				targetY - m_characterAction->getCharacter()->getCenterY()
 			);

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -15,9 +15,11 @@ using namespace std;
 GameDrawer::GameDrawer(const Game* game) {
 	m_game = game;
 
+	getGameEx(m_exX, m_exY);
+
 	m_worldDrawer = new WorldDrawer(nullptr);
 
-	m_skillHandle = CreateFontToHandle(nullptr, SKILL_SIZE, 10);
+	m_skillHandle = CreateFontToHandle(nullptr, (int)(SKILL_SIZE * m_exX), 10);
 }
 
 GameDrawer::~GameDrawer() {
@@ -46,7 +48,7 @@ void GameDrawer::draw() {
 			int cnt1 = (int)skill->getCnt();
 			int cnt2 = (int)((skill->getCnt() * 10) - cnt1 * 10);
 			oss << now + 1 << "/" << num << "F" << cnt1 << "." << cnt2;
-			DrawStringToHandle(700, 50, oss.str().c_str(), BLACK, m_skillHandle);
+			DrawStringToHandle((int)(700 * m_exX), (int)(50 * m_exY), oss.str().c_str(), BLACK, m_skillHandle);
 		}
 	}
 

--- a/GameDrawer.h
+++ b/GameDrawer.h
@@ -8,6 +8,10 @@ class GameDrawer {
 private:
 	const Game* m_game;
 
+	// テキストやフォントのサイズの倍率
+	double m_exX;
+	double m_exY;
+
 	WorldDrawer* m_worldDrawer;
 
 	// スキルの情報のフォント


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
スキル発動時の残り時間等の表示が解像度変更に対応していないため修正。

スキル発動時に斬撃攻撃の方向が再現されない（レコードがうまくいっていない）のを修正。

# やったこと
斬撃攻撃バグは単にスペルミスだった。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
