### PR TITLE
Api: イベント12の作成

### DIFF
--- a/Brain.h
+++ b/Brain.h
@@ -140,7 +140,7 @@ public:
 	void debug(int x, int y, int color) const { }
 
 	// ƒZƒbƒ^
-	void setCharacterAction(const CharacterAction* characterAction) {  }
+	void setCharacterAction(const CharacterAction* characterAction) { m_characterAction_p = characterAction; }
 
 	bool actionOrder() { return false; }
 	void bulletTargetPoint(int& x, int& y) {  }

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -232,6 +232,13 @@ bool CharacterAction::ableWalk() const {
 	return !m_moveRight && !m_moveLeft && !m_squat;
 }
 
+bool CharacterAction::ableChangeDirection() const {
+	if (m_bulletCnt > 0 || m_slashCnt > 0 || m_moveLeft || m_moveRight || m_moveUp || m_moveDown || m_damageCnt > 0) {
+		return false;
+	}
+	return true;
+}
+
 // 着地
 void CharacterAction::setGrand(bool grand) {
 	if (m_vy > 0) { // 着地モーションになる

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -226,6 +226,9 @@ public:
 	// ¡•à‚¯‚éó‘Ô
 	virtual bool ableWalk() const;
 
+	// •ûŒü“]Š·‰Â”\
+	virtual bool ableChangeDirection() const;
+
 	// •à‚«n‚ß‚é
 	void startMoveLeft();
 	void startMoveRight();

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -209,6 +209,7 @@ void CharacterController::action() {
 // Brain‚ªFreeze‚È‚çƒvƒŒƒCƒ„[‚Ì•ûŒü‚ğŒü‚©‚¹‚é
 void CharacterController::setPlayerDirection(Character* player_p, bool all) {
 	if (m_brain->getBrainName() != "Freeze" && !all) { return; }
+	if (!m_characterAction->ableChangeDirection()) { return; }
 	m_characterAction->setCharacterLeftDirection(player_p->getCenterX() < m_characterAction->getCharacter()->getCenterX());
 }
 

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -121,7 +121,7 @@ public:
 	// ダメージ
 	virtual void damage(int vx, int vy, int damageValue) = 0;
 
-	// BrainがFreezeならプレイヤーの方向を向かせる allがtrueなら全キャラが対象
+	// BrainがFreezeならプレイヤーの方向を向かせる allがtrueならFreeze以外の全キャラが対象
 	void setPlayerDirection(Character* player_p, bool all = false);
 
 	// AIの目標地点を設定

--- a/Define.cpp
+++ b/Define.cpp
@@ -9,3 +9,13 @@ void getGameEx(double& exX, double& exY) {
 	exX = (double)GAME_WIDE / GAME_WIDE_DEFAULT;
 	exY = (double)GAME_HEIGHT / GAME_HEIGHT_DEFAULT;
 }
+
+// 解像度変更
+void ChangeGameResolution() {
+	SetGraphMode(GAME_WIDE, GAME_HEIGHT, GAME_COLOR_BIT_NUM);
+	InitGraph();
+	InitSoundMem();
+	InitFontToHandle();
+	ChangeWindowMode(WINDOW), DxLib_Init(), SetDrawScreen(DX_SCREEN_BACK);
+	SetMouseDispFlag(MOUSE_DISP); //マウス表示
+}

--- a/Define.h
+++ b/Define.h
@@ -1,10 +1,10 @@
 #ifndef DEFINE_H_INCLUDED
 #define DEFINE_H_INCLUDED
 
-#include"DxLib.h"
+#include "DxLib.h"
 
 // フルスクリーンならFALSE
-static int WINDOW = TRUE;
+static int WINDOW = FALSE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = TRUE;
 
@@ -20,6 +20,9 @@ extern int GAME_HEIGHT;
 
 // 解像度の倍率
 void getGameEx(double& exX, double& exY);
+
+// 解像度変更
+void ChangeGameResolution();
 
 #define GAME_COLOR_BIT_NUM 16
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -489,6 +489,7 @@ void ChangeCharacterDirectionEvent::setWorld(World* world) {
 DeadCharacterEvent::DeadCharacterEvent(World* world, std::vector<std::string> param) :
 	EventElement(world)
 {
+	m_param = param;
 	m_character_p = m_world_p->getCharacterWithName(param[1]);
 }
 EVENT_RESULT DeadCharacterEvent::play() {

--- a/Event.h
+++ b/Event.h
@@ -99,8 +99,11 @@ private:
 	// 前のセーブポイントへ戻る要求
 	bool m_backPrevSaveFlag;
 
+	// 世界のバージョン
+	int m_version;
+
 public:
-	Event(int eventNum, World* world, SoundPlayer* soundPlayer);
+	Event(int eventNum, World* world, SoundPlayer* soundPlayer, int version);
 	~Event();
 
 	// ゲッタ
@@ -242,7 +245,7 @@ public:
 
 };
 // キャラを無敵にする
-class InvincinbleEvent :
+class InvincibleEvent :
 	public EventElement
 {
 private:
@@ -257,7 +260,7 @@ private:
 	Character* m_character_p;
 
 public:
-	InvincinbleEvent(World* world, std::vector<std::string> param);
+	InvincibleEvent(World* world, std::vector<std::string> param);
 
 	// プレイ
 	EVENT_RESULT play();
@@ -582,6 +585,29 @@ private:
 
 public:
 	BlindWorldEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+};
+
+// キャラの追加
+class PushCharacterEvent :
+	public EventElement
+{
+private:
+
+	// 追加するキャラの情報
+	std::string m_name;
+	int m_x, m_y;
+	bool m_sound;
+	int m_groupId;
+	std::string m_action;
+	std::string m_brain;
+	std::string m_controller;
+	int m_version;
+
+public:
+	PushCharacterEvent(World* world, std::vector<std::string> param, int version);
 
 	// プレイ
 	EVENT_RESULT play();

--- a/Game.cpp
+++ b/Game.cpp
@@ -670,7 +670,7 @@ bool Game::play() {
 		m_gameoverCnt++;
 	}
 	// ƒGƒŠƒAˆÚ“®
-	if (m_world->getBrightValue() == 0 && CheckSoundMem(m_world->getDoorSound()) == 0) {
+	else if (m_world->getBrightValue() == 0 && CheckSoundMem(m_world->getDoorSound()) == 0) {
 		int fromAreaNum = m_world->getAreaNum();
 		int toAreaNum = m_world->getNextAreaNum();
 		m_gameData->asignedWorld(m_world, false);
@@ -682,7 +682,7 @@ bool Game::play() {
 		if(resetBgmFlag){ m_soundPlayer->stopBGM(); }
 		m_gameData->asignWorld(m_world);
 		m_world->setPlayerOnDoor(fromAreaNum);
-		m_story->setWorld(m_world);//
+		m_story->setWorld(m_world);
 		m_gameData->setAreaNum(toAreaNum);
 		return true;
 	}

--- a/Game.cpp
+++ b/Game.cpp
@@ -669,7 +669,6 @@ bool Game::play() {
 		// やられるのがイベントの成功条件なら前のif文(m_story->getBackPrevSaveFlag())にひっかかるはず
 		m_gameoverCnt++;
 	}
-
 	// エリア移動
 	if (m_world->getBrightValue() == 0 && CheckSoundMem(m_world->getDoorSound()) == 0) {
 		int fromAreaNum = m_world->getAreaNum();
@@ -683,7 +682,7 @@ bool Game::play() {
 		if(resetBgmFlag){ m_soundPlayer->stopBGM(); }
 		m_gameData->asignWorld(m_world);
 		m_world->setPlayerOnDoor(fromAreaNum);
-		m_story->setWorld(m_world);
+		m_story->setWorld(m_world);//
 		m_gameData->setAreaNum(toAreaNum);
 		return true;
 	}

--- a/Main.cpp
+++ b/Main.cpp
@@ -110,11 +110,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 			else if (result == Title::REBOOT) {
 				// ゲームを再起動
 				delete title;
-				InitGraph();
-				InitSoundMem();
-				InitFontToHandle();
-				ChangeWindowMode(WINDOW), DxLib_Init(), SetDrawScreen(DX_SCREEN_BACK);
-				SetMouseDispFlag(MOUSE_DISP);//マウス表示
+				ChangeGameResolution();
 				title = new Title();
 			}
 		}

--- a/Story.cpp
+++ b/Story.cpp
@@ -72,7 +72,7 @@ void Story::loadCsvData(const char* fileName, World* world, SoundPlayer* soundPl
 			}
 		}
 		if (eventNum != -1) {
-			Event* eventOne = new Event(eventNum, world, soundPlayer);
+			Event* eventOne = new Event(eventNum, world, soundPlayer, m_version);
 			if (mustFlag) { m_mustEvent.push_back(eventOne); }
 			else { m_subEvent.push_back(eventOne); }
 		}

--- a/Title.cpp
+++ b/Title.cpp
@@ -28,6 +28,7 @@ SelectSaveData::SelectSaveData() {
 		oss << "savedata/" << i + 1 << "/";
 		m_gameData[i] = new GameData(oss.str().c_str());
 	}
+	ChangeGameResolution();
 
 	// ボタン
 	double exX, exY;
@@ -170,6 +171,9 @@ void SelectSaveData::saveCommon(int soundVolume) {
 */
 Title::Title() {
 
+	// セーブデータ選択画面
+	m_selectSaveData = new SelectSaveData();
+
 	m_state = TITLE;
 
 	m_handX = 0; m_handY = 0;
@@ -177,9 +181,6 @@ Title::Title() {
 	m_soundPlayer = new SoundPlayer();
 
 	m_titleGraph = LoadGraph("picture/movie/op/title/titleBlue.png");
-
-	// セーブデータ選択画面
-	m_selectSaveData = new SelectSaveData();
 
 	// セーブデータがあるなら音量セット
 	if (m_selectSaveData->saveDataExist()) { 
@@ -264,11 +265,12 @@ Title::TITLE_RESULT Title::play() {
 		m_option->play();
 		// 戻るボタン
 		if (m_cancelButton->overlap(m_handX, m_handY) && leftClick() == 1) {
-			// 解像度を更新して再起動
+			// 解像度を更新
 			GAME_WIDE = m_option->getNewGameWide();
 			GAME_HEIGHT = m_option->getNewGameHeight();
+			// 解像度と音量をセーブ
 			m_selectSaveData->saveCommon(m_option->getNewSoundVolume());
-			SetGraphMode(GAME_WIDE, GAME_HEIGHT, GAME_COLOR_BIT_NUM);
+			// 再起動（解像度の適用）
 			return REBOOT;
 		}
 		break;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#166 の対応も必要

# やったこと
- ゲームオーバー時に落ちることがあるバグの修正
  - 実はゲームオーバー時にエリア移動が起きていた。それが原因
  - else文でエリア移動をするよう変更し、ゲームオーバー時にはエリア移動が起きないようにした
- イベントでFreezeに変更された時、コハルの射撃時の横移動が消えず移動し続けるバグを修正
  - Freeze時にプレイヤーの方向を向かせるため、それによって射撃終了時の処理が期待通りに行われていなかったのが原因
- タイトル画面の解像度バグ修正
  - セーブデータの解像度が変更されていると、それがグローバル変数には適用されるが解像度自体には適用されていないのが原因
- PushCharacterEventの追加
  - シエスタがエリアを移動してプレイヤーについてくるイベントを作るため。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
