### PR TITLE
Api: キャラの方向が不自然になるケースの対処

### DIFF
--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -207,8 +207,8 @@ void CharacterController::action() {
 }
 
 // Brain‚ªFreeze‚È‚çƒvƒŒƒCƒ„[‚Ì•ûŒü‚ğŒü‚©‚¹‚é
-void CharacterController::setPlayerDirection(Character* player_p) {
-	if (m_brain->getBrainName() != "Freeze") { return; }
+void CharacterController::setPlayerDirection(Character* player_p, bool all) {
+	if (m_brain->getBrainName() != "Freeze" && !all) { return; }
 	m_characterAction->setCharacterLeftDirection(player_p->getCenterX() < m_characterAction->getCharacter()->getCenterX());
 }
 

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -121,8 +121,8 @@ public:
 	// ダメージ
 	virtual void damage(int vx, int vy, int damageValue) = 0;
 
-	// BrainがFreezeならプレイヤーの方向を向かせる
-	void setPlayerDirection(Character* player_p);
+	// BrainがFreezeならプレイヤーの方向を向かせる allがtrueなら全キャラが対象
+	void setPlayerDirection(Character* player_p, bool all = false);
 
 	// AIの目標地点を設定
 	void setGoal(int gx, int gy);

--- a/Define.h
+++ b/Define.h
@@ -4,7 +4,7 @@
 #include"DxLib.h"
 
 // フルスクリーンならFALSE
-static int WINDOW = TRUE;
+static int WINDOW = FALSE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = TRUE;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -25,7 +25,7 @@ const int FINISH_STORY = 9;
 // エリア0でデバッグするときはtrueにする
 const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
-const int SKILL_USEABLE_STORY = 1;
+const int SKILL_USEABLE_STORY = 10;
 
 
 /*

--- a/World.cpp
+++ b/World.cpp
@@ -135,6 +135,10 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) :
 			break;
 		}
 	}
+	// ƒvƒŒƒCƒ„[‚Ì•ûŒü‚ÖŒü‚©‚¹‚é
+	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
+		m_characterControllers[i]->setPlayerDirection(m_player_p, true);
+	}
 
 	m_camera->setEx(m_cameraMaxEx);
 
@@ -451,7 +455,9 @@ void World::asignedCharacterData(const char* name, CharacterData* data) {
 		Character* character = createCharacter(name);
 		asignedCharacter(character, data, true);
 		m_characters.push_back(character);
-		m_characterControllers.push_back(createControllerWithData(character, data));
+		CharacterController* controller = createControllerWithData(character, data);
+		controller->setPlayerDirection(m_player_p, true);
+		m_characterControllers.push_back(controller);
 		return;
 	}
 
@@ -461,6 +467,7 @@ void World::asignedCharacterData(const char* name, CharacterData* data) {
 		const Character* character = m_characterControllers[i]->getAction()->getCharacter();
 		if (name == character->getName()) {
 			CharacterController* controller = createControllerWithData(character, data);
+			controller->setPlayerDirection(m_player_p, true);
 			delete m_characterControllers[i];
 			m_characterControllers[i] = controller;
 		}


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#141 の解決。

例えば敗北イベントによってエリア移動が発生し、移動直後にテキストイベントが始まると、Freezeのキャラが主人公の方向を向いていない状態になっている。

# やったこと
World::m_characterControllersへpush_backする際に主人公のいる方向を向かせる。ただし複製の世界の場合はしなくていい（たぶん）。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
記入欄

# 懸念点
記入欄
