### PR TITLE
Api: ゲームオーバーの表示追加と敗北イベント＆カメラの自動調整機能の改善

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -230,6 +230,15 @@ GameData::~GameData() {
 	}
 }
 
+CharacterData* GameData::getCharacterData(string characterName) {
+	for (unsigned int i = 0; i < m_characterData.size(); i++) {
+		if (m_characterData[i]->name()) {
+			return m_characterData[i];
+		}
+	}
+	return nullptr;
+}
+
 // セーブ
 bool GameData::save() {
 
@@ -586,7 +595,8 @@ void Game::backPrevSave() {
 	// 以前のAreaNumでロード
 	m_world = new World(-1, prevData.getAreaNum(), m_soundPlayer);
 	m_gameData->asignWorld(m_world, true);
-	m_world->setPlayerOnDoor(m_gameData->getAreaNum());
+	m_world->setPlayerPoint(prevData.getCharacterData("ハート"));
+	m_world->setPlayerFollowerPoint();
 	m_story->setWorld(m_world);
 }
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -433,6 +433,8 @@ Game::Game(const char* saveFilePath, int storyNum) {
 		// チャプターのバックアップ
 		m_gameData->saveChapter();
 	}
+
+	m_gameoverCnt = 0;
 }
 
 Game::~Game() {
@@ -450,6 +452,15 @@ Game::~Game() {
 }
 
 bool Game::play() {
+
+	// ゲームオーバー
+	if (m_gameoverCnt > 0) {
+		m_gameoverCnt++;
+		if (m_gameoverCnt == 120) {
+			m_rebootFlag = true;
+		}
+		return false;
+	}
 
 	// 一時停止
 	if (controlQ() == 1) {
@@ -545,7 +556,7 @@ bool Game::play() {
 	else if (m_world->playerDead() && m_world->getBrightValue() == 0) {
 		// storyからハートがやられたことを伝えられたらタイトルへ戻る
 		// やられるのがイベントの成功条件なら前のif文(m_story->getBackPrevSaveFlag())にひっかかるはず
-		m_rebootFlag = true;
+		m_gameoverCnt++;
 	}
 
 	// エリア移動

--- a/Game.h
+++ b/Game.h
@@ -190,6 +190,7 @@ public:
 	inline int getFrom(int i) const { return m_doorData[i]->from(); }
 	inline int getTo(int i) const { return m_doorData[i]->to(); }
 	inline int getLatestStoryNum() const { return m_latestStoryNum; }
+	CharacterData* getCharacterData(std::string characterName);
 
 	// ƒZƒbƒ^
 	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }

--- a/Game.h
+++ b/Game.h
@@ -281,6 +281,9 @@ private:
 	// 世界
 	World* m_world;
 
+	// ゲームオーバーの表示
+	int m_gameoverCnt;
+
 	// ストーリー
 	Story* m_story;
 
@@ -305,6 +308,7 @@ public:
 	HeartSkill* getSkill() const { return m_skill; }
 	BattleOption* getGamePause() const { return m_battleOption; }
 	bool getRebootFlag() const { return m_rebootFlag; }
+	inline int getGameoverCnt() const { return m_gameoverCnt; }
 
 	// デバッグ
 	void debug(int x, int y, int color) const;

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -20,14 +20,27 @@ GameDrawer::GameDrawer(const Game* game) {
 	m_worldDrawer = new WorldDrawer(nullptr);
 
 	m_skillHandle = CreateFontToHandle(nullptr, (int)(SKILL_SIZE * m_exX), 10);
+
+	m_gameoverHandle = LoadGraph("picture/system/gameover.png");
 }
 
 GameDrawer::~GameDrawer() {
 	delete m_worldDrawer;
 	DeleteFontToHandle(m_skillHandle);
+	DeleteGraph(m_gameoverHandle);
 }
 
 void GameDrawer::draw() {
+
+	// ƒQ[ƒ€ƒI[ƒo[
+	int gameoverCnt = m_game->getGameoverCnt();
+	if (gameoverCnt > 0) {
+		if ((gameoverCnt < 60 && gameoverCnt / 2 % 2 == 0) || gameoverCnt > 60) {
+			DrawRotaGraph(GAME_WIDE / 2, GAME_HEIGHT / 2, min(m_exX, m_exY) * 0.7, 0.0, m_gameoverHandle, TRUE);
+		}
+
+		return;
+	}
 
 	// ¢ŠE‚ð•`‰æ
 	const HeartSkill* skill = m_game->getSkill();

--- a/GameDrawer.h
+++ b/GameDrawer.h
@@ -18,6 +18,9 @@ private:
 	const int SKILL_SIZE = 100;
 	int m_skillHandle;
 
+	// ゲームオーバーの画像
+	int m_gameoverHandle;
+
 public:
 	GameDrawer(const Game* game);
 

--- a/Object.cpp
+++ b/Object.cpp
@@ -847,7 +847,12 @@ StageObject::StageObject(int x1, int y1, int x2, int y2, const char* fileName, i
 	DoorObject(x1, y1, x2, y2, fileName, -1)
 {
 	m_textNum = textNum;
-	m_defaultText = "Ｗキーで調べる";
+	if (textNum == -1) {
+		m_defaultText = "";
+	}
+	else {
+		m_defaultText = "Ｗキーで調べる";
+	}
 }
 
 StageObject::~StageObject() {

--- a/World.cpp
+++ b/World.cpp
@@ -264,7 +264,6 @@ vector<const CharacterAction*> World::getActions() const {
 vector<const Object*> World::getFrontObjects() const {
 
 	vector<const Object*> allObjects;
-	allObjects.insert(allObjects.end(), m_stageObjects.begin(), m_stageObjects.end());
 	allObjects.insert(allObjects.end(), m_attackObjects.begin(), m_attackObjects.end());
 
 	return allObjects;
@@ -274,6 +273,7 @@ vector<const Object*> World::getFrontObjects() const {
 vector<const Object*> World::getBackObjects() const {
 
 	vector<const Object*> allObjects;
+	allObjects.insert(allObjects.end(), m_stageObjects.begin(), m_stageObjects.end());
 	allObjects.insert(allObjects.end(), m_doorObjects.begin(), m_doorObjects.end());
 
 	return allObjects;
@@ -557,6 +557,23 @@ void World::setPlayerOnDoor(int from) {
 	m_player_p->setX(doorX1);
 	m_player_p->setY(doorY2 - m_player_p->getHeight());
 
+	// 仲間も移動
+	setPlayerFollowerPoint();
+
+	// カメラリセット
+	cameraPointInit();
+}
+
+// プレイヤーを特定の座標へ移動
+void World::setPlayerPoint(CharacterData* characterData) {
+	m_player_p->setX(characterData->x());
+	m_player_p->setY(characterData->y() - m_player_p->getHeight());
+	// カメラリセット
+	cameraPointInit();
+}
+
+// 仲間をプレイヤーの位置へ移動
+void World::setPlayerFollowerPoint() {
 	// プレイヤーの仲間
 	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
 		const Character* follow = m_characterControllers[i]->getBrain()->getFollow();
@@ -565,14 +582,13 @@ void World::setPlayerOnDoor(int from) {
 			// Controllerに対応するCharacterに変更を加える
 			for (unsigned int j = 0; j < m_characters.size(); j++) {
 				if (m_characterControllers[i]->getAction()->getCharacter()->getId() == m_characters[j]->getId()) {
-					m_characters[j]->setX(doorX1);
-					m_characters[j]->setY(doorY2 - m_characters[j]->getHeight());
+					m_characters[j]->setX(m_player_p->getX());
+					m_characters[j]->setY(m_player_p->getY() + m_player_p->getHeight() - m_characters[j]->getHeight());
 					break;
 				}
 			}
 		}
 	}
-	cameraPointInit();
 }
 
 // データ管理：カメラの位置をリセット

--- a/World.cpp
+++ b/World.cpp
@@ -709,7 +709,9 @@ void World::updateCamera() {
 		}
 		// フォーカスしているキャラ以外なら距離を調べる
 		else if (m_characters[i]->getHp() > 0) {
-			int dx = abs(m_camera->getX() - m_characters[i]->getX()) + m_characters[i]->getWide();
+			int x = m_characters[i]->getX();
+			if (m_camera->getX() < x) { x += m_characters[i]->getWide(); }
+			int dx = abs(m_camera->getX() - x);
 			if (dx < MAX_DISABLE) {
 				max_dx = max(max_dx, dx);
 				max_dy = max(max_dy, abs(m_camera->getY() - m_characters[i]->getY()) + m_characters[i]->getHeight());
@@ -732,8 +734,8 @@ void World::updateCamera() {
 	else {
 		int nowWide = (int)(GAME_WIDE / 2 / nowEx);
 		int nowHeight = (int)(GAME_HEIGHT / 2 / nowEx);
-		max_dx = (int)(max_dx * nowEx / m_exX);
-		max_dy = (int)(max_dy * nowEx / m_exY);
+		max_dx = (int)(max_dx / m_exX);
+		max_dy = (int)(max_dy / m_exY);
 		if (nowEx > m_cameraMinEx && (max_dx > nowWide || max_dy > nowHeight)) {
 			// 縮小
 			double d = double(max(max_dx - nowWide, max_dy - nowHeight));
@@ -742,7 +744,7 @@ void World::updateCamera() {
 		else if (nowEx < m_cameraMaxEx && (max_dx < nowWide && max_dy < nowHeight)) {
 			// 拡大
 			double d = double(max(nowWide - max_dx, nowHeight - max_dy));
-			m_camera->setEx(nowEx + min(0.08, d / 100000));
+			m_camera->setEx(nowEx + min(0.001, d / 100000));
 		}
 	}
 }

--- a/World.h
+++ b/World.h
@@ -214,8 +214,14 @@ public:
 	// データ管理：Doorの状態を教える
 	void asignDoorData(std::vector<DoorData*>& data, int fromAreaNum) const;
 
-	// データ管理：プレイヤーとその仲間をドアの前に移動
+	// データ管理：プレイヤーをドアの前まで移動
 	void setPlayerOnDoor(int from);
+
+	// プレイヤーを特定の座標へ移動
+	void setPlayerPoint(CharacterData* characterData);
+
+	// 仲間をプレイヤーの位置へ移動
+	void setPlayerFollowerPoint();
 
 	// キャラに戦わせる
 	void battle();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
敗北イベント以外でプレイヤーがやられた際、タイトルに戻る前にゲームオーバーの表示をする。

敗北イベント後、プレイヤーの位置がセーブ位置になるよう修正。

カメラの自動拡大・縮小機能を改善する。 #137

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
