### PR TITLE
世界のやり直しイベントの実装

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -1,7 +1,9 @@
 #include "Animation.h"
 #include "AnimationDrawer.h"
+#include "Control.h"
 #include "GraphHandle.h"
 #include "Sound.h"
+#include "DrawTool.h"
 #include "Define.h"
 #include "DxLib.h"
 
@@ -71,9 +73,8 @@ GraphHandle* Animation::getHandle() const {
 * 動画の基底クラス
 */
 Movie::Movie(SoundPlayer* soundPlayer_p) {
-	double exX, exY;
-	getGameEx(exX, exY);
-	m_ex = min(exX, exY);
+	getGameEx(m_exX, m_exY);
+	m_ex = min(m_exX, m_exY);
 	m_finishFlag = false;
 	m_cnt = 0;
 	m_animation = nullptr;
@@ -84,6 +85,9 @@ Movie::Movie(SoundPlayer* soundPlayer_p) {
 
 	m_flameWide = (GAME_WIDE - (int)(GAME_WIDE_DEFAULT * m_ex)) / 2;
 	m_flameHeight = (GAME_HEIGHT - (int)(GAME_HEIGHT_DEFAULT * m_ex)) / 2;
+
+	// フォントデータ
+	m_textHandle = CreateFontToHandle(nullptr, (int)(TEXT_SIZE * m_exX), 3);
 }
 
 Movie::~Movie() {
@@ -91,6 +95,8 @@ Movie::~Movie() {
 		delete m_animation;
 	}
 	m_soundPlayer_p->setBGM(m_originalBgmPath);
+	// フォントデータ削除
+	DeleteFontToHandle(m_textHandle);
 }
 
 void Movie::play() {
@@ -116,6 +122,14 @@ void Movie::play() {
 			m_subAnimation.push(subAnimation);
 		}
 	}
+
+	// Zキー長押しで終了
+	if (controlZ() > 0) {
+		if (m_skipCnt++ == 60) {
+			m_finishFlag = true;
+		}
+	}
+	else { m_skipCnt = 0; }
 }
 
 void Movie::draw() {
@@ -721,4 +735,7 @@ void OpMovie::draw() {
 	}
 	drawFlame();
 	SetDrawMode(DX_DRAWMODE_NEAREST);
+
+	// Zキー長押しでスキップの表示
+	drawSkip(m_skipCnt, m_exX, m_exY, m_textHandle);
 }

--- a/Animation.h
+++ b/Animation.h
@@ -72,11 +72,21 @@ protected:
 
 	// 解像度の変更に対応
 	double m_ex;
+	// テキストやフォントのサイズの倍率
+	double m_exX;
+	double m_exY;
+
+	// フォント（テキスト）
+	int m_textHandle;
+	const int TEXT_SIZE = 50;
 
 	int m_flameWide, m_flameHeight;
 
 	// 終了したらtrue
 	bool m_finishFlag;
+
+	// Zキーの長押し時間
+	int m_skipCnt;
 
 	// 開始からの経過時間
 	int m_cnt;
@@ -103,9 +113,10 @@ public:
 	virtual ~Movie();
 
 	// ゲッタ
-	bool getFinishFlag() const { return m_finishFlag; }
-	Animation* getAnimation() const { return m_animation; }
-	std::queue<Animation*> getSubAnimation() const { return m_subAnimation; }
+	inline bool getFinishFlag() const { return m_finishFlag; }
+	inline bool getSkipCnt() const { return m_skipCnt; }
+	inline Animation* getAnimation() const { return m_animation; }
+	inline std::queue<Animation*> getSubAnimation() const { return m_subAnimation; }
 	inline int getCnt() const { return m_cnt; }
 
 	// 再生

--- a/Define.h
+++ b/Define.h
@@ -4,7 +4,7 @@
 #include"DxLib.h"
 
 // フルスクリーンならFALSE
-static int WINDOW = FALSE;
+static int WINDOW = TRUE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = TRUE;
 

--- a/DrawTool.cpp
+++ b/DrawTool.cpp
@@ -1,0 +1,16 @@
+#include "Define.h"
+
+void drawSkip(int cnt, double exX, double exY, int fontHandle) {
+	static const int SKIP_WIDE = 600;
+	static const int SKIP_HEIGHT = 100;
+	if (cnt > 0) {
+		int x2 = GAME_WIDE - 10;
+		int x1 = x2 - (int)(SKIP_WIDE * exX);
+		int x15 = (int)(x1 + cnt * (SKIP_WIDE / 60) * exX);
+		int y1 = 10;
+		int y2 = y1 + (int)(SKIP_HEIGHT * exY);
+		DrawBox(x1, y1, x15, y2, BLACK, TRUE);
+		DrawBox(x15, y1, x2, y2, GRAY, TRUE);
+		DrawStringToHandle(x1 + 5, y1 + 5, "Ｚキー長押しでスキップ", WHITE, fontHandle);
+	}
+}

--- a/DrawTool.h
+++ b/DrawTool.h
@@ -1,0 +1,7 @@
+#ifndef DRAW_TOOL_H_INCLUDED
+#define DRAW_TOL_H_INCLUDED
+
+// Zキー長押しでスキップの表示
+void drawSkip(int cnt, double exX, double exY, int fontHandle);
+
+#endif

--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -181,6 +181,7 @@
     <ClCompile Include="Text.cpp" />
     <ClCompile Include="TextDrawer.cpp" />
     <ClCompile Include="Title.cpp" />
+    <ClCompile Include="DrawTool.cpp" />
     <ClCompile Include="World.cpp" />
     <ClCompile Include="WorldDrawer.cpp" />
   </ItemGroup>
@@ -199,6 +200,7 @@
     <ClInclude Include="ControllerRecorder.h" />
     <ClInclude Include="CsvReader.h" />
     <ClInclude Include="Define.h" />
+    <ClInclude Include="DrawTool.h" />
     <ClInclude Include="Event.h" />
     <ClInclude Include="Game.h" />
     <ClInclude Include="GameDrawer.h" />

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClCompile Include="Item.cpp">
       <Filter>ソース ファイル\Domain</Filter>
     </ClCompile>
+    <ClCompile Include="DrawTool.cpp">
+      <Filter>ソース ファイル\ui</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">
@@ -232,6 +235,9 @@
     </ClInclude>
     <ClInclude Include="Item.h">
       <Filter>ヘッダー ファイル\Domain</Filter>
+    </ClInclude>
+    <ClInclude Include="DrawTool.h">
+      <Filter>ヘッダー ファイル\ui</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Event.cpp
+++ b/Event.cpp
@@ -596,8 +596,14 @@ MoveAreaEvent::MoveAreaEvent(World* world, std::vector<std::string> param) :
 	m_areaNum = stoi(param[1]);
 }
 EVENT_RESULT MoveAreaEvent::play() {
-	m_world_p->moveArea(m_areaNum);
-	return EVENT_RESULT::SUCCESS;
+	m_world_p->dealBrightValue();
+	if (m_world_p->getNextAreaNum() != m_areaNum) {
+		m_world_p->moveArea(m_areaNum);
+	}
+	else if (m_world_p->getAreaNum() == m_areaNum) {
+		return EVENT_RESULT::SUCCESS;
+	}
+	return EVENT_RESULT::NOW;
 }
 
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -149,6 +149,12 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	else if (param0 == "PlayerDead") {
 		element = new PlayerDeadEvent(world, param);
 	}
