### PR TITLE
Api: eventDataロードバグの修正

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -363,6 +363,7 @@ bool GameData::load() {
 	for (int i = 0; i < doorSum; i++) {
 		m_doorData.push_back(new DoorData(intFp, strFp));
 	}
+	m_eventData->init();
 	m_eventData->load(eventFp);
 	// ƒtƒ@ƒCƒ‹‚ð•Â‚¶‚é
 	fclose(intFp);

--- a/Game.h
+++ b/Game.h
@@ -156,6 +156,9 @@ public:
 	void save(FILE* eventFp);
 	void load(FILE* eventFp);
 
+	// 初期化
+	void init() { m_clearEvent.clear(); }
+
 	// 特定のイベントをクリアしてるか
 	bool checkClearEvent(int eventNum);
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
クリア済みチャプターをプレイすると未クリアのはずのサブイベントがクリア済みになっており起動しないバグがある。

原因は、最新のセーブデータをロードしてから過去のチャプターのデータをロードするため。

過去のチャプターをロードする際にeventDataをいったんリセットして解決する。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
