### PR TITLE
CsvReader2の不要な関数を削除

### DIFF
--- a/CsvReader.cpp
+++ b/CsvReader.cpp
@@ -170,35 +170,6 @@ CsvReader2::CsvReader2(const char* fileName) {
 }
 
 
-/*
-* ドメイン名がdomainNameのデータから、
-* カラム名がvalueのデータを取得
-* 例：findOne("name", "キャラ名");
-* 見つからなかったら空のデータを返す
-*/
-map<string, string> CsvReader2::findOne(const char* domainName, const char* columnName, const char* value) {
-
-	// m_data[i][columnName] == valueとなるiを調べる
-	map<string, string>::iterator ite;
-	for (int i = 0; i < m_data.size(); i++) {
-
-		// カラム名に対応する値を取得
-		ite = m_data[domainName][i].find(columnName);
-
-		// そのカラム名が存在しない
-		if (ite == m_data[domainName][i].end()) { continue; }
-
-		// 条件に一致
-		if (ite->second == value) {
-			return m_data[domainName][i];
-		}
-	}
-
-	// 空のデータを返す
-	map<string, string> res;
-	return res;
-}
-
 
 /*
 * area/area?.csvからキャラクターやオブジェクトをロードする

--- a/CsvReader.h
+++ b/CsvReader.h
@@ -57,13 +57,6 @@ public:
 	// ファイル名を指定してCSVファイルを読み込む
 	CsvReader2(const char* fileName);
 
-	/*
-	* ドメイン名がdomainNameのデータから、
-	* カラム名がvalueのデータを取得
-	* 例：findOne("Character", "Name", "キャラ名");
-	*/
-	std::map<std::string, std::string> findOne(const char* domainName, const char* columnName, const char* value);
-
 	std::vector<std::map<std::string, std::string> > getDomainData(const char* domainName) { return m_data[domainName]; }
 
 };


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

Calculatorリポジトリでバグに気づいた。for文の継続条件が間違っている。しかし、そもそもこの関数を使っていなかったので修正ではなく削除を行う。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
