### PR TITLE
Api: プレイヤーの敗北イベントで敵を無敵にする

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -237,7 +237,7 @@ void OpMovie::play() {
 	}
 	else if (m_cnt < 690 && m_cnt >= 600) {
 		m_animation->setX(GAME_WIDE / 2);
-		if (m_cnt / 5 % 2 == 0) {
+		if (m_cnt / 5 % 2 == 1) {
 			m_animation->changeGraph(m_titleBlue, 60);
 		}
 		else {
@@ -245,7 +245,7 @@ void OpMovie::play() {
 		}
 	}
 	else if (m_cnt < 700 && m_cnt >= 690) {
-		m_animation->changeGraph(m_titleOrange, 60);
+		m_animation->changeGraph(m_titleBlue, 60);
 	}
 	else if (m_cnt >= 2130 && !characterQueue.empty()) {
 		if (m_animation->getFinishFlag() && !characterQueue.empty()) {

--- a/Character.cpp
+++ b/Character.cpp
@@ -210,6 +210,7 @@ Character::Character(int hp, int x, int y, int groupId) {
 	m_hp = hp;
 	m_prevHp = m_hp;
 	m_dispHpCnt = 0;
+	m_invincible = false;
 	m_x = x;
 	m_y = y;
 
@@ -249,6 +250,7 @@ void Character::setParam(Character* character) {
 	character->setLeftDirection(m_leftDirection);
 	character->setHp(m_hp);
 	character->setPrevHp(m_prevHp);
+	character->setInvincible(m_invincible);
 	character->getCharacterGraphHandle()->setGraph(getGraphHandle());
 }
 
@@ -289,6 +291,11 @@ void Character::setLeftDirection(bool leftDirection) {
 
 // HPå∏è≠
 void Character::damageHp(int value) {
+
+	// ñ≥ìG
+	if (m_invincible) { return; }
+	
+	// ñ≥ìGÇ∂Ç·Ç»Ç¢Ç»ÇÁHPåªè€
 	m_hp = max(0, m_hp - value);
 	m_dispHpCnt = 60;
 }

--- a/Character.h
+++ b/Character.h
@@ -206,6 +206,9 @@ protected:
 	// HPバーを表示する残り時間
 	int m_dispHpCnt;
 
+	// 無敵ならtrue
+	bool m_invincible;
+
 	// X座標、Y座標
 	int m_x, m_y;
 
@@ -247,6 +250,7 @@ public:
 	inline int getHp() const { return m_hp; }
 	inline int getPrevHp() const { return m_prevHp; }
 	inline int getDispHpCnt() const { return m_dispHpCnt; }
+	inline bool getInvincible() const { return m_invincible; }
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline bool getLeftDirection() const { return m_leftDirection; }
@@ -262,6 +266,7 @@ public:
 		m_prevHp = (prevHp < m_hp) ? m_hp : prevHp;
 		if (m_prevHp == m_hp && m_dispHpCnt > 0) { m_dispHpCnt--; }
 	}
+	inline void setInvincible(bool invincible) { m_invincible = invincible; }
 	inline void setX(int x) { m_x = x; }
 	inline void setY(int y) { m_y = y; }
 	inline void setId(int id) { m_id = id; }

--- a/Control.cpp
+++ b/Control.cpp
@@ -99,6 +99,12 @@ int controlLeftShift()
 	return Key[KEY_INPUT_LSHIFT];
 }
 
+//右Shiftキー
+int controlRightShift()
+{
+	return Key[KEY_INPUT_RSHIFT];
+}
+
 //ゲーム終了用
 int controlEsc() {
 	if (Key[KEY_INPUT_ESCAPE] == 1) { //ESCキーが1カウント押されていたら

--- a/Control.h
+++ b/Control.h
@@ -37,6 +37,9 @@ int controlSpace();
 // 左Shiftキー
 int controlLeftShift();
 
+// 右Shiftキー
+int controlRightShift();
+
 //ESCキー：ゲーム終了
 int controlEsc();
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -110,6 +110,9 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	if (param0 == "LockArea") {
 		element = new LockAreaEvent(world, param);
 	}
+	else if (param0 == "InvincinbleEvent") {
+		element = new InvincinbleEvent(world, param);
+	}
 	else if (param0 == "ChangeBrain") {
 		element = new ChangeBrainEvent(world, param);
 	}
@@ -145,6 +148,8 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 }
 
 bool Event::fire() {
+
+	// 条件を"すべて"満たしたら発火
 	for (unsigned int i = 0; i < m_eventFire.size(); i++) {
 		if (!m_eventFire[i]->fire()) {
 			return false;
@@ -276,6 +281,26 @@ LockAreaEvent::LockAreaEvent(World* world, std::vector<std::string> param):
 EVENT_RESULT LockAreaEvent::play() {
 	m_world_p->setAreaLock(m_lock);
 	return EVENT_RESULT::SUCCESS;
+}
+
+// キャラを無敵にする
+InvincinbleEvent::InvincinbleEvent(World* world, vector<string> param) :
+	EventElement(world)
+{
+	m_invincible = param[1] == "1" ? true : false;
+	m_character_p = m_world_p->getCharacterWithName(param[2]);
+	m_param = param;
+}
+EVENT_RESULT InvincinbleEvent::play() {
+
+	// 対象のキャラを無敵にする
+	m_character_p->setInvincible(m_invincible);
+
+	return EVENT_RESULT::SUCCESS;
+}
+void InvincinbleEvent::setWorld(World* world) {
+	EventElement::setWorld(world);
+	m_character_p = m_world_p->getCharacterWithName(m_param[2]);
 }
 
 // キャラのBrainを変更する

--- a/Event.h
+++ b/Event.h
@@ -238,6 +238,33 @@ public:
 	EVENT_RESULT play();
 
 };
+// キャラを無敵にする
+class InvincinbleEvent :
+	public EventElement
+{
+private:
+
+	// パラメータ
+	std::vector<std::string> m_param;
+
+	// trueなら無敵にする
+	bool m_invincible;
+
+	// 対象のキャラ
+	Character* m_character_p;
+
+public:
+	InvincinbleEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
+	// 世界を設定しなおす
+	void setWorld(World* world);
+};
 // キャラのAIを変える
 class ChangeBrainEvent :
 	public EventElement

--- a/Game.cpp
+++ b/Game.cpp
@@ -35,6 +35,7 @@ CharacterData::CharacterData(const char* name) {
 	m_version = 1;
 	m_name = name;
 	m_hp = -1;
+	m_invincible = false;
 	// id=-1ÇÕÉfÅ[É^Ç»ÇµÇà”ñ°Ç∑ÇÈ
 	m_id = -1;
 	m_groupId = -1;
@@ -52,6 +53,7 @@ CharacterData::CharacterData(const char* name) {
 void CharacterData::save(FILE* intFp, FILE* strFp) {
 	fwrite(&m_version, sizeof(m_version), 1, intFp);
 	fwrite(&m_hp, sizeof(m_hp), 1, intFp);
+	fwrite(&m_invincible, sizeof(m_invincible), 1, intFp);
 	fwrite(&m_id, sizeof(m_id), 1, intFp);
 	fwrite(&m_groupId, sizeof(m_groupId), 1, intFp);
 	fwrite(&m_areaNum, sizeof(m_areaNum), 1, intFp);
@@ -71,6 +73,7 @@ void CharacterData::save(FILE* intFp, FILE* strFp) {
 void CharacterData::load(FILE* intFp, FILE* strFp) {
 	fread(&m_version, sizeof(m_version), 1, intFp);
 	fread(&m_hp, sizeof(m_hp), 1, intFp);
+	fread(&m_invincible, sizeof(m_invincible), 1, intFp);
 	fread(&m_id, sizeof(m_id), 1, intFp);
 	fread(&m_groupId, sizeof(m_groupId), 1, intFp);
 	fread(&m_areaNum, sizeof(m_areaNum), 1, intFp);

--- a/Game.h
+++ b/Game.h
@@ -24,6 +24,9 @@ private:
 	// HP
 	int m_hp;
 
+	// –³“G‚È‚çtrue
+	bool m_invincible;
+
 	// ID
 	int m_id;
 
@@ -65,6 +68,7 @@ public:
 	inline const char* name() const { return m_name.c_str(); }
 	inline const int version() const { return m_version; }
 	inline int hp() const { return m_hp; }
+	inline bool invincible() const { return m_invincible; }
 	inline int id() const { return m_id; }
 	inline int groupId() const { return m_groupId; }
 	inline int areaNum() const { return m_areaNum; }
@@ -80,6 +84,7 @@ public:
 	// ƒZƒbƒ^
 	inline void setVersion(int version) { m_version = version; }
 	inline void setHp(int hp) { m_hp = hp; }
+	inline void setInvincible(bool invincible) { m_invincible = invincible; }
 	inline void setId(int id) { m_id = id; }
 	inline void setGroupId(int groupId) { m_groupId = groupId; }
 	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }

--- a/World.cpp
+++ b/World.cpp
@@ -467,6 +467,7 @@ void World::asignCharacterData(const char* name, CharacterData* data, int fromAr
 			const Character* c = m_characterControllers[i]->getAction()->getCharacter();
 			data->setVersion(c->getVersion());
 			data->setHp(c->getHp());
+			data->setInvincible(c->getInvincible());
 			data->setId(c->getId());
 			data->setGroupId(c->getGroupId());
 			data->setAreaNum(fromAreaNum);
@@ -581,7 +582,7 @@ void World::asignedCharacter(Character* character, CharacterData* data, bool cha
 		// ‚±‚ÌƒQ[ƒ€‚Å‰“oê‚¶‚á‚È‚¢
 		character->setHp(data->hp());
 	}
-	//character->setId(data.id());
+	character->setInvincible(data->invincible());
 	character->setGroupId(data->groupId());
 	if (changePosition) {
 		character->setX(data->x());
@@ -685,8 +686,8 @@ void World::updateCamera() {
 	// ƒJƒƒ‰‚ÌŠg‘åEk¬
 	// ‘å‚«‚­•ÏX‚·‚é•K—v‚ª‚ ‚éê‡‚Ù‚ÇA‘å‚«‚­Šg‘å—¦‚ð•ÏX‚·‚éB
 	double nowEx = m_camera->getEx();
-	int leftShift = controlLeftShift();
-	if (leftShift > 0) {
+	int shift = controlLeftShift() + controlRightShift();
+	if (shift > 0) {
 		if (nowEx > m_cameraMinEx) {
 			m_camera->setEx(max(nowEx - 0.01, 0.1));
 		}


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
プレイヤーの敗北イベントで万が一でもプレイヤーが勝ってしまうと困るので、敵を無敵にする。

無敵の間はHPが減らないが、攻撃を当ててもHPバーが表示されないため、プレイヤーにはHPが減っていないことがばれない。

# やったこと
新しいメンバ変数Character::m_invicibleがtrueのときはHPが減らないようにした。

m_invicibleはセーブ対象のデータとする。

InvicibleEventを追加。m_invicibleのオンオフを切り替えるEventElement。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
