### PR TITLE
テキストイベントのフキダシに動きを持たせる

### DIFF
--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -12,6 +12,39 @@
 using namespace std;
 
 
+// ”wŒi
+TitleBackGround::TitleBackGround() {
+	double exX, exY;
+	getGameEx(exX, exY);
+	m_haikei = LoadGraph("picture/system/savedata.png");
+	GetGraphSize(m_haikei, &m_haikeiWide, &m_haikeiHeight);
+	m_haikeiEx = min(exX, exY);
+	m_haikeiWide = (int)(m_haikeiWide * m_haikeiEx);
+	m_haikeiHeight = (int)(m_haikeiHeight * m_haikeiEx);
+	m_haikeiX = m_haikeiWide / 2;
+	m_haikeiY = m_haikeiHeight / 2;
+}
+
+TitleBackGround::~TitleBackGround() {
+	DeleteGraph(m_haikei);
+}
+
+void TitleBackGround::draw() {
+	// ”wŒi‰æ‘œ
+	m_haikeiX--; m_haikeiY++;
+	SetDrawBlendMode(DX_BLENDMODE_ALPHA, 100);
+	DrawRotaGraph(m_haikeiX, m_haikeiY, m_haikeiEx, 0, m_haikei, TRUE);
+	DrawRotaGraph(m_haikeiX + m_haikeiWide, m_haikeiY, m_haikeiEx, 0, m_haikei, TRUE);
+	DrawRotaGraph(m_haikeiX, m_haikeiY - m_haikeiHeight, m_haikeiEx, 0, m_haikei, TRUE);
+	DrawRotaGraph(m_haikeiX + m_haikeiWide, m_haikeiY - m_haikeiHeight, m_haikeiEx, 0, m_haikei, TRUE);
+	SetDrawBlendMode(DX_BLENDMODE_NOBLEND, 0);
+	if (m_haikeiX <= -m_haikeiWide / 2 && m_haikeiY >= GAME_HEIGHT + m_haikeiHeight / 2) {
+		m_haikeiX += m_haikeiWide;
+		m_haikeiY -= m_haikeiHeight;
+	}
+}
+
+
 ControlBar::ControlBar(int x1, int y1, int x2, int y2, int minValue, int maxValue, int initValue, string name) {
 	
 	m_name = name;
@@ -204,6 +237,9 @@ TitleOption::TitleOption(SoundPlayer* soundPlayer) :
 	m_rightButton = new Button("¨", m_gameWideController->getRightX() - (int)(100 * m_exX), (int)((HEIGHT_Y2 + 50) * m_exY), (int)(100 * m_exX), (int)(100 * m_exY), WHITE, GRAY2, m_font, BLACK);
 	m_tmpApplyButton = new Button("Apply", m_gameWideController->getLeftX(), (int)((HEIGHT_Y2 + 170) * m_exY), m_gameWideController->getRightX() - m_gameWideController->getLeftX(), (int)(100 * m_exY), WHITE, GRAY2, m_font, BLACK);
 	m_nowTmpIndex = 0;
+
+	// ”wŒi
+	m_haikei = new TitleBackGround();
 }
 
 TitleOption::~TitleOption() {
@@ -213,6 +249,7 @@ TitleOption::~TitleOption() {
 	delete m_leftButton;
 	delete m_rightButton;
 	delete m_tmpApplyButton;
+	delete m_haikei;
 }
 
 void TitleOption::play() {
@@ -242,6 +279,9 @@ void TitleOption::play() {
 }
 
 void TitleOption::draw() const {
+
+	// ”wŒi
+	m_haikei->draw();
 
 	GamePause::draw();
 

--- a/PausePage.h
+++ b/PausePage.h
@@ -7,6 +7,30 @@
 class Button;
 class SoundPlayer;
 
+class TitleBackGround {
+private:
+
+	// 背景画像
+	int m_haikei;
+
+	// 座標
+	int m_haikeiX, m_haikeiY;
+
+	// 画像サイズ
+	int m_haikeiWide, m_haikeiHeight;
+
+	// 画像倍率
+	double m_haikeiEx;
+
+public:
+
+	TitleBackGround();
+	~TitleBackGround();
+
+	void draw();
+
+};
+
 
 // マウスでボタンを左右に動かして値を調整する機能
 class ControlBar {
@@ -182,6 +206,9 @@ class TitleOption :
 		{1280, 768}, {1280, 720}, {1176, 664}, {1152, 864}, {1024, 768}, {800, 600},
 		{640, 480} };
 	int m_nowTmpIndex;
+
+	// 背景
+	TitleBackGround* m_haikei;
 
 public:
 	TitleOption(SoundPlayer* soundPlayer);

--- a/Text.h
+++ b/Text.h
@@ -61,6 +61,46 @@ public:
 
 
 /*
+* フキダシのアクション
+*/
+class TextAction {
+private:
+
+	// ジャンプ中
+	bool m_jumpFlag;
+
+	// 座標のずれ
+	int m_dx, m_dy;
+
+	// 速度
+	int m_vy;
+
+	// 振動する残り時間
+	int m_quakeCnt;
+
+	// 振動によるずれ
+	int m_quakeDx, m_quakeDy;
+
+public:
+
+	TextAction();
+
+	// ゲッタ
+	int getDx() const { return m_dx + m_quakeDx; }
+	int getDy() const { return m_dy + m_quakeDy; }
+
+	// セッタ
+	void setVy(int vy) { m_vy = vy; m_jumpFlag = true; }
+	void setQuakeCnt(int cnt) { m_quakeCnt = cnt; }
+
+	void init();
+
+	void play();
+
+};
+
+
+/*
 * 会話イベント
 */
 class Conversation {
@@ -129,6 +169,12 @@ private:
 	// 発言終了時の印画像
 	GraphHandle* m_textFinishGraph;
 
+	// フキダシのアクション
+	TextAction m_textAction;
+
+	// 効果音
+	int m_sound;
+
 public:
 	Conversation(int textNum, World* world, SoundPlayer* soundPlayer);
 	~Conversation();
@@ -153,6 +199,7 @@ public:
 	const std::vector<Animation*> getAnimations() const { return m_animations; }
 	const GraphHandle* getTextFinishGraph() const { return m_textFinishGraph; }
 	const EventAnime* getEventAnime() const { return m_eventAnime; }
+	const TextAction getTextAction() const { return m_textAction; }
 
 	// セッタ
 	void setWorld(World* world);

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -89,31 +89,35 @@ void ConversationDrawer::draw() {
 		}
 		// 会話中
 		else {
+			int dx = m_conversation->getTextAction().getDx();
+			int dy = m_conversation->getTextAction().getDy();
+
 			// フキダシ
-			DrawExtendGraph(EDGE_X, Y1, GAME_WIDE - EDGE_X, GAME_HEIGHT - EDGE_DOWN, m_frameHandle, TRUE);
+			DrawExtendGraph(EDGE_X + dx, Y1 + dy, GAME_WIDE - EDGE_X + dx, GAME_HEIGHT - EDGE_DOWN + dy, m_frameHandle, TRUE);
 
 			// 発言者の名前、セリフ顔画像
 			int now = 0;
 			int i = 0;
 			const int CHAR_EDGE = (int)(30 * m_exX);
 			if (m_conversation->getNoFace()) { // 顔画像がない場合
-				int x = EDGE_X + TEXT_GRAPH_EDGE + graphSize / 2;
+				int x = EDGE_X + TEXT_GRAPH_EDGE + graphSize / 2 + dx;
 				// 名前
-				DrawStringToHandle(x, GAME_HEIGHT - EDGE_DOWN - (int)(NAME_SIZE * m_exX) - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
+				DrawStringToHandle(x, GAME_HEIGHT - EDGE_DOWN - (int)(NAME_SIZE * m_exX) - TEXT_GRAPH_EDGE + dy, name.c_str(), BLACK, m_nameHandle);
 				// セリフ
-				drawText(x, Y1 + TEXT_GRAPH_EDGE, (int)(TEXT_SIZE * m_exX) + CHAR_EDGE, text, BLACK, m_textHandle);
+				drawText(x, Y1 + TEXT_GRAPH_EDGE + dy, (int)(TEXT_SIZE * m_exX) + CHAR_EDGE, text, BLACK, m_textHandle);
 			}
 			else { // 顔画像がある場合
 				// 名前
-				DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE + graphSize + (int)(NAME_SIZE * m_exX), GAME_HEIGHT - EDGE_DOWN - (int)(NAME_SIZE * m_exX) - TEXT_GRAPH_EDGE, name.c_str(), BLACK, m_nameHandle);
+				DrawStringToHandle(EDGE_X + TEXT_GRAPH_EDGE + graphSize + (int)(NAME_SIZE * m_exX) + dx, GAME_HEIGHT - EDGE_DOWN - (int)(NAME_SIZE * m_exX) - TEXT_GRAPH_EDGE + dy, name.c_str(), BLACK, m_nameHandle);
 				// セリフ
-				drawText(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize, Y1 + TEXT_GRAPH_EDGE, (int)(TEXT_SIZE * m_exX) + CHAR_EDGE, text, BLACK, m_textHandle);
+				drawText(EDGE_X + TEXT_GRAPH_EDGE * 2 + graphSize + dx, Y1 + TEXT_GRAPH_EDGE + dy, (int)(TEXT_SIZE * m_exX) + CHAR_EDGE, text, BLACK, m_textHandle);
 				// キャラの顔画像
-				graph->draw(EDGE_X + TEXT_GRAPH_EDGE + graphSize / 2, Y1 + TEXT_GRAPH_EDGE + graphSize / 2, m_exX);
+				graph->draw(EDGE_X + TEXT_GRAPH_EDGE + graphSize / 2 + dx, Y1 + TEXT_GRAPH_EDGE + graphSize / 2 + dy, m_exX);
 			}
 		}
 	}
 	
+	// 画面右下のクリック要求アイコン
 	bool textFinish = m_conversation->finishText() && m_conversation->getFinishCnt() == 0 && m_conversation->getStartCnt() == 0;
 	bool eventFinish = !(m_conversation->animePlayNow()) || (m_conversation->getEventAnime()->getAnime()->getFinishFlag());
 	if (textFinish &&eventFinish) {

--- a/Title.cpp
+++ b/Title.cpp
@@ -54,14 +54,8 @@ SelectSaveData::SelectSaveData() {
 		}
 	}
 
-	// ”wŒi‰æ‘œ
-	m_haikei = LoadGraph("picture/system/savedata.png");
-	GetGraphSize(m_haikei, &m_haikeiWide, &m_haikeiHeight);
-	m_haikeiEx = min(exX, exY);
-	m_haikeiWide = (int)(m_haikeiWide * m_haikeiEx);
-	m_haikeiHeight = (int)(m_haikeiHeight * m_haikeiEx);
-	m_haikeiX = m_haikeiWide / 2;
-	m_haikeiY = m_haikeiHeight / 2;
+	// ”wŒi
+	m_haikei = new TitleBackGround();
 
 }
 
@@ -73,7 +67,7 @@ SelectSaveData::~SelectSaveData() {
 		delete m_dataInitButton[i];
 		delete m_startStoryNum[i];
 	}
-	DeleteGraph(m_haikei);
+	delete m_haikei;
 }
 
 int SelectSaveData::getSoundVolume() {
@@ -130,18 +124,8 @@ bool SelectSaveData::play(int handX, int handY) {
 
 void SelectSaveData::draw(int handX, int handY) {
 
-	// ”wŒi‰æ‘œ
-	m_haikeiX--; m_haikeiY++;
-	SetDrawBlendMode(DX_BLENDMODE_ALPHA, 100);
-	DrawRotaGraph(m_haikeiX, m_haikeiY, m_haikeiEx, 0, m_haikei, TRUE);
-	DrawRotaGraph(m_haikeiX + m_haikeiWide, m_haikeiY, m_haikeiEx, 0, m_haikei, TRUE);
-	DrawRotaGraph(m_haikeiX, m_haikeiY - m_haikeiHeight, m_haikeiEx, 0, m_haikei, TRUE);
-	DrawRotaGraph(m_haikeiX + m_haikeiWide, m_haikeiY - m_haikeiHeight, m_haikeiEx, 0, m_haikei, TRUE);
-	SetDrawBlendMode(DX_BLENDMODE_NOBLEND, 0);
-	if (m_haikeiX <= -m_haikeiWide / 2 && m_haikeiY >= GAME_HEIGHT + m_haikeiHeight / 2) {
-		m_haikeiX += m_haikeiWide;
-		m_haikeiY -= m_haikeiHeight;
-	}
+	// ”wŒi
+	m_haikei->draw();
 	
 	// ƒ{ƒ^ƒ“
 	for (int i = 0; i < GAME_DATA_SUM; i++) {

--- a/Title.h
+++ b/Title.h
@@ -9,6 +9,7 @@ class OpMovie;
 class AnimationDrawer;
 class GameData;
 class ControlBar;
+class TitleBackGround;
 
 
 /*
@@ -42,11 +43,8 @@ private:
 	// ŠJn‚·‚éƒ`ƒƒƒvƒ^[”Ô†
 	ControlBar* m_startStoryNum[GAME_DATA_SUM];
 
-	// ”wŒi‰æ‘œ
-	int m_haikei;
-	int m_haikeiX, m_haikeiY;
-	int m_haikeiWide, m_haikeiHeight;
-	double m_haikeiEx;
+	// ”wŒi
+	TitleBackGround* m_haikei;
 
 public:
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

TextActionクラスを実装。これはフキダシの座標のずれを制御する。

# やったこと
文法は以下の通り

```
# 効果音関連
@sound
<音ファイルへのパス(/sound/は省略)>


# フキダシに動きを持たせる
@jump
<ジャンプの初速（負の値）>

@quake
<振動する時間>
```

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
