### PR TITLE
jumpOrderの修正

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -349,13 +349,14 @@ int NormalAI::jumpOrder() {
 	// ダメージを食らったらリセット
 	if (m_characterAction_p->getState() == CHARACTER_STATE::DAMAGE) {
 		m_jumpCnt = 0;
+		// 受け身
 		if (GetRand(120) == 0) { return 1; }
 	}
 
 	int maxJump = m_characterAction_p->getPreJumpMax();
 	int minJump = maxJump / 3;
 
-	if (m_jumpCnt == 0) {
+	if (m_characterAction_p->getPreJumpCnt() == -1) {
 		// ランダムでジャンプ
 		if (m_squatCnt == 0 && GetRand(99) == 0) { m_jumpCnt = GetRand(maxJump - minJump) + minJump; }
 

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -141,6 +141,7 @@ public:
 	bool getUpLock() const { return m_upLock; }
 	bool getDownLock() const { return m_downLock; }
 	const SoundPlayer* getSoundPlayer() const { return m_soundPlayer_p; }
+	inline int getPreJumpCnt() const { return m_preJumpCnt; }
 	virtual int getPreJumpMax() const { return PRE_JUMP_MAX; }
 
 	// ƒZƒbƒ^

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -65,7 +65,8 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int enemyNoticeH
 	camera->setCamera(&x, &y, &ex);
 
 	// ‰æ–ÊŠO
-	wide *= camera->getEx(); height *= camera->getEx();
+	wide = (int)(wide * camera->getEx());
+	height = (int)(height * camera->getEx());
 	if (x - wide / 2 > GAME_WIDE || y - height / 2 > GAME_HEIGHT || x + wide / 2 < 0 || y + height / 2 < 0) {
 		drawEnemyNotice(x, y, 0.5, enemyNoticeHandle);
 		return;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
CPUが壁をジャンプで乗り越えるとき、小ジャンプを繰り返して乗り越えられないことがある。

原因はNormalAI::jumpCntとCharacterAction::preJumpCntが連動しておらず、ジャンプ中にAI側は最大ジャンプの命令をしてしまう可能性があること。言い換えると、Action側はまだジャンプを溜められるのにBrain側は最大まで溜まったと判断しjump命令を終了することで、Action側は命令終了を受け小ジャンプをする。

# やったこと
Action側のpreJumpCntが-1 (ジャンプ準備中でない)ならBrain側はジャンプ命令を開始するよう変更。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [ ] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
