### PR TITLE
会話イベントスキップ機能の改善＆チュートリアル追加

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -262,7 +262,7 @@ OpMovie::OpMovie(SoundPlayer* soundPlayer_p):
 
 	// キャラ
 	double charaEx = m_ex * 1.1;
-	m_archive = new GraphHandles((path + "アーカイブ").c_str(), 1, charaEx);
+	m_archive = new GraphHandles((path + "アーカイブ").c_str(), 5, charaEx);
 	m_aigis = new GraphHandles((path + "アイギス").c_str(), 4, charaEx, 0, false, true);
 	m_assault = new GraphHandles((path + "アサルト03").c_str(), 4, charaEx);
 	m_vermelia = new GraphHandles((path + "ヴェルメリア").c_str(), 1, charaEx);
@@ -680,6 +680,7 @@ void OpMovie::draw() {
 		int alpha = min(255, m_cnt - 4350);
 		SetDrawBlendMode(DX_BLENDMODE_ALPHA, alpha);
 	}
+	SetDrawMode(DX_DRAWMODE_BILINEAR);
 	Movie::draw();
 	SetDrawBlendMode(DX_BLENDMODE_ALPHA, 255);
 	if (m_cnt > 980 && m_cnt < 1470) {
@@ -692,4 +693,5 @@ void OpMovie::draw() {
 		DrawBox(0, 0, GAME_WIDE, GAME_HEIGHT, BLACK, TRUE);
 	}
 	drawFlame();
+	SetDrawMode(DX_DRAWMODE_NEAREST);
 }

--- a/Control.cpp
+++ b/Control.cpp
@@ -79,6 +79,11 @@ int controlQ() {
 	return Key[KEY_INPUT_Q];
 }
 
