### PR TITLE
OPのmp4化

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -103,25 +103,18 @@ void Movie::play() {
 
 	if (m_cnt == 0) {
 		// 音楽開始
-		m_soundPlayer_p->setBGM(m_bgmPath.c_str());
-		m_soundPlayer_p->playBGM();
+		if (m_bgmPath != "") {
+			m_soundPlayer_p->setBGM(m_bgmPath.c_str());
+			m_soundPlayer_p->playBGM();
+		}
 		m_soundPlayer_p->clearSoundQueue();
 	}
 
 	m_cnt++;
 
 	// メイン画像
-	m_animation->count();
-
-	// サブ画像
-	unsigned int size = (unsigned int)m_subAnimation.size();
-	for (unsigned int i = 0; i < size; i++) {
-		Animation* subAnimation = m_subAnimation.front();
-		m_subAnimation.pop();
-		subAnimation->count();
-		if (!subAnimation->getFinishFlag()) {
-			m_subAnimation.push(subAnimation);
-		}
+	if (m_animation != nullptr) {
+		m_animation->count();
 	}
 
 	// Zキー長押しで終了
@@ -737,4 +730,40 @@ void OpMovie::draw() {
 
 	// Zキー長押しでスキップの表示
 	drawSkip(m_skipCnt, m_exX, m_exY, m_textHandle);
+}
+
+
+OpMovieMp4::OpMovieMp4(SoundPlayer* soundPlayer_p) :
+	Movie(soundPlayer_p)
+{
+	m_mp4 = LoadGraph("picture/movie/DuplicationHeartOp.mp4");
+	int volume = (int)(1000 * m_soundPlayer_p->getVolume() / 100.0);
+	SetMovieVolumeToGraph(9000, m_mp4);
+	PlayMovieToGraph(m_mp4);
+}
+OpMovieMp4::~OpMovieMp4() {
+	DeleteGraph(m_mp4);
+}
+
+// 再生
+void OpMovieMp4::play() {
+	Movie::play();
+	// 終了
+	if (GetMovieStateToGraph(m_mp4) != 1) {
+		m_finishFlag = true;
+	}
+}
+
+// 描画
+void OpMovieMp4::draw() {
+
+	DrawRotaGraph(GAME_WIDE / 2, GAME_HEIGHT / 2, m_ex, 0, m_mp4, TRUE);
+
+	drawFlame();
+
+	// Zキー長押しでスキップの表示
+	drawSkip(m_skipCnt, m_exX, m_exY, m_textHandle);
+
+	// 画面のちらつき防止
+	WaitTimer(15);
 }

--- a/Animation.h
+++ b/Animation.h
@@ -99,9 +99,6 @@ protected:
 	Animation* m_animation;
 	AnimationDrawer* m_animationDrawer;
 
-	// サブ画像 cntが0になったものはpopしていく
-	std::queue<Animation*> m_subAnimation;
-
 	// サウンドプレイヤー
 	SoundPlayer* m_soundPlayer_p;
 
@@ -119,7 +116,6 @@ public:
 	inline bool getFinishFlag() const { return m_finishFlag; }
 	inline bool getSkipCnt() const { return m_skipCnt; }
 	inline Animation* getAnimation() const { return m_animation; }
-	inline std::queue<Animation*> getSubAnimation() const { return m_subAnimation; }
 	inline int getCnt() const { return m_cnt; }
 
 	// 再生
@@ -268,5 +264,23 @@ private:
 	void pushPartOneCharacter(int index, bool front, GraphHandle* character);
 };
 
+// オープニング (mp4)
+class OpMovieMp4 :
+	public Movie
+{
+private:
+
+	int m_mp4;
+
+public:
+	OpMovieMp4(SoundPlayer* soundPlayer_p);
+	~OpMovieMp4();
+
+	// 再生
+	void play();
+
+	// 描画
+	void draw();
+};
 
 #endif

--- a/Event.cpp
+++ b/Event.cpp
@@ -576,7 +576,7 @@ MovieEvent::MovieEvent(World* world, SoundPlayer* soundPlayer, std::vector<std::
 	EventElement(world)
 {
 	if (param[1] == "op") {
-		m_movie = new OpMovie(soundPlayer);
+		m_movie = new OpMovieMp4(soundPlayer);
 	}
 }
 

--- a/Title.cpp
+++ b/Title.cpp
@@ -188,7 +188,7 @@ Title::Title() {
 		int s = m_selectSaveData->getLatestStoryNum();
 		if (s >= 9) {
 			// 初めてOPを見るのは9章なので、それ以降のセーブデータがあるならOP用意
-			m_movie = new OpMovie(m_soundPlayer);
+			m_movie = new OpMovieMp4(m_soundPlayer);
 		}
 	}
 	else {

--- a/Title.h
+++ b/Title.h
@@ -5,7 +5,7 @@
 class SoundPlayer;
 class Button;
 class TitleOption;
-class OpMovie;
+class Movie;
 class AnimationDrawer;
 class GameData;
 class ControlBar;
@@ -97,7 +97,7 @@ private:
 	TitleOption* m_option;
 
 	// OPムービー
-	OpMovie* m_movie;
+	Movie* m_movie;
 
 	// セーブデータ選択画面
 	SelectSaveData* m_selectSaveData;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

現状、音楽に合わせて画像を描画し動画を表現しているが、処理落ちや解像度変更によって挙動が変わり不安定である。

キャプチャし、mp4ファイルとして保存したものを再生することで挙動を安定化させる。

また、mp4ファイル１つをロードするだけになるので、ロード時間も短くなる。

参考：
- https://dxlib.xsrv.jp/dxfunc.html
- https://dxlib.xsrv.jp/cgi/patiobbs/patio.cgi?mode=past&no=2465

# やったこと
mp4ファイルを再生するOpMovieMp4クラスを作成。

以前のOpMovieクラスも念のため残す。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
高解像度で動画を再生すると、ところどころ画面がちらつく。でもWaitを長くするとそれはそれでおかしくなる。妥協。
