### PR TITLE
セーブ完了通知機能を追加

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -199,6 +199,8 @@ void EventData::setClearEvent(int eventNum) {
 // 初期状態のデータを作成
 GameData::GameData() {
 
+	m_noticeSaveDone = 0;
+
 	m_exist = false;
 
 	m_soundVolume = 50;
@@ -325,6 +327,10 @@ bool GameData::save() {
 		fclose(intFp);
 		fclose(strFp);
 		fclose(eventFp);
+	}
+	// セーブ完了通知 Chapter 1だけはしない
+	if (m_storyNum > 1) {
+		m_noticeSaveDone = NOTICE_SAVE_DONE_TIME;
 	}
 	return true;
 }
@@ -616,6 +622,9 @@ bool Game::play() {
 			m_world->setSkillFlag(false);
 		}
 	}
+
+	// セーブ完了通知
+	m_gameData->setNoticeSaveDone(max(0, m_gameData->getNoticeSaveDone() - 1));
 
 	// 音
 	m_soundPlayer->play();

--- a/Game.h
+++ b/Game.h
@@ -195,11 +195,17 @@ private:
 	// 音量
 	int m_soundVolume;
 
+	// セーブ完了の通知を表示する残り時間
+	int m_noticeSaveDone;
+
 public:
 	GameData();
 	GameData(const char* saveFilePath);
 	GameData(const char* saveFilePath, int storyNum);
 	~GameData();
+
+	// セーブ完了の通知を表示する時間
+	const int NOTICE_SAVE_DONE_TIME = 300;
 
 	// セーブとロード
 	bool save();
@@ -220,12 +226,14 @@ public:
 	inline int getTo(int i) const { return m_doorData[i]->to(); }
 	inline int getLatestStoryNum() const { return m_latestStoryNum; }
 	inline EventData* getEventData() { return m_eventData; }
+	inline int getNoticeSaveDone() const { return m_noticeSaveDone; }
 	CharacterData* getCharacterData(std::string characterName);
 
 	// セッタ
 	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }
 	inline void setStoryNum(int storyNum) { m_storyNum = storyNum; }
 	inline void setSoundVolume(int soundVolume) { m_soundVolume = soundVolume; }
+	inline void setNoticeSaveDone(int noticeSaveDone) { m_noticeSaveDone = noticeSaveDone; }
 
 	// セーブデータ削除
 	void removeSaveData();
@@ -340,6 +348,7 @@ public:
 	BattleOption* getGamePause() const { return m_battleOption; }
 	bool getRebootFlag() const { return m_rebootFlag; }
 	inline int getGameoverCnt() const { return m_gameoverCnt; }
+	inline const GameData* getGameData() const { return m_gameData; }
 
 	// デバッグ
 	void debug(int x, int y, int color) const;

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -22,12 +22,21 @@ GameDrawer::GameDrawer(const Game* game) {
 	m_skillHandle = CreateFontToHandle(nullptr, (int)(SKILL_SIZE * m_exX), 10);
 
 	m_gameoverHandle = LoadGraph("picture/system/gameover.png");
+
+	m_noticeSaveDataHandle = LoadGraph("picture/system/noticeSaveDone.png");
+	m_noticeEx = 0.7;
+	GetGraphSize(m_noticeSaveDataHandle, &m_noticeX, &m_noticeY);
+	m_noticeX = (int)(m_noticeX * (m_exX / 2 * m_noticeEx));
+	m_noticeY = (int)(m_noticeY * (m_exY / 2 * m_noticeEx));
+	m_noticeX += (int)(10 * m_exX);
+	m_noticeY = GAME_HEIGHT - m_noticeY - (int)(10 * m_exY);
 }
 
 GameDrawer::~GameDrawer() {
 	delete m_worldDrawer;
 	DeleteFontToHandle(m_skillHandle);
 	DeleteGraph(m_gameoverHandle);
+	DeleteGraph(m_noticeSaveDataHandle);
 }
 
 void GameDrawer::draw() {
@@ -51,6 +60,24 @@ void GameDrawer::draw() {
 		m_worldDrawer->setWorld(m_game->getWorld());
 	}
 	m_worldDrawer->draw();
+
+	// セーブ完了通知
+	int noticeSaveDone = m_game->getGameData()->getNoticeSaveDone();
+	int alpha = 0;
+	if (noticeSaveDone > 0) {
+		if (noticeSaveDone * 3 > m_game->getGameData()->NOTICE_SAVE_DONE_TIME * 2) {
+			alpha = min(255, (m_game->getGameData()->NOTICE_SAVE_DONE_TIME - noticeSaveDone) * 3);
+		}
+		else if (noticeSaveDone * 3 > m_game->getGameData()->NOTICE_SAVE_DONE_TIME ) {
+			alpha = 255;
+		}
+		else {
+			alpha = max(0, noticeSaveDone * 3);
+		}
+		SetDrawBlendMode(DX_BLENDMODE_ALPHA, alpha);
+		DrawRotaGraph(m_noticeX, m_noticeY, min(m_exX, m_exY) * m_noticeEx, 0.0, m_noticeSaveDataHandle, TRUE);
+		SetDrawBlendMode(DX_BLENDMODE_ALPHA, 255);
+	}
 
 	// スキルの時間等を描画
 	if (skill != nullptr) {

--- a/GameDrawer.h
+++ b/GameDrawer.h
@@ -21,6 +21,11 @@ private:
 	// ゲームオーバーの画像
 	int m_gameoverHandle;
 
+	// セーブ完了通知の画像
+	int m_noticeSaveDataHandle;
+	int m_noticeX, m_noticeY;
+	double m_noticeEx;
+
 public:
 	GameDrawer(const Game* game);
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り (#150 の対応)

オートセーブした際に画面の左下に「Game data saved.」と表示する。

表示は少しずつ浮き出るように表示され、少しずつ薄くなって消えていく。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