+// Zキー（イベントスキップ）
+int controlZ() {
+	return Key[KEY_INPUT_Z];
+}
+
 //デバッグモード起動用
 int controlDebug() {
 	if (Key[KEY_INPUT_P] == 1) { // Pキーが押されていたら

--- a/Control.h
+++ b/Control.h
@@ -28,6 +28,9 @@ int controlF();
 // Qキー（一時停止）
 int controlQ();
 
+// Zキー（イベントスキップ）
+int controlZ();
+
 //FPS表示のオンオフ
 int controlDebug();
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -175,7 +175,7 @@ GameData::GameData() {
 	}
 
 	// 主要キャラを設定
-	const int mainSum = 13;
+	const int mainSum = 14;
 	const char* mainCharacters[mainSum] = {
 		"ハート",
 		"シエスタ",
@@ -189,7 +189,8 @@ GameData::GameData() {
 		"アーカイブ",
 		"アイギス",
 		"コハル",
-		"マスカーラ"
+		"マスカーラ",
+		"ヴェルメリア"
 	};
 	for (int i = 0; i < mainSum; i++) {
 		m_characterData.push_back(new CharacterData(mainCharacters[i]));
@@ -294,6 +295,7 @@ bool GameData::load() {
 	fread(&m_storyNum, sizeof(m_storyNum), 1, intFp);
 	fread(&m_latestStoryNum, sizeof(m_latestStoryNum), 1, intFp);
 	for (unsigned int i = 0; i < m_characterData.size(); i++) {
+		if (feof(intFp) != 0 || feof(strFp) != 0) { break; }
 		m_characterData[i]->load(intFp, strFp);
 	}
 	int doorSum = 0;

--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -170,6 +170,45 @@ void GamePause::draw() const {
 
 
 /*
+* チュートリアルの描画
+*/
+TutorialDisp::TutorialDisp(int font_p, int fontSize, double exX, double exY) {
+	m_font_p = font_p;
+	m_fontSize = fontSize;
+	m_exX = exX;
+	m_exY = exY;
+	setPoint(0, 0, 0, 0);
+}
+
+void TutorialDisp::draw() {
+	draw(m_x1, m_y1, m_x2, m_y2);
+}
+
+void TutorialDisp::draw(int x1, int y1, int x2, int y2) {
+	DrawBox(x1, y1, x2, y2, WHITE, TRUE);
+	
+	int i = m_fontSize;
+	DrawStringToHandle(x1 + m_fontSize, y1 + i, "移動：Ａ，Ｄキー", BLACK, m_font_p);
+	i += m_fontSize * 2;
+	DrawStringToHandle(x1 + m_fontSize, y1 + i, "しゃがむ：Ｓキー", BLACK, m_font_p);
+	i += m_fontSize * 2;
+	DrawStringToHandle(x1 + m_fontSize, y1 + i, "ジャンプ：スペースキー", BLACK, m_font_p);
+	i += m_fontSize * 2;
+	DrawStringToHandle(x1 + m_fontSize, y1 + i, "射撃：左クリック（長押しで連射）", BLACK, m_font_p);
+	i += m_fontSize * 2;
+	DrawStringToHandle(x1 + m_fontSize, y1 + i, "斬撃：右クリック", BLACK, m_font_p);
+	i += m_fontSize * 2;
+	DrawStringToHandle(x1 + m_fontSize, y1 + i, "キャラ切り替え：Ｅキー", BLACK, m_font_p);
+	i += m_fontSize * 2;
+	DrawStringToHandle(x1 + m_fontSize, y1 + i, "スキル発動：Ｆキー", BLACK, m_font_p);
+	i += m_fontSize * 2;
+	DrawStringToHandle(x1 + m_fontSize, y1 + i, "会話をスキップ：Ｚキー長押し", BLACK, m_font_p);
+	i += m_fontSize * 2;
+	DrawStringToHandle(x1 + m_fontSize, y1 + i, "ズームアウト：シフトキー長押し", BLACK, m_font_p);
+}
+
+
+/*
 * ゲーム中に開くオプション画面 タイトルに戻るボタンやチュートリアルがある
 */
 BattleOption::BattleOption(SoundPlayer* soundPlayer):
@@ -185,13 +224,17 @@ BattleOption::BattleOption(SoundPlayer* soundPlayer):
 	int y = (int)(TITLE_Y1 * m_exY);
 	int wide = (int)((TITLE_X2 - TITLE_X1) * m_exX);
 	int height = (int)((TITLE_Y2 - TITLE_Y1) * m_exY);
-	m_titleButton = new Button("Back to the title", x, y, wide, height, GRAY, RED, m_font, BLACK);
+	m_titleButton = new Button("Back to the title", x, y, wide, height, WHITE, RED, m_font, BLACK);
 	m_titleFlag = false;
+
+	m_tutorialDisp = new TutorialDisp(m_font, m_fontSize, m_exX, m_exY);
+	m_tutorialDisp->setPoint(GAME_WIDE / 2 - (int)(100 * m_exX), (int)(50 * m_exY), GAME_WIDE - (int)(50 * m_exX), GAME_HEIGHT - (int)(50 * m_exY));
 }
 BattleOption::~BattleOption() {
 	delete m_titleButton;
 	DeleteGraph(m_backgroundGraph);
 	DeleteFontToHandle(m_font);
+	delete m_tutorialDisp;
 }
 
 void BattleOption::play() {
@@ -215,6 +258,8 @@ void BattleOption::draw() const {
 	GamePause::draw();
 
 	m_titleButton->draw(m_handX, m_handY);
+
+	m_tutorialDisp->draw();
 
 }
 

--- a/PausePage.h
+++ b/PausePage.h
@@ -7,6 +7,10 @@
 class Button;
 class SoundPlayer;
 
+
+/*
+* セーブデータ選択画面やタイトルのオプション画面に使う背景画像
+*/
 class TitleBackGround {
 private:
 
@@ -123,6 +127,40 @@ public:
 
 
 /*
+* チュートリアルの描画
+*/
+class TutorialDisp {
+private:
+
+	// フォント
+	int m_font_p;
+	int m_fontSize;
+
+	// 1920を基準としたGAME_WIDEの倍率
+	double m_exX;
+	// 1080を基準としたGAME_HEIGHTの倍率
+	double m_exY;
+
+	// 描画範囲 設定しなくてもいい
+	int m_x1, m_y1, m_x2, m_y2;
+
+public:
+
+	TutorialDisp(int font_p, int fontSize, double exX, double exY);
+
+	void setPoint(int x1, int y1, int x2, int y2) {
+		m_x1 = x1;
+		m_y1 = y1;
+		m_x2 = x2;
+		m_y2 = y2;
+	}
+
+	void draw();
+	void draw(int x1, int y1, int x2, int y2);
+};
+
+
+/*
 * ゲーム中に開くオプション画面 タイトルに戻るボタンやチュートリアルがある
 */
 class BattleOption :
@@ -151,6 +189,9 @@ private:
 	// タイトルへ戻るボタン
 	Button* m_titleButton;
 	bool m_titleFlag;
+
+	// 操作説明
+	TutorialDisp* m_tutorialDisp;
 
 public:
 	BattleOption(SoundPlayer* soundPlayer);

--- a/Text.cpp
+++ b/Text.cpp
@@ -112,6 +112,7 @@ void TextAction::play() {
 Conversation::Conversation(int textNum, World* world, SoundPlayer* soundPlayer) {
 
 	m_finishCnt = 0;
+	m_skipCnt = 0;
 	m_startCnt = FINISH_COUNT;
 	m_finishFlag = false;
 	m_world_p = world;
@@ -227,8 +228,14 @@ bool Conversation::play() {
 		m_animations.push_back(new Animation(handX, handY, 4, m_clickGraph));
 	}
 
-	// クリック長押しで終了
-	if (leftClick() == 60) { m_finishFlag = true; return true; }
+	// Zキー長押しで終了
+	if (controlZ() > 0) { 
+		if (m_skipCnt++ == 60) {
+			m_finishFlag = true;
+			return true;
+		}
+	}
+	else { m_skipCnt = 0; }
 
 	// 終了処理
 	if (m_finishCnt > 0) {

--- a/Text.h
+++ b/Text.h
@@ -113,6 +113,9 @@ private:
 	// FINISH_CINT -> 0で発言開始
 	int m_startCnt;
 
+	// Zキーの長押し時間
+	int m_skipCnt;
+
 	// イベント終了したか
 	bool m_finishFlag;
 
@@ -198,6 +201,7 @@ public:
 	inline bool getNoFace() const { return m_noFace; }
 	inline 	std::string getSpeakerName() const { return m_speakerName; }
 	inline int getFinishCnt() const { return m_finishCnt; }
+	inline int getSkipCnt() const { return m_skipCnt; }
 	inline int getStartCnt() const { return m_startCnt; }
 	inline bool getFinishFlag() const { return m_finishFlag; }
 	inline int getTextNow() const { return m_textNow; }

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -116,6 +116,20 @@ void ConversationDrawer::draw() {
 			}
 		}
 	}
+
+	int skipCnt = m_conversation->getSkipCnt();
+	static const int SKIP_WIDE = 600;
+	static const int SKIP_HEIGHT = 100;
+	if (skipCnt > 0) {
+		int x2 = GAME_WIDE - 10;
+		int x1 = x2 - SKIP_WIDE * m_exX;
+		int x15 = x1 + skipCnt * (SKIP_WIDE / 60) * m_exX;
+		int y1 = 10;
+		int y2 = y1 + SKIP_HEIGHT * m_exY;
+		DrawBox(x1, y1, x15, y2, BLACK, TRUE);
+		DrawBox(x15, y1, x2, y2, GRAY, TRUE);
+		DrawStringToHandle(x1 + 5, y1 + 5, "Zキー長押しでスキップ", WHITE, m_textHandle);
+	}
 	
 	// 画面右下のクリック要求アイコン
 	bool textFinish = m_conversation->finishText() && m_conversation->getFinishCnt() == 0 && m_conversation->getStartCnt() == 0 && m_conversation->nextTextAble();

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -128,7 +128,7 @@ void ConversationDrawer::draw() {
 		int y2 = y1 + SKIP_HEIGHT * m_exY;
 		DrawBox(x1, y1, x15, y2, BLACK, TRUE);
 		DrawBox(x15, y1, x2, y2, GRAY, TRUE);
-		DrawStringToHandle(x1 + 5, y1 + 5, "Zキー長押しでスキップ", WHITE, m_textHandle);
+		DrawStringToHandle(x1 + 5, y1 + 5, "Ｚキー長押しでスキップ", WHITE, m_textHandle);
 	}
 	
 	// 画面右下のクリック要求アイコン


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#147 の対処。左クリック長押しではなく、Zキー長押しで会話イベントをスキップするように。

また、Zキー長押し中は、あとどれくらい長押しすればスキップされるか視覚化される。

チュートリアルの追加については、Qキーで一時停止時に操作方法が表示されるように。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