+	else if (param0 == "MoveArea"){
+		element = new MoveAreaEvent(world, param);
+	}
+	else if (param0 == "BlindWorld") {
+		element = new BlindWorldEvent(world, param);
+	}
 
 	if (element != nullptr) { 
 		m_eventElement = element;
@@ -580,4 +586,28 @@ EVENT_RESULT PlayerDeadEvent::play() {
 		return EVENT_RESULT::SUCCESS;
 	}
 	return EVENT_RESULT::NOW;
+}
+
+
+// 特定のエリアへ強制的に移動する
+MoveAreaEvent::MoveAreaEvent(World* world, std::vector<std::string> param) :
+	EventElement(world)
+{
+	m_areaNum = stoi(param[1]);
+}
+EVENT_RESULT MoveAreaEvent::play() {
+	m_world_p->moveArea(m_areaNum);
+	return EVENT_RESULT::SUCCESS;
+}
+
+
+// 世界の描画をする・しない
+BlindWorldEvent::BlindWorldEvent(World* world, std::vector<std::string> param) :
+	EventElement(world)
+{
+	m_flag = (bool)stoi(param[1]);
+}
+EVENT_RESULT BlindWorldEvent::play() {
+	m_world_p->setBlindFlag(m_flag);
+	return EVENT_RESULT::SUCCESS;
 }

