### PR TITLE
StageObjectの追加

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -548,11 +548,14 @@ void OpMovie::play() {
 	}
 	else if (m_cnt < 3050 && m_cnt >= 2780) {
 		if (m_cnt == 2780) {
-			m_heart->setEx(m_ex + 10.0);
+			m_heart->setEx(m_ex * 10.0);
 			m_animation->changeGraph(m_heart);
 		}
 		if (m_heart->getGraphHandle()->getEx() > m_ex) {
-			m_heart->setEx(m_heart->getGraphHandle()->getEx() - 1.0);
+			m_heart->setEx(m_heart->getGraphHandle()->getEx() * 2 / 3);
+		}
+		if (m_heart->getGraphHandle()->getEx() < m_ex) {
+			m_heart->setEx(m_ex);
 		}
 		if (m_cnt < 2870) {
 			m_animation->setX(m_animation->getX() + GetRand(2) - 1);
@@ -653,7 +656,7 @@ void OpMovie::play() {
 
 
 	// èIóπ
-	if (m_cnt == 5000) {
+	if (m_cnt == 4800) {
 		m_finishFlag = true;
 	}
 }

--- a/Object.cpp
+++ b/Object.cpp
@@ -815,6 +815,8 @@ DoorObject::DoorObject(int x1, int y1, int x2, int y2, const char* fileName, int
 	m_handle = new GraphHandle(filePath.c_str(), 1.0, 0.0, true);
 	m_areaNum = areaNum;
 	m_text = "";
+	m_defaultText = "Ｗキーで入る";
+	m_textNum = -1;
 }
 
 DoorObject::~DoorObject() {
@@ -834,11 +836,23 @@ bool DoorObject::atari(CharacterController* characterController) {
 
 	// 当たり判定
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2) {
-		m_text = "Ｗキーで入る";
+		m_text = m_defaultText;
 		return true;
 	}
 	m_text = "";
 	return false;
+}
+
+StageObject::StageObject(int x1, int y1, int x2, int y2, const char* fileName, int textNum) :
+	DoorObject(x1, y1, x2, y2, fileName, -1)
+{
+	m_textNum = textNum;
+	m_defaultText = "Ｗキーで調べる";
+}
+
+StageObject::~StageObject() {
+	// DoorObjectでdeleteされるので不要
+	//delete m_handle;
 }
 
 
@@ -899,6 +913,12 @@ void SlashObject::setSlashParam(SlashObject* object) {
 }
 Object* DoorObject::createCopy() {
 	DoorObject* res = new DoorObject(m_x1, m_y1, m_x2, m_y2, m_fileName.c_str(), m_areaNum);
+	setParam(res);
+	res->setText(m_text.c_str());
+	return res;
+}
+Object* StageObject::createCopy() {
+	StageObject* res = new StageObject(m_x1, m_y1, m_x2, m_y2, m_fileName.c_str(), m_textNum);
 	setParam(res);
 	res->setText(m_text.c_str());
 	return res;

--- a/Object.h
+++ b/Object.h
@@ -91,6 +91,7 @@ public:
 
 	// 扉用
 	virtual inline int getAreaNum() const { return -1; }
+	virtual inline int getTextNum() const { return -1; }
 
 	// 画像を返す　ないならnullptr
 	virtual GraphHandle* getHandle() const { return m_handle; }
@@ -417,7 +418,7 @@ public:
 class DoorObject :
 	public Object 
 {
-private:
+protected:
 	// ファイルネームを保存しておく
 	std::string m_fileName;
 
@@ -426,6 +427,10 @@ private:
 
 	// チュートリアルのテキスト
 	std::string m_text;
+
+	std::string m_defaultText;
+
+	int m_textNum;
 
 public:
 	DoorObject(int x1, int y1, int x2, int y2, const char* fileName, int areaNum);
@@ -439,12 +444,27 @@ public:
 	inline int getAreaNum() const { return m_areaNum; }
 	inline std::string getText() const { return m_text; }
 	const char* getFileName() const { return m_fileName.c_str(); }
+	inline int getTextNum() const { return m_textNum; }
 
 	// セッタ
 	inline void setText(const char* text) { m_text = text; }
 
 	// キャラとの当たり判定
 	virtual bool atari(CharacterController* characterController);
+};
+
+
+// 当たり判定のないオブジェクト
+class StageObject :
+	public DoorObject
+{
+public:
+
+	StageObject(int x1, int y1, int x2, int y2, const char* fileName, int textNum);
+	~StageObject();
+
+	Object* createCopy();
+
 };
 
 #endif

--- a/ObjectLoader.cpp
+++ b/ObjectLoader.cpp
@@ -63,6 +63,9 @@ pair<vector<Object*>, vector<Object*> > ObjectLoader::getObjects(int areaNum) {
 		if (name == "Door") {
 			res.second.push_back(new DoorObject(x1, y1, x2, y2, graph.c_str(), stoi(other)));
 		}
+		else if (name == "Stage") {
+			res.second.push_back(new StageObject(x1, y1, x2, y2, graph.c_str(), stoi(other)));
+		}
 	}
 	
 	return res;

--- a/World.h
+++ b/World.h
@@ -40,6 +40,8 @@ private:
 	// 会話イベント EventElementクラスからもらう
 	Conversation* m_conversation_p;
 
+	Conversation* m_objectConversation;
+
 	// ムービー EventElementクラスからもらう
 	Movie* m_movie_p;
 
@@ -136,6 +138,7 @@ public:
 	inline const int getBackGroundGraph() const { return m_backGroundGraph; }
 	inline const int getBackGroundColor() const { return m_backGroundColor; }
 	inline const Conversation* getConversation() const { return m_conversation_p; }
+	inline const Conversation* getObjectConversation() const { return m_objectConversation; }
 	inline Movie* getMovie() const { return m_movie_p; }
 	inline SoundPlayer* getSoundPlayer() const { return m_soundPlayer_p; }
 	inline double getCameraMaxEx() const { return m_cameraMaxEx; }

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -175,6 +175,14 @@ void WorldDrawer::draw() {
 		m_conversationDrawer->setConversation(conversation);
 		m_conversationDrawer->draw();
 	}
+	else {
+		// StageObjectを調べた際のテキストイベント
+		conversation = m_world->getObjectConversation();
+		if (conversation != nullptr) {
+			m_conversationDrawer->setConversation(conversation);
+			m_conversationDrawer->draw();
+		}
+	}
 
 	if (movie == nullptr && conversation == nullptr) {
 		// ターゲット


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
自販機や建物など、当たり判定のないオブジェクトを配置できるようにする。

また、それらのオブジェクトはWキーで調べることができ、テキストイベントを見れる。

# やったこと
StageObjectクラスを追加。DoorObjectと一緒に管理するが、セーブデータには含まないようにする。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
