### PR TITLE
Api: イベントのクリア状況を保持して利用

### DIFF
--- a/Event.h
+++ b/Event.h
@@ -103,6 +103,9 @@ public:
 	Event(int eventNum, World* world, SoundPlayer* soundPlayer);
 	~Event();
 
+	// ƒQƒbƒ^
+	inline int getEventNum() { return m_eventNum; }
+
 	// ”­‰Î
 	bool fire();
 

--- a/Game.h
+++ b/Game.h
@@ -139,6 +139,32 @@ public:
 };
 
 
+/*
+* クリアしたイベントのリスト
+*/
+class EventData {
+private:
+
+	// クリアしたイベント番号
+	std::vector<int> m_clearEvent;
+
+public:
+
+	EventData();
+	EventData(FILE* eventFp);
+
+	void save(FILE* eventFp);
+	void load(FILE* eventFp);
+
+	// 特定のイベントをクリアしてるか
+	bool checkClearEvent(int eventNum);
+
+	//特定のイベントをクリアした
+	void setClearEvent(int eventNum);
+
+};
+
+
 // セーブデータ
 class GameData {
 private:
@@ -153,6 +179,9 @@ private:
 
 	// ドアのデータ
 	std::vector<DoorData*> m_doorData;
+
+	// イベントのデータ
+	EventData* m_eventData;
 
 	// 今いるエリア
 	int m_areaNum;
@@ -190,6 +219,7 @@ public:
 	inline int getFrom(int i) const { return m_doorData[i]->from(); }
 	inline int getTo(int i) const { return m_doorData[i]->to(); }
 	inline int getLatestStoryNum() const { return m_latestStoryNum; }
+	inline EventData* getEventData() { return m_eventData; }
 	CharacterData* getCharacterData(std::string characterName);
 
 	// セッタ

--- a/Story.h
+++ b/Story.h
@@ -4,10 +4,12 @@
 #include <vector>
 
 class Event;
+class EventData;
 class World;
 class SoundPlayer;
 class CharacterLoader;
 class ObjectLoader;
+
 
 // ストーリ－
 class Story {
@@ -34,6 +36,9 @@ private:
 	// クリア任意イベント
 	std::vector<Event*> m_subEvent;
 
+	// イベントのクリア状況 Gameクラスからもらう
+	EventData* m_eventData_p;
+
 	// キャラクターのデータ
 	CharacterLoader* m_characterLoader;
 
@@ -41,7 +46,7 @@ private:
 	ObjectLoader* m_objectLoader;
 
 public:
-	Story(int storyNum, World* world, SoundPlayer* soundPlayer);
+	Story(int storyNum, World* world, SoundPlayer* soundPlayer, EventData* eventData);
 	~Story();
 
 	// csvファイルを読み込む


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#148 の対処。

クリアしたイベントのリストをセーブデータとして取り扱う。

使い道としては、クリアしたことのあるイベントを再度起動しない、あるいは代わりのイベントに挿げ替えることの2つ。

# やったこと
イベントのクリア状況はvectorで管理する。クリアしたイベントの番号をvectorにpush_backしていく。

eventData.datファイルに保存する。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
