### PR TITLE
Api: キャラが移動するだけのイベントを追加

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -474,6 +474,28 @@ const char*  NormalAI::getTargetName() const {
 	return m_target_p == nullptr ? "" : m_target_p->getName().c_str();
 }
 
+// 目標地点へ移動するだけ 達成済みならtrueで何もしない
+bool NormalAI::moveGoalOrder(int& right, int& left, int& up, int& down, int& jump) {
+	// 現在地
+	int x = m_characterAction_p->getCharacter()->getCenterX();
+	int y = m_characterAction_p->getCharacter()->getY() + m_characterAction_p->getCharacter()->getHeight();
+	// 目標に到達しているか
+	if (m_gx > x - GX_ERROR && m_gx < x + GX_ERROR && m_gy > y - GY_ERROR && m_gy < y + GY_ERROR) {
+		return true;
+	}
+	// 到達していないので移動
+	stickOrder(right, left, up, down);
+	// 壁にぶつかったからジャンプ
+	int maxJump = m_characterAction_p->getPreJumpMax();
+	if (m_jumpCnt == 0) {
+		if (m_rightKey > 0 && m_characterAction_p->getRightLock()) { m_jumpCnt = maxJump; }
+		else if (m_leftKey > 0 && m_characterAction_p->getLeftLock()) { m_jumpCnt = maxJump; }
+	}
+	if (m_jumpCnt > 0) { m_jumpCnt--; }
+	jump = m_jumpCnt == 0 ? 0 : maxJump - m_jumpCnt;
+	return false;
+}
+
 
 /*
 * キャラについていくNormalAI
@@ -813,6 +835,18 @@ void FlightAI::moveOrder(int& right, int& left, int& up, int& down) {
 	stickOrder(right, left, up, down);
 }
 
+// 目標地点へ移動するだけ 達成済みならtrueで何もしない
+bool FlightAI::moveGoalOrder(int& right, int& left, int& up, int& down, int& jump) {
+	bool flag = NormalAI::moveGoalOrder(right, left, up, down, jump);
+	if (!flag) {
+		// 現在地
+		int x = m_characterAction_p->getCharacter()->getCenterX();
+		int y = m_characterAction_p->getCharacter()->getY() + m_characterAction_p->getCharacter()->getHeight();
+		moveUpDownOrder(x, y, m_try);
+	}
+	return false;
+}
+
 
 /*
 * 空を飛ぶAI
@@ -870,6 +904,18 @@ void FollowFlightAI::moveOrder(int& right, int& left, int& up, int& down) {
 		m_try = false;
 	}
 	stickOrder(right, left, up, down);
+}
+
+// 目標地点へ移動するだけ 達成済みならtrueで何もしない
+bool FollowFlightAI::moveGoalOrder(int& right, int& left, int& up, int& down, int& jump) {
+	bool flag = NormalAI::moveGoalOrder(right, left, up, down, jump);
+	if (!flag) {
+		// 現在地
+		int x = m_characterAction_p->getCharacter()->getCenterX();
+		int y = m_characterAction_p->getCharacter()->getY() + m_characterAction_p->getCharacter()->getHeight();
+		moveUpDownOrder(x, y, m_try);
+	}
+	return false;
 }
 
 

--- a/Brain.h
+++ b/Brain.h
@@ -31,6 +31,8 @@ public:
 	virtual bool actionOrder() { return false; }
 
 	// セッタ
+	virtual void setGx(int gx) { }
+	virtual void setGy(int gy) { }
 	virtual void setCharacterAction(const CharacterAction* characterAction) = 0;
 
 	// 遠距離攻撃の目標座標
@@ -77,6 +79,9 @@ public:
 
 	// 追跡対象の近くにいるか判定
 	virtual bool checkAlreadyFollow() { return true; }
+
+	// 目標地点へ移動するだけ 達成済みならtrueで何もしない
+	virtual bool moveGoalOrder(int& right, int& left, int& up, int& down, int& jump) { return true; }
 };
 
 
@@ -232,6 +237,9 @@ public:
 	int getTargetId() const;
 	const char* getTargetName() const;
 
+	// 目標地点へ移動するだけ 達成済みならtrueで何もしない
+	bool moveGoalOrder(int& right, int& left, int& up, int& down, int& jump);
+
 protected:
 	// スティック操作
 	void stickOrder(int& right, int& left, int& up, int& down);
@@ -366,6 +374,9 @@ public:
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
 
 	void moveOrder(int& right, int& left, int& up, int& down);
+
+	// 目標地点へ移動するだけ 達成済みならtrueで何もしない
+	bool moveGoalOrder(int& right, int& left, int& up, int& down, int& jump);
 };
 
 
@@ -387,6 +398,9 @@ public:
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
 
 	void moveOrder(int& right, int& left, int& up, int& down);
+
+	// 目標地点へ移動するだけ 達成済みならtrueで何もしない
+	bool moveGoalOrder(int& right, int& left, int& up, int& down, int& jump);
 };
 
 

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -212,6 +212,24 @@ void CharacterController::setPlayerDirection(Character* player_p) {
 	m_characterAction->setCharacterLeftDirection(player_p->getCenterX() < m_characterAction->getCharacter()->getCenterX());
 }
 
+// AIの目標地点を設定
+void CharacterController::setGoal(int gx, int gy) {
+	m_brain->setGx(gx);
+	m_brain->setGy(gy);
+}
+
+// 目標地点へ移動するだけ
+bool CharacterController::moveGoal() {
+	// 移動 stickなどの入力状態を更新する
+	int rightStick = 0, leftStick = 0, upStick = 0, downStick = 0, jump = 0;
+	bool alreadyGoal = m_brain->moveGoalOrder(rightStick, leftStick, upStick, downStick, jump);
+	// stickに応じて移動
+	m_characterAction->move(rightStick, leftStick, upStick, downStick);
+	// ジャンプ
+	m_characterAction->jump(jump);
+	return alreadyGoal;
+}
+
 
 /*
 * キャラコントロール マウスを使う可能性もあるのでCameraが必要

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -123,6 +123,12 @@ public:
 
 	// BrainがFreezeならプレイヤーの方向を向かせる
 	void setPlayerDirection(Character* player_p);
+
+	// AIの目標地点を設定
+	void setGoal(int gx, int gy);
+
+	// 目標地点へ移動するだけ
+	bool moveGoal();
 };
 
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -110,8 +110,14 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	if (param0 == "LockArea") {
 		element = new LockAreaEvent(world, param);
 	}
-	else if (param0 == "InvincinbleEvent") {
+	else if (param0 == "Invincinble") {
 		element = new InvincinbleEvent(world, param);
+	}
+	else if (param0 == "SetGoalPoint") {
+		element = new SetGoalPointEvent(world, param);
+	}
+	else if (param0 == "MoveGoal") {
+		element = new MoveGoalEvent(world, param);
 	}
 	else if (param0 == "ChangeBrain") {
 		element = new ChangeBrainEvent(world, param);
@@ -318,7 +324,7 @@ EVENT_RESULT ChangeBrainEvent::play() {
 	m_controller_p->setBrain(brain);
 
 	// 追跡対象が必要なBrainは追跡対象を設定
-	if (brain->getBrainName() == FollowNormalAI::BRAIN_NAME || 
+	if (brain->getBrainName() == FollowNormalAI::BRAIN_NAME ||
 		brain->getBrainName() == FollowParabolaAI::BRAIN_NAME ||
 		brain->getBrainName() == ValkiriaAI::BRAIN_NAME ||
 		brain->getBrainName() == FollowFlightAI::BRAIN_NAME) {
@@ -331,6 +337,40 @@ EVENT_RESULT ChangeBrainEvent::play() {
 void ChangeBrainEvent::setWorld(World* world) {
 	EventElement::setWorld(world);
 	m_controller_p = m_world_p->getControllerWithName(m_param[2]);
+}
+
+// キャラの目標地点を設定を変える
+SetGoalPointEvent::SetGoalPointEvent(World* world, vector<string> param) :
+	EventElement(world)
+{
+	m_gx = stoi(param[1]);
+	m_gy = stoi(param[2]);
+	m_controller_p = m_world_p->getControllerWithName(param[3]);
+	m_param = param;
+}
+EVENT_RESULT SetGoalPointEvent::play() {
+
+	// 対象のキャラの目標地点を設定
+	m_controller_p->setGoal(m_gx, m_gy);
+
+	return EVENT_RESULT::SUCCESS;
+}
+void SetGoalPointEvent::setWorld(World* world) {
+	EventElement::setWorld(world);
+	m_controller_p = m_world_p->getControllerWithName(m_param[3]);
+}
+
+// 全キャラが目標地点へ移動するまで待機
+MoveGoalEvent::MoveGoalEvent(World* world, std::vector<std::string> param) :
+	EventElement(world)
+{
+	int x = 1;
+}
+EVENT_RESULT MoveGoalEvent::play() {
+	if (m_world_p->moveGoalCharacter()) {
+		return EVENT_RESULT::SUCCESS;
+	}
+	return EVENT_RESULT::NOW;
 }
 
 // キャラのGroupIDを変更する

--- a/Event.h
+++ b/Event.h
@@ -265,6 +265,52 @@ public:
 	// 世界を設定しなおす
 	void setWorld(World* world);
 };
+// キャラの目標地点を設定を変える
+class SetGoalPointEvent :
+	public EventElement
+{
+private:
+
+	// パラメータ
+	std::vector<std::string> m_param;
+
+	// 目標地点
+	int m_gx, m_gy;
+
+	// 対象のキャラ
+	CharacterController* m_controller_p;
+
+public:
+	SetGoalPointEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
+	// 世界を設定しなおす
+	void setWorld(World* world);
+};
+// 全キャラが目標地点へ移動するまで待機
+class MoveGoalEvent :
+	public EventElement
+{
+private:
+
+	// パラメータ
+	std::vector<std::string> m_param;
+
+public:
+	MoveGoalEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
+};
 // キャラのAIを変える
 class ChangeBrainEvent :
 	public EventElement

--- a/World.h
+++ b/World.h
@@ -212,6 +212,9 @@ public:
 	// キャラに戦わせる
 	void battle();
 
+	// 各キャラが目標地点へ移動するだけ
+	bool moveGoalCharacter();
+
 	// キャラに会話させる
 	void talk();
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
市販のゲームでもよくある、プレイヤーの操作が効かなくなり、キャラが動いて勝手にシナリオが進む機能を追加。

例えば、遠くにいるキャラがプレイヤーに話しかけるイベントで、テキストイベントの前にプレイヤーの前まで移動してくるシーンを挟んで自然にできる。

# やったこと
Brainに目標地点へ移動するだけのメンバ関数を追加、それを呼び出す関数をControllerのメンバに追加。

Worldに全キャラが目標地点へ移動するまで移動のみをさせるメンバ関数を追加。

以下の2つのイベントを追加。

```
SetPointEvent
特定のキャラの目標地点を設定
gx, gy, キャラ名

MoveGoalEvent
全キャラが目標地点へ移動完了するまで待機
なし
```

MoveGoalEventは上記のWorldのメンバ関数を呼びつづけ、全員が目標地点まで到達したら完了。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
