### PR TITLE
Api: Emote Onlineのバージョンアップ機能追加

### DIFF
--- a/Event.cpp
+++ b/Event.cpp
@@ -403,7 +403,7 @@ ChangeInfoVersionEvent::ChangeInfoVersionEvent(World* world, std::vector<string>
 	m_character_p = m_world_p->getCharacterWithName(param[2]);
 }
 EVENT_RESULT ChangeInfoVersionEvent::play() {
-	// 対象のキャラのGroupIdを変更する
+	// 対象のキャラのversionを変更する
 	m_character_p->changeInfoVersion(m_version);
 	return EVENT_RESULT::SUCCESS;
 }

--- a/Game.cpp
+++ b/Game.cpp
@@ -421,6 +421,8 @@ Game::Game(const char* saveFilePath, int storyNum) {
 
 	// ストーリー
 	m_story = new Story(m_gameData->getStoryNum(), m_world, m_soundPlayer);
+	m_world->changeCharacterVersion(m_story->getVersion());
+	m_world->setDate(m_story->getDate());
 
 	// セーブデータに上書き
 	m_gameData->updateStory(m_story);

--- a/Game.cpp
+++ b/Game.cpp
@@ -421,7 +421,6 @@ Game::Game(const char* saveFilePath, int storyNum) {
 
 	// ストーリー
 	m_story = new Story(m_gameData->getStoryNum(), m_world, m_soundPlayer);
-	m_world->setDate(m_story->getDate());
 
 	// セーブデータに上書き
 	m_gameData->updateStory(m_story);

--- a/Story.cpp
+++ b/Story.cpp
@@ -22,8 +22,6 @@ Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer) {
 	ostringstream oss;
 	oss << "data/story/story" << storyNum << ".csv";
 	loadCsvData(oss.str().c_str(), world, soundPlayer);
-	m_world_p->changeCharacterVersion(m_version);
-	m_world_p->setDate(m_date);
 
 	// イベントの発火確認
 	checkFire();

--- a/Story.cpp
+++ b/Story.cpp
@@ -15,39 +15,15 @@ Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer) {
 	m_nowEvent = nullptr;
 	m_storyNum = storyNum;
 
+	m_characterLoader = new CharacterLoader;
+	m_objectLoader = new ObjectLoader;
+
+	// story○○.csvをロード
 	ostringstream oss;
 	oss << "data/story/story" << storyNum << ".csv";
-	CsvReader2 csvReader2(oss.str().c_str());
-
-	// イベント生成
-	vector<map<string, string> > eventData = csvReader2.getDomainData("EVENT:");
-	for (unsigned int i = 0; i < eventData.size(); i++) {
-		int eventNum = stoi(eventData[i]["num"]);
-		bool mustFlag = (bool)stoi(eventData[i]["mustFlag"]);
-		Event* eventOne = new Event(eventNum, world, soundPlayer);
-		if (mustFlag) { m_mustEvent.push_back(eventOne); }
-		else { m_subEvent.push_back(eventOne); }
-	}
-
-	// キャラクターを用意
-	vector<map<string, string> > characterData = csvReader2.getDomainData("CHARACTER:");
-	m_characterLoader = new CharacterLoader;
-	for (unsigned int i = 0; i < characterData.size(); i++) {
-		m_characterLoader->addCharacter(characterData[i]);
-	}
-
-	// オブジェクトを用意
-	vector<map<string, string> > objectData = csvReader2.getDomainData("OBJECT:");
-	m_objectLoader = new ObjectLoader;
-	for (unsigned int i = 0; i < objectData.size(); i++) {
-		m_objectLoader->addObject(objectData[i]);
-	}
-
-	// 時間帯を決定
-	vector<map<string, string> > dateData = csvReader2.getDomainData("DATE:");
-	if (dateData.size() > 0) {
-		m_date = stoi(dateData[0]["num"]);
-	}
+	loadCsvData(oss.str().c_str(), world, soundPlayer);
+	m_world_p->changeCharacterVersion(m_version);
+	m_world_p->setDate(m_date);
 
 	// イベントの発火確認
 	checkFire();
@@ -66,6 +42,50 @@ Story::~Story() {
 	}
 	delete m_characterLoader;
 	delete m_objectLoader;
+}
+
+// csvファイルを読み込む
+void Story::loadCsvData(const char* fileName, World* world, SoundPlayer* soundPlayer) {
+	CsvReader2 csvReader2(fileName);
+
+	// イベント生成
+	vector<map<string, string> > eventData = csvReader2.getDomainData("EVENT:");
+	for (unsigned int i = 0; i < eventData.size(); i++) {
+		int eventNum = stoi(eventData[i]["num"]);
+		bool mustFlag = (bool)stoi(eventData[i]["mustFlag"]);
+		Event* eventOne = new Event(eventNum, world, soundPlayer);
+		if (mustFlag) { m_mustEvent.push_back(eventOne); }
+		else { m_subEvent.push_back(eventOne); }
+	}
+
+	// キャラクターを用意
+	vector<map<string, string> > characterData = csvReader2.getDomainData("CHARACTER:");
+	for (unsigned int i = 0; i < characterData.size(); i++) {
+		m_characterLoader->addCharacter(characterData[i]);
+	}
+
+	// オブジェクトを用意
+	vector<map<string, string> > objectData = csvReader2.getDomainData("OBJECT:");
+	for (unsigned int i = 0; i < objectData.size(); i++) {
+		m_objectLoader->addObject(objectData[i]);
+	}
+
+	// 時間帯を決定
+	vector<map<string, string> > dateData = csvReader2.getDomainData("DATE:");
+	if (dateData.size() > 0) {
+		m_date = stoi(dateData[0]["num"]);
+	}
+
+	// 世界のバージョンを取得しロードする 変化ない(updateが0)ならロードしない
+	vector<map<string, string> > versionData = csvReader2.getDomainData("VERSION:");
+	if (versionData.size() > 0) {
+		m_version = stoi(versionData[0]["num"]);
+		if (m_version > 0 && (bool)stoi(versionData[0]["update"])) {
+			ostringstream oss;
+			oss << "data/story/version" << m_version << ".csv";
+			loadCsvData(oss.str().c_str(), world, soundPlayer);
+		}
+	}
 }
 
 bool Story::play() {
@@ -128,6 +148,7 @@ bool Story::skillAble() {
 // セッタ
 void Story::setWorld(World* world) {
 	m_world_p = world;
+	m_world_p->changeCharacterVersion(m_version);
 	m_world_p->setDate(m_date);
 	if (m_nowEvent != nullptr) {
 		m_nowEvent->setWorld(m_world_p);

--- a/Story.h
+++ b/Story.h
@@ -59,6 +59,8 @@ public:
 
 	// ƒQƒbƒ^
 	inline int getStoryNum() const { return m_storyNum; }
+	inline int getDate() const { return m_date; }
+	inline int getVersion() const { return m_version; }
 	inline CharacterLoader* getCharacterLoader() const { return m_characterLoader; }
 	inline ObjectLoader* getObjectLoader() const { return m_objectLoader; }
 	inline const World* getWorld() const { return m_world_p; }

--- a/Story.h
+++ b/Story.h
@@ -22,6 +22,9 @@ private:
 	// 時間帯
 	int m_date;
 
+	// Emote Onlineのversion
+	int m_version;
+
 	// 進行中のイベント
 	Event* m_nowEvent;
 	
@@ -41,6 +44,9 @@ public:
 	Story(int storyNum, World* world, SoundPlayer* soundPlayer);
 	~Story();
 
+	// csvファイルを読み込む
+	void loadCsvData(const char* fileName, World* world, SoundPlayer* soundPlayer);
+
 	void debug(int x, int y, int color);
 
 	bool play();
@@ -53,7 +59,6 @@ public:
 
 	// ゲッタ
 	inline int getStoryNum() const { return m_storyNum; }
-	inline int getDate() const { return m_date; }
 	inline CharacterLoader* getCharacterLoader() const { return m_characterLoader; }
 	inline ObjectLoader* getObjectLoader() const { return m_objectLoader; }
 	inline const World* getWorld() const { return m_world_p; }

--- a/World.cpp
+++ b/World.cpp
@@ -349,6 +349,13 @@ void World::addCharacter(CharacterLoader* characterLoader) {
 	m_characterControllers.insert(m_characterControllers.end(), p.second.begin(), p.second.end());
 }
 
+// ストーリーによるキャラの性能変化
+void World::changeCharacterVersion(int version) {
+	for (unsigned int i = 0; i < m_characters.size(); i++) {
+		m_characters[i]->changeInfoVersion(version);
+	}
+}
+
 // ストーリーによる追加オブジェクト
 void World::addObject(ObjectLoader* objectLoader) {
 	pair<vector<Object*>, vector<Object*> > p = objectLoader->getObjects(m_areaNum);

--- a/World.h
+++ b/World.h
@@ -175,6 +175,9 @@ public:
 	// ストーリーによるキャラ追加
 	void addCharacter(CharacterLoader* characterLoader);
 
+	// ストーリーによるキャラの性能変化
+	void changeCharacterVersion(int version);
+
 	// ストーリーによるオブジェクト追加
 	void addObject(ObjectLoader* objectLoader);
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
以下の2点
- シナリオが進むことによる世界の変化は、今までstory.csvから読み込んでいた。しかしシナリオの特性上、何度も世界を繰り返すため同じ記述をいくつものstory.csvに書く必要があった。そのため、繰り返しの記述はversion.csvにまとめて、story.csvから呼び出せるようにする。具体的には、エモートオンラインのバージョンアップによる変化は定型化できるため、version.csvに書く。
- 今までキャラの性能変化はEventElementによってのみ行えた。しかし性能変化はエモートオンラインのバージョンアップによるものなので、読み込んだversion.csvの番号によってキャラの性能が自動的に設定されるようにする。具体的には、Storyクラスが読み込んだversion.csvによってversion番号を保持しておき、そのバージョン番号をWorldクラスの全キャラに適用する。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
