### PR TITLE
Api: キャラの目の瞬き機能追加

### DIFF
--- a/Define.h
+++ b/Define.h
@@ -4,7 +4,7 @@
 #include"DxLib.h"
 
 // フルスクリーンならFALSE
-static int WINDOW = FALSE;
+static int WINDOW = TRUE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = TRUE;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -175,7 +175,7 @@ GameData::GameData() {
 	}
 
 	// 主要キャラを設定
-	const int mainSum = 9;
+	const int mainSum = 13;
 	const char* mainCharacters[mainSum] = {
 		"ハート",
 		"シエスタ",
@@ -185,7 +185,11 @@ GameData::GameData() {
 		"メモリー",
 		"ユーリ",
 		"エム・サディ",
-		"フレンチ"
+		"フレンチ",
+		"アーカイブ",
+		"アイギス",
+		"コハル",
+		"マスカーラ"
 	};
 	for (int i = 0; i < mainSum; i++) {
 		m_characterData.push_back(new CharacterData(mainCharacters[i]));

--- a/Game.cpp
+++ b/Game.cpp
@@ -413,6 +413,7 @@ Game::Game(const char* saveFilePath, int storyNum) {
 
 	// 世界
 	m_world = new World(-1, m_gameData->getAreaNum(), m_soundPlayer);
+	m_soundPlayer->stopBGM();
 
 	// ストーリー
 	m_story = new Story(m_gameData->getStoryNum(), m_world, m_soundPlayer);

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -147,6 +147,35 @@ void GraphHandles::draw(int x, int y, int index) {
 
 
 /*
+* キャラクターの目の瞬きの処理をするクラス
+*/
+CharacterEyeClose::CharacterEyeClose() {
+	m_cnt = 0;
+}
+
+// 瞬きスタートでtrue
+bool CharacterEyeClose::closeFlag() {
+	count();
+	// 眼を閉じている
+	if (closeNow()) {
+		return true;
+	}
+	// 眼を閉じ始める
+	if (GetRand(100) < 1) {
+		m_cnt = EYE_CLOSE_MIN_TIME + GetRand(EYE_CLOSE_MAX_TIME - EYE_CLOSE_MIN_TIME);
+		return true;
+	}
+	// 眼を開けている
+	return false;
+}
+
+// 眼を閉じる時間をカウント
+void CharacterEyeClose::count() {
+	m_cnt = m_cnt > 0 ? m_cnt - 1 : 0;
+}
+
+
+/*
 * キャラの画像
 */
 // 画像ロード用
@@ -196,28 +225,30 @@ CharacterGraphHandle::CharacterGraphHandle(const char* characterName, double dra
 	loadCharacterGraph(dir, characterName, m_boostHandles, "boost", data, m_ex);
 	loadCharacterGraph(dir, characterName, m_airBulletHandles, "airBullet", data, m_ex);
 	loadCharacterGraph(dir, characterName, m_airSlashHandles, "airSlash", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_closeHandles, "close", data, m_ex);
 
 	switchStand();
 }
 // 画像を削除
 CharacterGraphHandle::~CharacterGraphHandle() {
 	if (m_standHandles != nullptr) { delete m_standHandles; }
-	if (m_standHandles != nullptr) { delete m_slashHandles; }
-	if (m_standHandles != nullptr) { delete m_bulletHandles; }
-	if (m_standHandles != nullptr) { delete m_squatHandles; }
-	if (m_standHandles != nullptr) { delete m_squatBulletHandles; }
-	if (m_standHandles != nullptr) { delete m_standBulletHandles; }
-	if (m_standHandles != nullptr) { delete m_standSlashHandles; }
-	if (m_standHandles != nullptr) { delete m_runHandles; }
-	if (m_standHandles != nullptr) { delete m_runBulletHandles; }
-	if (m_standHandles != nullptr) { delete m_landHandles; }
-	if (m_standHandles != nullptr) { delete m_jumpHandles; }
-	if (m_standHandles != nullptr) { delete m_downHandles; }
-	if (m_standHandles != nullptr) { delete m_preJumpHandles; }
-	if (m_standHandles != nullptr) { delete m_damageHandles; }
-	if (m_standHandles != nullptr) { delete m_boostHandles; }
-	if (m_standHandles != nullptr) { delete m_airBulletHandles; }
-	if (m_standHandles != nullptr) { delete m_airSlashHandles; }
+	if (m_slashHandles != nullptr) { delete m_slashHandles; }
+	if (m_bulletHandles != nullptr) { delete m_bulletHandles; }
+	if (m_squatHandles != nullptr) { delete m_squatHandles; }
+	if (m_squatBulletHandles != nullptr) { delete m_squatBulletHandles; }
+	if (m_standBulletHandles != nullptr) { delete m_standBulletHandles; }
+	if (m_standSlashHandles != nullptr) { delete m_standSlashHandles; }
+	if (m_runHandles != nullptr) { delete m_runHandles; }
+	if (m_runBulletHandles != nullptr) { delete m_runBulletHandles; }
+	if (m_landHandles != nullptr) { delete m_landHandles; }
+	if (m_jumpHandles != nullptr) { delete m_jumpHandles; }
+	if (m_downHandles != nullptr) { delete m_downHandles; }
+	if (m_preJumpHandles != nullptr) { delete m_preJumpHandles; }
+	if (m_damageHandles != nullptr) { delete m_damageHandles; }
+	if (m_boostHandles != nullptr) { delete m_boostHandles; }
+	if (m_airBulletHandles != nullptr) { delete m_airBulletHandles; }
+	if (m_airSlashHandles != nullptr) { delete m_airSlashHandles; }
+	if (m_closeHandles != nullptr) { delete m_closeHandles; }
 }
 
 // 画像のサイズをセット
@@ -242,7 +273,12 @@ void CharacterGraphHandle::setGraph(GraphHandle* graphHandle) {
 
 // 立ち画像をセット
 void CharacterGraphHandle::switchStand(int index){
-	setGraph(m_standHandles, index);
+	if (m_closeHandles != nullptr && m_characterEyeClose.closeFlag()) {
+		setGraph(m_closeHandles, index);
+	}
+	else {
+		setGraph(m_standHandles, index);
+	}
 }
 // 立ち射撃画像をセット
 void CharacterGraphHandle::switchBullet(int index){
@@ -304,6 +340,10 @@ void CharacterGraphHandle::switchAirBullet(int index){
 // 空中斬撃画像をセット
 void CharacterGraphHandle::switchAirSlash(int index){
 	setGraph(m_airSlashHandles, index);
+}
+// 瞬き画像をセット
+void CharacterGraphHandle::switchClose(int index) {
+	setGraph(m_closeHandles, index);
 }
 
 

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -85,6 +85,37 @@ public:
 
 
 /*
+* キャラの眼の瞬きを処理するクラス
+*/
+class CharacterEyeClose {
+private:
+
+	// 眼を閉じる時間
+	static const int EYE_CLOSE_MIN_TIME = 5;
+	static const int EYE_CLOSE_MAX_TIME = 10;
+	
+	// 眼を閉じる残り時間
+	int m_cnt;
+
+public:
+
+	CharacterEyeClose();
+
+	// 瞬きスタートでtrue
+	bool closeFlag();
+
+private:
+
+	// 眼を閉じる時間をカウント
+	void count();
+
+	// 瞬き中ならtrue
+	inline bool closeNow() { return m_cnt > 0; }
+
+};
+
+
+/*
 * キャラの画像を管理するクラス
 */
 class CharacterGraphHandle {
@@ -95,6 +126,9 @@ private:
 	double m_ex;
 
 	int m_wide, m_height;
+
+	// 瞬き
+	CharacterEyeClose m_characterEyeClose;
 
 	// キャラのパーツの画像
 	// 斬撃攻撃画像
@@ -148,6 +182,10 @@ private:
 
 	// 空中斬撃画像
 	GraphHandles* m_airSlashHandles;
+
+	// 瞬き画像
+	GraphHandles* m_closeHandles;
+
 public:
 	// デフォルト値で初期化
 	CharacterGraphHandle();
@@ -179,6 +217,7 @@ public:
 	inline GraphHandles* getBoostHandle() { return m_boostHandles; }
 	inline GraphHandles* getAirBulletHandle() { return m_airBulletHandles; }
 	inline GraphHandles* getAirSlashHandle() { return m_airSlashHandles; }
+	inline GraphHandles* getCloseHandle() { return m_closeHandles; }
 
 	// 画像サイズをセット
 	void setGraphSize();
@@ -217,6 +256,8 @@ public:
 	void switchAirBullet(int index = 0);
 	// 空中斬撃画像をセット
 	void switchAirSlash(int index = 0);
+	// 瞬き画像をセット
+	void switchClose(int index = 0);
 };
 
 

--- a/World.cpp
+++ b/World.cpp
@@ -710,7 +710,7 @@ void World::updateCamera() {
 	// キャラとカメラの距離の最大値を調べる
 	int max_dx = 0, max_dy = 0;
 	// 画面内に入れようとする距離の最大　これより離れたキャラは無視
-	const int MAX_DISABLE = 3000;
+	const int MAX_DISABLE = 2000;
 	size_t size = m_characters.size();
 	for (unsigned int i = 0; i < size; i++) {
 		// 今フォーカスしているキャラの座標に合わせる


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
キャラが瞬きしないのは無機質に感じるので、何もせず立っているときだけでも瞬きをしてもらうよう機能追加。

# やったこと
CharacterGraphHandleクラスで目を閉じる時間等を管理する。なぜなら、CharacterActionにその責務を渡すと、派生クラス等修正が必要な個所が多くなるためである。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
