### PR TITLE
UI: 画面外の敵の位置通知機能を追加

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -714,7 +714,6 @@ void OpMovie::draw() {
 		int alpha = min(255, m_cnt - 4350);
 		SetDrawBlendMode(DX_BLENDMODE_ALPHA, alpha);
 	}
-	SetDrawMode(DX_DRAWMODE_BILINEAR);
 	if (m_cnt < 3750 && m_cnt >= 3050) {
 		m_animationDrawer->setAnimation(m_orangeAnime);
 		m_animationDrawer->drawAnimation();
@@ -735,7 +734,6 @@ void OpMovie::draw() {
 		DrawBox(0, 0, GAME_WIDE, GAME_HEIGHT, BLACK, TRUE);
 	}
 	drawFlame();
-	SetDrawMode(DX_DRAWMODE_NEAREST);
 
 	// Zキー長押しでスキップの表示
 	drawSkip(m_skipCnt, m_exX, m_exY, m_textHandle);

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -6,6 +6,8 @@
 #include "Define.h"
 #include "DxLib.h"
 
+#include <cmath>
+
 
 // 体力バーを表示
 void drawHpBar(int x1, int y1, int x2, int y2, int hp, int prevHp, int maxHp, int damageColor, int prevHpColor, int hpColor) {
@@ -16,6 +18,20 @@ void drawHpBar(int x1, int y1, int x2, int y2, int hp, int prevHp, int maxHp, in
 	DrawBox(x1 + remain, y1, x1 + prev, y2, prevHpColor, TRUE);
 	DrawBox(x1 + prev, y1, x2, y2, damageColor, TRUE);
 }
+
+
+// 敵がいる方向の通知
+void drawEnemyNotice(int x, int y, double ex, int handle) {
+	int wide = 0, height = 0;
+	GetGraphSize(handle, &wide, &height);
+	wide = (int)(wide * ex);
+	height = (int)(height * ex);
+	int drawX = max(0 + wide, min(GAME_WIDE - wide, x));
+	int drawY = max(0 + wide, min(GAME_HEIGHT - wide, y));
+	double r = atan2(y - GAME_HEIGHT / 2, x - GAME_WIDE / 2);
+	DrawRotaGraph(drawX, drawY, ex, r, handle, TRUE);
+}
+
 
 int CharacterDrawer::HP_COLOR = GetColor(0, 255, 0);
 int CharacterDrawer::PREV_HP_COLOR = GetColor(255, 0, 0);
@@ -28,7 +44,7 @@ CharacterDrawer::CharacterDrawer(const CharacterAction* const characterAction) {
 }
 
 // キャラを描画する
-void CharacterDrawer::drawCharacter(const Camera* const camera, int bright) {
+void CharacterDrawer::drawCharacter(const Camera* const camera, int enemyNoticeHandle, int bright) {
 	// 描画するキャラクター
 	const Character* character = m_characterAction->getCharacter();
 
@@ -36,16 +52,24 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int bright) {
 	const GraphHandle* graphHandle = character->getGraphHandle();
 
 	// 座標と拡大率取得
-	int x, y;
+	int x1 = character->getX(), y1 = character->getY();
+	int wide = character->getWide(), height = character->getHeight();
 	double ex;
 	// 画像の中心を座標とする
-	x = character->getX() + (character->getWide() / 2);
-	y = character->getY() + (character->getHeight() / 2);
+	int x = x1 + wide / 2;
+	int y = y1 + height / 2;
 	// 画像固有の拡大率取得
 	ex = graphHandle->getEx();
 
 	// カメラで調整
 	camera->setCamera(&x, &y, &ex);
+
+	// 画面外
+	wide *= camera->getEx(); height *= camera->getEx();
+	if (x - wide / 2 > GAME_WIDE || y - height / 2 > GAME_HEIGHT || x + wide / 2 < 0 || y + height / 2 < 0) {
+		drawEnemyNotice(x, y, 0.5, enemyNoticeHandle);
+		return;
+	}
 
 	// 描画 ダメージ状態なら点滅
 	if (m_characterAction->getState() == CHARACTER_STATE::DAMAGE && ++m_cnt / 2 % 2 == 1) {

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -36,7 +36,7 @@ public:
 	// ƒZƒbƒ^
 	void setCharacterAction(const CharacterAction* action) { m_characterAction = action; }
 
-	void drawCharacter(const Camera* const camera, int bright = 255);
+	void drawCharacter(const Camera* const camera, int enemyNoticeHandle, int bright = 255);
 
 	void drawPlayerHpBar(const Character* player, int hpBarGraph);
 

--- a/Define.h
+++ b/Define.h
@@ -4,7 +4,7 @@
 #include "DxLib.h"
 
 // フルスクリーンならFALSE
-static int WINDOW = FALSE;
+static int WINDOW = TRUE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = TRUE;
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -58,8 +58,8 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	//SetMousePoint(320, 240);//マウスカーソルの初期位置
 	
 	// 画像の拡大処理方式
-	//SetDrawMode(DX_DRAWMODE_BILINEAR);
-	SetDrawMode(DX_DRAWMODE_NEAREST);
+	SetDrawMode(DX_DRAWMODE_BILINEAR);
+	//SetDrawMode(DX_DRAWMODE_NEAREST);
 	SetFullScreenScalingMode(DX_DRAWMODE_NEAREST);
 
 	// ゲーム本体

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -57,6 +57,7 @@ WorldDrawer::WorldDrawer(const World* world) {
 	m_noonHaikei = LoadGraph("picture/stageMaterial/noon.jpg");
 	m_eveningHaikei = LoadGraph("picture/stageMaterial/evening.jpg");
 	m_nightHaikei = LoadGraph("picture/stageMaterial/night.jpg");
+	m_enemyNotice = LoadGraph("picture/battleMaterial/enemyNotice.png");
 }
 
 WorldDrawer::~WorldDrawer() {
@@ -68,6 +69,7 @@ WorldDrawer::~WorldDrawer() {
 	DeleteGraph(m_noonHaikei);
 	DeleteGraph(m_eveningHaikei);
 	DeleteGraph(m_nightHaikei);
+	DeleteGraph(m_enemyNotice);
 }
 
 
@@ -163,14 +165,29 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright) {
 
 	// 各Actionを描画
 	vector<const CharacterAction*> actions = m_world->getActions();
+	int player = 0;
 	size = actions.size();
 	for (unsigned int i = 0; i < size; i++) {
-		// キャラをDrawerにセット
-		m_characterDrawer->setCharacterAction(actions[i]);
-
-		// カメラを使ってキャラを描画
-		m_characterDrawer->drawCharacter(camera, bright);
+		if (actions[i]->getCharacter()->getId() == m_world->getPlayerId()) {
+			player = i;
+		}
 	}
+	for (unsigned int i = 0; i < size; i++) {
+		if (i != player) {
+			// キャラをDrawerにセット
+			m_characterDrawer->setCharacterAction(actions[i]);
+			int enemyNotice = -1, groupId = actions[i]->getCharacter()->getGroupId();
+			// 中立と味方なら通知しない
+			if (groupId != -1 && groupId != actions[player]->getCharacter()->getGroupId()) {
+				enemyNotice = m_enemyNotice;
+			}
+			// カメラを使ってキャラを描画
+			m_characterDrawer->drawCharacter(camera, enemyNotice, bright);
+		}
+	}
+	// プレイヤーは手前に描画
+	m_characterDrawer->setCharacterAction(actions[player]);
+	m_characterDrawer->drawCharacter(camera, -1, bright);
 
 	// 各Objectを描画
 	objects = m_world->getFrontObjects();

--- a/WorldDrawer.h
+++ b/WorldDrawer.h
@@ -63,6 +63,8 @@ private:
 	// 会話イベント
 	ConversationDrawer* m_conversationDrawer;
 
+	int m_enemyNotice;
+
 public:
 	WorldDrawer(const World* world);
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
画面外に敵がいる場合、その通知を表示する。また、プレイヤーは全キャラの中で一番手前に描画するよう変更。

また、画質改善のため描画設定を変更した。

# やったこと
CharacterDrawerで通知を制御する。

WorldDrawerでプレイヤーの表示を他のキャラと分離する。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
