### PR TITLE
Api: BGMの再生バグ修正&カメラの改善

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -104,6 +104,7 @@ void Movie::play() {
 	if (m_cnt == 0) {
 		// ‰¹ŠyŠJŽn
 		m_soundPlayer_p->setBGM(m_bgmPath.c_str());
+		m_soundPlayer_p->playBGM();
 		m_soundPlayer_p->clearSoundQueue();
 	}
 

--- a/Camera.cpp
+++ b/Camera.cpp
@@ -21,6 +21,7 @@ Camera::Camera(int x, int y, double ex, int speed) {
 	m_centerY = GAME_HEIGHT / 2;
 	m_shakingWidth = 0;
 	m_shakingTime = 0;
+	m_zoomOutMode = false;
 }
 
 Camera::Camera(const Camera* original) {
@@ -35,6 +36,7 @@ Camera::Camera(const Camera* original) {
 	m_centerY = GAME_HEIGHT / 2;
 	m_shakingWidth = original->getShakingWidth();
 	m_shakingTime = original->getShakingTime();
+	m_zoomOutMode = original->getZoomOutMode();
 }
 
 // カメラの移動 目標地点が近いほど鈍感になる

--- a/Camera.h
+++ b/Camera.h
@@ -29,6 +29,9 @@ private:
 	// 揺れる残り時間
 	int m_shakingTime;
 
+	// trueなら常にカメラ最低倍率
+	bool m_zoomOutMode;
+
 public:
 	Camera();
 	Camera(int x, int y, double ex, int speed=0);
@@ -45,6 +48,7 @@ public:
 	inline int getMaxSpeed() const { return m_maxSpeed; }
 	inline int getShakingWidth() const { return m_shakingWidth; }
 	inline int getShakingTime() const { return m_shakingTime; }
+	inline int getZoomOutMode() const { return m_zoomOutMode; }
 
 	// セッタ
 	inline void setPoint(int x, int y) { m_x = x; m_y = y; }
@@ -55,6 +59,7 @@ public:
 	inline void setGy(int y) { m_gy = y; }
 	inline void setSpeed(int speed) { m_speed = speed; }
 	inline void setEx(double ex) { m_ex = ex; }
+	inline void setZoomOutMode(bool zoomOutMode) { m_zoomOutMode = zoomOutMode; }
 
 	// カメラの動き
 	void move();

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 12;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = true;
+const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 13;
 

--- a/Sound.cpp
+++ b/Sound.cpp
@@ -47,19 +47,20 @@ void SoundPlayer::setVolume(int volume) {
 }
 
 // BGMをセット（変更）
-void SoundPlayer::setBGM(std::string bgmName, int volume) {
+void SoundPlayer::setBGM(std::string bgmName) {
 	if (bgmName == m_bgmName || bgmName == "" || bgmName == "null") { return; }
 	DeleteSoundMem(m_bgmHandle);
 	m_bgmName = bgmName;
 	m_bgmHandle = LoadSoundMem(bgmName.c_str());
 	// 音量調整
-	changeSoundVolume(m_volume * volume / 100, m_bgmHandle);
-	playBGM();
+	changeSoundVolume(m_volume, m_bgmHandle);
 }
 
 // BGMを再生
 void SoundPlayer::playBGM() {
-	PlaySoundMem(m_bgmHandle, DX_PLAYTYPE_LOOP, FALSE);
+	if (!checkBGMplay()) {
+		PlaySoundMem(m_bgmHandle, DX_PLAYTYPE_LOOP, FALSE);
+	}
 }
 
 // BGMをストップ

--- a/Sound.h
+++ b/Sound.h
@@ -38,7 +38,7 @@ public:
 	inline void setCameraX(int cameraX) { m_cameraX = cameraX; }
 
 	// BGMをセット（変更）
-	void setBGM(std::string bgmName, int volume = 100);
+	void setBGM(std::string bgmName);
 
 	// 今流している音楽をチェックする
 	inline bool sameBGM(std::string bgmName) const { return m_bgmName == bgmName; }

--- a/Text.cpp
+++ b/Text.cpp
@@ -159,6 +159,7 @@ Conversation::~Conversation() {
 	if (m_eventAnime != nullptr) { delete m_eventAnime; }
 	// BGMを戻す
 	m_soundPlayer_p->setBGM(m_originalBgmPath);
+	m_soundPlayer_p->playBGM();
 	// クリックエフェクト削除
 	delete m_clickGraph;
 	for (unsigned i = 0; i < m_animations.size(); i++) {
@@ -373,6 +374,7 @@ void Conversation::loadNextBlock() {
 		string path = "sound/";
 		path += buff;
 		m_soundPlayer_p->setBGM(path);
+		m_soundPlayer_p->playBGM();
 		loadNextBlock();
 	}
 	else if (str == "@stopBGM") {
@@ -383,6 +385,7 @@ void Conversation::loadNextBlock() {
 	else if (str == "@resetBGM") {
 		// BGMを戻す
 		m_soundPlayer_p->setBGM(m_originalBgmPath);
+		m_soundPlayer_p->playBGM();
 		loadNextBlock();
 	}
 	else if (str == "@setWorldBGM") {

--- a/World.cpp
+++ b/World.cpp
@@ -757,9 +757,12 @@ void World::updateCamera() {
 	// 大きく変更する必要がある場合ほど、大きく拡大率を変更する。
 	double nowEx = m_camera->getEx();
 	int shift = controlLeftShift() + controlRightShift();
-	if (shift > 0) {
+	if (shift == 1) {
+		m_camera->setZoomOutMode(!m_camera->getZoomOutMode());
+	}
+	if (m_camera->getZoomOutMode()) {
 		if (nowEx > m_cameraMinEx) {
-			m_camera->setEx(max(nowEx - 0.01 * m_exX, 0.1));
+			m_camera->setEx(max(nowEx - 0.02 * m_exX, 0.1));
 		}
 	}
 	else {
@@ -1041,6 +1044,8 @@ void World::createBomb(int x, int y, Object* attackObject) {
 		m_attackObjects.push_back(bomb);
 		// 効果音
 		m_soundPlayer_p->pushSoundQueue(m_bombSound, adjustPanSound(x, m_camera->getX()));
+		// 画面の揺れ
+		m_camera->shakingStart(20, 20);
 	}
 }
 
@@ -1120,6 +1125,7 @@ bool World::dealBrightValue() {
 // 会話させる
 void World::talk() {
 	if (m_conversation_p != nullptr) {
+		updateCamera();
 		m_conversation_p->play();
 		// 会話終了
 		if (m_conversation_p->getFinishFlag()) {

--- a/World.cpp
+++ b/World.cpp
@@ -125,7 +125,7 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) :
 	m_camera = data.getCamera();
 	m_focusId = data.getFocusId();
 	m_playerId = data.getPlayerId();
-	m_soundPlayer_p->setBGM(data.getBgm(), data.getBgmVolume());
+	m_soundPlayer_p->setBGM(data.getBgm());
 	m_characters = data.getCharacters();
 	m_characterControllers = data.getCharacterControllers();
 	m_stageObjects = data.getObjects();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
以下を修正
- イベント中にBGMが重複して再生され、音が大きくなるバグ
- ２章の開始時に一瞬エリア１のBGMが流れるバグ

カメラの変更点
- カメラのズームアウト機能追加
- 爆発時に画面が揺れる
- 会話イベント中もupdateCamera()を実行

# やったこと
setBGMとplayBGMを分離

playBGMを修正

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