--- a/Event.h
+++ b/Event.h
@@ -557,4 +557,34 @@ public:
 	bool needBackPrevSave() { return true; }
 };
 
+// 特定のエリアへ強制的に移動する
+class MoveAreaEvent :
+	public EventElement
+{
+private:
+	
+	int m_areaNum;
+
+public:
+	MoveAreaEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+};
+
+// 世界の描画をする・しない
+class BlindWorldEvent :
+	public EventElement
+{
+private:
+
+	int m_flag;
+
+public:
+	BlindWorldEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+};
+
 #endif

--- a/Game.cpp
+++ b/Game.cpp
@@ -21,11 +21,11 @@ using namespace std;
 
 
 // どこまで
-const int FINISH_STORY = 9;
+const int FINISH_STORY = 10;
 // エリア0でデバッグするときはtrueにする
 const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
-const int SKILL_USEABLE_STORY = 10;
+const int SKILL_USEABLE_STORY = 13;
 
 
 /*
@@ -602,6 +602,7 @@ bool Game::play() {
 		int nextStoryNum = m_gameData->getStoryNum() + 1;
 		delete m_story;
 		m_story = new Story(nextStoryNum, m_world, m_soundPlayer, m_gameData->getEventData());
+		if (m_story->getInitDark()) { m_soundPlayer->stopBGM(); }
 		// ストーリーの影響でオブジェクトが追加される（一度追加されると今後GameDataでデータは保持され続ける）
 		// セーブデータに上書き
 		m_gameData->updateStory(m_story);
@@ -648,8 +649,10 @@ bool Game::play() {
 		int fromAreaNum = m_world->getAreaNum();
 		int toAreaNum = m_world->getNextAreaNum();
 		m_gameData->asignedWorld(m_world, false);
+		bool resetBgmFlag = m_world->getResetBgmFlag();
 		delete m_world;
 		m_world = new World(fromAreaNum, toAreaNum, m_soundPlayer);
+		if(resetBgmFlag){ m_soundPlayer->stopBGM(); }
 		m_gameData->asignWorld(m_world);
 		m_world->setPlayerOnDoor(fromAreaNum);
 		m_story->setWorld(m_world);
@@ -673,6 +676,11 @@ void Game::backPrevSave() {
 	m_world->setPlayerPoint(prevData.getCharacterData("ハート"));
 	m_world->setPlayerFollowerPoint();
 	m_story->setWorld(m_world);
+}
+
+// 描画していいならtrue
+bool Game::ableDraw() {
+	return !m_story->getInitDark();
 }
 
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -515,6 +515,8 @@ Game::Game(const char* saveFilePath, int storyNum) {
 	// データを世界に反映
 	m_gameData->asignWorld(m_world, true);
 
+	m_world->cameraPointInit();
+
 	// スキル
 	m_skill = nullptr;
 

--- a/Game.h
+++ b/Game.h
@@ -361,6 +361,9 @@ public:
 
 	// セーブデータをロード（前のセーブポイントへ戻る）
 	void backPrevSave();
+
+	// 描画していいならtrue
+	bool ableDraw();
 };
 
 #endif

--- a/Game.h
+++ b/Game.h
@@ -211,9 +211,10 @@ public:
 	const int NOTICE_SAVE_DONE_TIME = 300;
 
 	// セーブとロード
-	bool save();
+	bool save(bool force = false);
 	bool load();
 	bool saveChapter();
+	bool loadChapter(int storyNum);
 	// 全セーブデータ共通
 	bool saveCommon(int soundVolume, int gameWide, int gameHeight);
 	bool loadCommon(int* soundVolume, int* gameWide, int* gameHeight);
@@ -249,6 +250,9 @@ public:
 
 	// ストーリーが進んだ時にセーブデータを更新する
 	void updateStory(Story* story);
+
+	// 世界のやり直し
+	void resetWorld();
 
 };
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -96,7 +96,9 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 				SetMouseDispFlag(MOUSE_DISP);//マウス表示
 				title = new Title();
 			}
-			else{ gameDrawer->draw(); }
+			else if(game->ableDraw()){ 
+				gameDrawer->draw();
+			}
 		}
 		else {
 			Title::TITLE_RESULT result = title->play();

--- a/Main.cpp
+++ b/Main.cpp
@@ -44,9 +44,7 @@ void Wait() {
 int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	SetWindowSizeChangeEnableFlag(TRUE);//windowサイズ変更可能
 	SetUseDirectInputFlag(TRUE);
-	GameData* gameData = new GameData();
 	SetGraphMode(GAME_WIDE, GAME_HEIGHT, GAME_COLOR_BIT_NUM);
-	delete gameData;
 
 	ChangeWindowMode(WINDOW), DxLib_Init(), SetDrawScreen(DX_SCREEN_BACK);
 	

--- a/Story.cpp
+++ b/Story.cpp
@@ -20,6 +20,10 @@ Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer, EventData* ev
 	m_characterLoader = new CharacterLoader;
 	m_objectLoader = new ObjectLoader;
 
+	m_date = 0;
+	m_version = 0;
+	m_initDark = false;
+
 	// story››.csv‚ğƒ[ƒh
 	ostringstream oss;
 	oss << "data/story/story" << storyNum << ".csv";
@@ -101,9 +105,16 @@ void Story::loadCsvData(const char* fileName, World* world, SoundPlayer* soundPl
 			loadCsvData(oss.str().c_str(), world, soundPlayer);
 		}
 	}
+
+	// Story‚Ì‰Šúó‘Ô
+	vector<map<string, string> > initData = csvReader2.getDomainData("INIT:");
+	if (initData.size() > 0) {
+		m_initDark = (bool)stoi(initData[0]["dark"]);
+	}
 }
 
 bool Story::play() {
+	m_initDark = false;
 	if (m_nowEvent == nullptr) {
 		// •’Ê‚É¢ŠE‚ğ“®‚©‚·
 		m_world_p->battle();

--- a/Story.cpp
+++ b/Story.cpp
@@ -22,6 +22,7 @@ Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer, EventData* ev
 
 	m_date = 0;
 	m_version = 0;
+	m_resetWorld = false;
 	m_initDark = false;
 
 	// story››.csv‚ğƒ[ƒh
@@ -110,6 +111,7 @@ void Story::loadCsvData(const char* fileName, World* world, SoundPlayer* soundPl
 	vector<map<string, string> > initData = csvReader2.getDomainData("INIT:");
 	if (initData.size() > 0) {
 		m_initDark = (bool)stoi(initData[0]["dark"]);
+		m_resetWorld = (bool)stoi(initData[0]["resetWorld"]);
 	}
 }
 

--- a/Story.h
+++ b/Story.h
@@ -30,6 +30,9 @@ private:
 	// Storyを画面暗転の状態からスタートならtrue
 	bool m_initDark;
 
+	// 世界のドアデータを全削除
+	bool m_resetWorld;
+
 	// 進行中のイベント
 	Event* m_nowEvent;
 	
@@ -69,6 +72,7 @@ public:
 	inline int getStoryNum() const { return m_storyNum; }
 	inline int getDate() const { return m_date; }
 	inline int getVersion() const { return m_version; }
+	inline bool getResetWorld() const { return m_resetWorld; }
 	inline bool getInitDark() const { return m_initDark; }
 	inline CharacterLoader* getCharacterLoader() const { return m_characterLoader; }
 	inline ObjectLoader* getObjectLoader() const { return m_objectLoader; }

--- a/Story.h
+++ b/Story.h
@@ -27,6 +27,9 @@ private:
 	// Emote Onlineのversion
 	int m_version;
 
+	// Storyを画面暗転の状態からスタートならtrue
+	bool m_initDark;
+
 	// 進行中のイベント
 	Event* m_nowEvent;
 	
@@ -66,6 +69,7 @@ public:
 	inline int getStoryNum() const { return m_storyNum; }
 	inline int getDate() const { return m_date; }
 	inline int getVersion() const { return m_version; }
+	inline bool getInitDark() const { return m_initDark; }
 	inline CharacterLoader* getCharacterLoader() const { return m_characterLoader; }
 	inline ObjectLoader* getObjectLoader() const { return m_objectLoader; }
 	inline const World* getWorld() const { return m_world_p; }

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -3,6 +3,7 @@
 #include "GraphHandle.h"
 #include "Animation.h"
 #include "AnimationDrawer.h"
+#include "DrawTool.h"
 #include "Define.h"
 #include "DxLib.h"
 #include <string>
@@ -117,19 +118,8 @@ void ConversationDrawer::draw() {
 		}
 	}
 
-	int skipCnt = m_conversation->getSkipCnt();
-	static const int SKIP_WIDE = 600;
-	static const int SKIP_HEIGHT = 100;
-	if (skipCnt > 0) {
-		int x2 = GAME_WIDE - 10;
-		int x1 = x2 - (int)(SKIP_WIDE * m_exX);
-		int x15 = (int)(x1 + skipCnt * (SKIP_WIDE / 60) * m_exX);
-		int y1 = 10;
-		int y2 = y1 + (int)(SKIP_HEIGHT * m_exY);
-		DrawBox(x1, y1, x15, y2, BLACK, TRUE);
-		DrawBox(x15, y1, x2, y2, GRAY, TRUE);
-		DrawStringToHandle(x1 + 5, y1 + 5, "Ｚキー長押しでスキップ", WHITE, m_textHandle);
-	}
+	// Zキー長押しでスキップの表示
+	drawSkip(m_conversation->getSkipCnt(), m_exX, m_exY, m_textHandle);
 	
 	// 画面右下のクリック要求アイコン
 	bool textFinish = m_conversation->finishText() && m_conversation->getFinishCnt() == 0 && m_conversation->getStartCnt() == 0 && m_conversation->nextTextAble();

--- a/World.cpp
+++ b/World.cpp
@@ -733,8 +733,8 @@ void World::updateCamera() {
 			if (dx < MAX_DISABLE) {
 				max_dx = max(max_dx, dx);
 				int y = m_characters[i]->getY();
-				if (m_camera->getY() < y) { y += m_characters[i]->getHeight() * 2; }
-				else { y -= m_characters[i]->getHeight(); }
+				if (m_camera->getY() < y) { y += m_characters[i]->getHeight() * 3 / 2; }
+				else { y -= m_characters[i]->getHeight() / 2; }
 				max_dy = max(max_dy, abs(m_camera->getY() - y));
 			}
 		}

--- a/World.cpp
+++ b/World.cpp
@@ -667,11 +667,9 @@ void World::battle() {
 	if (!m_soundPlayer_p->checkBGMplay()) {
 		m_soundPlayer_p->playBGM();
 	}
-	// 画面暗転中 エリア移動かプレイヤーやられ時
-	if (m_brightValue != 255 || playerDead()) {
-		m_brightValue = max(0, m_brightValue - 10);
-		if (!playerDead()) { return; }
-	}
+	
+	// 画面暗転処理
+	if (dealBrightValue()) { return; }
 
 	// オブジェクトを調べた時のテキスト
 	if (m_objectConversation != nullptr) {
@@ -1068,6 +1066,15 @@ bool World::moveGoalCharacter() {
 	updateAnimation();
 
 	return allCharacterAlreadyGoal;
+}
+
+bool World::dealBrightValue() {
+	// 画面暗転中 エリア移動かプレイヤーやられ時
+	if (m_brightValue != 255 || playerDead()) {
+		m_brightValue = max(0, m_brightValue - 10);
+		if (!playerDead()) { return true; }
+	}
+	return false;
 }
 
 // 会話させる

--- a/World.cpp
+++ b/World.cpp
@@ -81,6 +81,10 @@ World::World() {
 
 	m_brightValue = 255;
 
+	m_resetBgmFlag = false;
+
+	m_blindFlag = false;
+
 	// 会話イベント
 	m_conversation_p = nullptr;
 	m_objectConversation = nullptr;

--- a/World.h
+++ b/World.h
@@ -232,6 +232,9 @@ public:
 	// データ管理：プレイヤーをドアの前まで移動
 	void setPlayerOnDoor(int from);
 
+	// データ管理：カメラの位置をリセット
+	void cameraPointInit();
+
 	// プレイヤーを特定の座標へ移動
 	void setPlayerPoint(CharacterData* characterData);
 
@@ -254,9 +257,6 @@ public:
 	void moviePlay();
 
 private:
-
-	// データ管理：カメラの位置をリセット
-	void cameraPointInit();
 
 	// データ管理：キャラのセーブデータを自身に反映させる
 	void asignedCharacter(Character* character, CharacterData* data, bool changePosition);

--- a/World.h
+++ b/World.h
@@ -179,7 +179,7 @@ public:
 	inline void setBlindFlag(bool blindFlag) { m_blindFlag = blindFlag; }
 
 	// 強制的にエリア移動
-	inline void moveArea(int nextArea) { m_brightValue = 0; m_nextAreaNum = nextArea; m_resetBgmFlag = true; }
+	inline void moveArea(int nextArea) { m_brightValue--; m_nextAreaNum = nextArea; m_resetBgmFlag = true; }
 
 	// ID指定でBrain変更
 	void setBrainWithId(int id, Brain* brain);
@@ -243,6 +243,9 @@ public:
 
 	// 各キャラが目標地点へ移動するだけ
 	bool moveGoalCharacter();
+
+	// 画面が暗転するだけ キャラが動けない期間ならtrue
+	bool dealBrightValue();
 
 	// キャラに会話させる
 	void talk();

--- a/World.h
+++ b/World.h
@@ -57,9 +57,15 @@ private:
 	// プレイヤー（ハート）のID
 	int m_playerId;
 
-	// いま世界のどのエリアにいるか（メモリ節約のためプレイヤーの付近のみを読み込む）
+	// いま世界のどのエリアにいるか
 	int m_areaNum;
 	int m_nextAreaNum;
+
+	// エリア移動時にBGMをいったん止めるならtrue
+	bool m_resetBgmFlag;
+
+	// 描画するかどうか(動画とテキストは除く)
+	bool m_blindFlag;
 
 	// 時間帯 0は昼、1は夕方、2は夜
 	int m_date;
@@ -127,6 +133,8 @@ public:
 	inline int getAreaNum() const { return m_areaNum; }
 	inline int getNextAreaNum() const { return m_nextAreaNum; }
 	inline int getDate() const { return m_date; }
+	inline bool getResetBgmFlag() const { return m_resetBgmFlag; }
+	inline bool getBlindFlag() const { return m_blindFlag; }
 	inline const Camera* getCamera() const { return m_camera; }
 	std::vector<CharacterController*> getCharacterControllers() const { return m_characterControllers; }
 	std::vector<Character*> getCharacters() const { return m_characters; }
@@ -168,6 +176,10 @@ public:
 	inline void setMovie(Movie* movie) { m_movie_p = movie; }
 	inline void setAreaLock(bool lock) { m_areaLock = lock; }
 	inline void setDate(int date) { m_date = date; }
+	inline void setBlindFlag(bool blindFlag) { m_blindFlag = blindFlag; }
+
+	// 強制的にエリア移動
+	inline void moveArea(int nextArea) { m_brightValue = 0; m_nextAreaNum = nextArea; m_resetBgmFlag = true; }
 
 	// ID指定でBrain変更
 	void setBrainWithId(int id, Brain* brain);

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -107,7 +107,7 @@ void WorldDrawer::draw() {
 		}
 	}
 
-	if (movie == nullptr && conversation == nullptr) {
+	if (!m_world->getBlindFlag() && movie == nullptr && conversation == nullptr) {
 		// ターゲット
 		m_targetDrawer.setEx(camera->getEx());
 		m_targetDrawer.draw();

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -70,12 +70,55 @@ WorldDrawer::~WorldDrawer() {
 	DeleteGraph(m_nightHaikei);
 }
 
+
 // 描画する
 void WorldDrawer::draw() {
 	
 	int bright = m_world->getBrightValue();
 	SetDrawBright(bright, bright, bright);
 
+	// カメラを取得
+	const Camera* camera = m_world->getCamera();
+
+	// 戦場
+	if (!m_world->getBlindFlag()) {
+		drawBattleField(camera, bright);
+	}
+
+	// ムービー
+	Movie* movie = m_world->getMovie();
+	if (movie != nullptr) {
+		DrawBox(0, 0, GAME_WIDE, GAME_HEIGHT, BLACK, TRUE);
+		movie->draw();
+	}
+
+	// テキストイベント
+	const Conversation* conversation = m_world->getConversation();
+	if (conversation != nullptr) {
+		m_conversationDrawer->setConversation(conversation);
+		m_conversationDrawer->draw();
+	}
+	else {
+		// StageObjectを調べた際のテキストイベント
+		conversation = m_world->getObjectConversation();
+		if (conversation != nullptr) {
+			m_conversationDrawer->setConversation(conversation);
+			m_conversationDrawer->draw();
+		}
+	}
+
+	if (movie == nullptr && conversation == nullptr) {
+		// ターゲット
+		m_targetDrawer.setEx(camera->getEx());
+		m_targetDrawer.draw();
+	}
+
+	SetDrawBright(255, 255, 255);
+}
+
+
+// 戦場の描画
+void WorldDrawer::drawBattleField(const Camera* camera, int bright) {
 	// 背景
 	int groundGraph = m_world->getBackGroundGraph();
 	if (groundGraph != -1) {
@@ -106,9 +149,6 @@ void WorldDrawer::draw() {
 			break;
 		}
 	}
-
-	// カメラを取得
-	const Camera* camera = m_world->getCamera();
 
 	// 各Objectを描画
 	vector<const Object*> objects = m_world->getBackObjects();
@@ -161,34 +201,4 @@ void WorldDrawer::draw() {
 			m_characterDrawer->drawPlayerHpBar(m_world->getCharacters()[i], m_hpBarGraph);
 		}
 	}
-
-	// ムービー
-	Movie* movie = m_world->getMovie();
-	if (movie != nullptr) {
-		DrawBox(0, 0, GAME_WIDE, GAME_HEIGHT, BLACK, TRUE);
-		movie->draw();
-	}
-
-	// テキストイベント
-	const Conversation* conversation = m_world->getConversation();
-	if (conversation != nullptr) {
-		m_conversationDrawer->setConversation(conversation);
-		m_conversationDrawer->draw();
-	}
-	else {
-		// StageObjectを調べた際のテキストイベント
-		conversation = m_world->getObjectConversation();
-		if (conversation != nullptr) {
-			m_conversationDrawer->setConversation(conversation);
-			m_conversationDrawer->draw();
-		}
-	}
-
-	if (movie == nullptr && conversation == nullptr) {
-		// ターゲット
-		m_targetDrawer.setEx(camera->getEx());
-		m_targetDrawer.draw();
-	}
-
-	SetDrawBright(255, 255, 255);
 }

--- a/WorldDrawer.h
+++ b/WorldDrawer.h
@@ -2,6 +2,7 @@
 #define WORLD_DRAWER_H_INCLUDED
 
 class World;
+class Camera;
 class CharacterDrawer;
 class ObjectDrawer;
 class AnimationDrawer;
@@ -72,6 +73,10 @@ public:
 
 	// •`‰æ‚·‚é
 	void draw();
+
+private:
+
+	void drawBattleField(const Camera* camera, int bright);
 };
 
 #endif


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
世界をやり直すとき、主人公はarea1にワープする。しかしそのときイベントをはさむことで、ワープしているのではなく世界をやり直しているように見せたい。

課題は以下 (areaX -> area1へワープする際、その前後で一瞬世界の画面が見えてしまう)
- やり直しスタートのイベントを挟む直前（画面が切り替わる直前）にarea1の画面が一瞬見えてしまう。
- 第一章の終わりに、OPが流れた後area1にワープさせる際、一瞬移動前のエリアの画面が見えてしまう。

# やったこと
- story.csvにINITドメインを追加。Storyの開始時に画面を暗転した状態から始めるかどうかを指定できる。
  - 暗転した状態から始めるなら(`dark=1`)、BGMもストップした状態から始める。
  - `resetWorld=1`ならキャラID、areaNumを`-1`にする。また、ドアデータを全削除する。
- エリア強制移動イベントを追加。
  - area1にワープさせる用。
  - 移動先のエリアのBGMはいったんストップさせる。そのため、Talkイベント等でBGMを再生させないと無音のまま。
- BlindWorldイベントを追加。
  - このイベントでWorld::m_blindFlagをtrueにすると、動画とテキストイベントを除く世界の描画が行われなくなる。
  - OPが流れた後area1にワープさせる際、一瞬世界の画面が見えてしまうのを防ぐため、OPイベントの前に挿入する。

## その他
- ムービーのスキップ機能実装
- カメラの初期位置バグ修正

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
