### PR TITLE
キャラの当たり判定を改修

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -270,19 +270,6 @@ void Character::getHandleSize(int& wide, int& height) const {
 
 // “–‚½‚è”»’è‚Ì”ÍˆÍ‚ðŽæ“¾
 void Character::getAtariArea(int* x1, int* y1, int* x2, int* y2) const {
-	//const int wide = 100;
-	//const int height = 150;
-	//const int minusWide = (wide - m_graphHandle->getWide()) / 2;
-	//const int minusHeight = (height - m_graphHandle->getHeight()) / 2;
-	//*x2 = m_x + m_graphHandle->getWide() + minusWide;
-	//*y2 = m_y + m_graphHandle->getHeight() + minusHeight;
-	//*x1 = *x2 - wide;
-	//*y1 = *y2 - height;
-	//*x1 = m_x + 50;
-	//*y1 = m_y + 50;
-	//*x2 = m_x + 150;
-	//*y2 = m_y + 200;
-
 	m_graphHandle->getAtari(x1, y1, x2, y2);
 	*x1 = *x1 + m_x;
 	*y1 = *y1 + m_y;

--- a/Character.cpp
+++ b/Character.cpp
@@ -268,6 +268,22 @@ void Character::getHandleSize(int& wide, int& height) const {
 	height = getHeight();
 }
 
+// 当たり判定の範囲を取得
+void Character::getAtariArea(int* x1, int* y1, int* x2, int* y2) const {
+	const int wide = 100;
+	const int height = 150;
+	const int minusWide = (wide - m_graphHandle->getWide()) / 2;
+	const int minusHeight = (height - m_graphHandle->getHeight()) / 2;
+	*x2 = m_x + m_graphHandle->getWide() + minusWide;
+	*y2 = m_y + m_graphHandle->getHeight() + minusHeight;
+	*x1 = *x2 - wide;
+	*y1 = *y2 - height;
+	//*x1 = m_x + 50;
+	//*y1 = m_y + 50;
+	//*x2 = m_x + 150;
+	//*y2 = m_y + 200;
+}
+
 // Infoのバージョンを変更する
 void Character::changeInfoVersion(int version) {
 	m_version = version;

--- a/Character.cpp
+++ b/Character.cpp
@@ -255,7 +255,7 @@ void Character::setParam(Character* character) {
 	character->setHp(m_hp);
 	character->setPrevHp(m_prevHp);
 	character->setInvincible(m_invincible);
-	character->getCharacterGraphHandle()->setGraph(getGraphHandle());
+	character->getCharacterGraphHandle()->setGraph(m_graphHandle->getDispGraphHandle(), m_graphHandle->getDispGraphIndex());
 }
 
 GraphHandle* Character::getGraphHandle() const {
@@ -270,18 +270,24 @@ void Character::getHandleSize(int& wide, int& height) const {
 
 // 当たり判定の範囲を取得
 void Character::getAtariArea(int* x1, int* y1, int* x2, int* y2) const {
-	const int wide = 100;
-	const int height = 150;
-	const int minusWide = (wide - m_graphHandle->getWide()) / 2;
-	const int minusHeight = (height - m_graphHandle->getHeight()) / 2;
-	*x2 = m_x + m_graphHandle->getWide() + minusWide;
-	*y2 = m_y + m_graphHandle->getHeight() + minusHeight;
-	*x1 = *x2 - wide;
-	*y1 = *y2 - height;
+	//const int wide = 100;
+	//const int height = 150;
+	//const int minusWide = (wide - m_graphHandle->getWide()) / 2;
+	//const int minusHeight = (height - m_graphHandle->getHeight()) / 2;
+	//*x2 = m_x + m_graphHandle->getWide() + minusWide;
+	//*y2 = m_y + m_graphHandle->getHeight() + minusHeight;
+	//*x1 = *x2 - wide;
+	//*y1 = *y2 - height;
 	//*x1 = m_x + 50;
 	//*y1 = m_y + 50;
 	//*x2 = m_x + 150;
 	//*y2 = m_y + 200;
+
+	m_graphHandle->getAtari(x1, y1, x2, y2);
+	*x1 = *x1 + m_x;
+	*y1 = *y1 + m_y;
+	*x2 = *x2 + m_x;
+	*y2 = *y2 + m_y;
 }
 
 // Infoのバージョンを変更する
@@ -430,7 +436,7 @@ Character* Heart::createCopy() {
 // 走り画像をセット
 void Heart::switchRun(int cnt) { 
 	if (m_graphHandle->getRunHandle() == nullptr) { return; }
-	int index = (cnt / RUN_ANIME_SPEED) % (m_graphHandle->getRunHandle()->getSize());
+	int index = (cnt / RUN_ANIME_SPEED) % (m_graphHandle->getRunHandle()->getGraphHandles()->getSize());
 	m_graphHandle->switchRun(index);
 }
 
@@ -440,14 +446,14 @@ void Heart::switchRunBullet(int cnt) {
 		switchRun(cnt);
 		return;
 	}
-	int index = (cnt / RUN_ANIME_SPEED) % (m_graphHandle->getRunBulletHandle()->getSize());
+	int index = (cnt / RUN_ANIME_SPEED) % (m_graphHandle->getRunBulletHandle()->getGraphHandles()->getSize());
 	m_graphHandle->switchRunBullet(index);
 }
 
 // ジャンプ前画像をセット
 void Heart::switchPreJump(int cnt) { 
 	if (m_graphHandle->getPreJumpHandle() == nullptr) { return; }
-	int index = (cnt / RUN_PREJUMP_SPEED) % (m_graphHandle->getPreJumpHandle()->getSize());
+	int index = (cnt / RUN_PREJUMP_SPEED) % (m_graphHandle->getPreJumpHandle()->getGraphHandles()->getSize());
 	m_graphHandle->switchPreJump(index);
 }
 
@@ -457,7 +463,7 @@ Object* Heart::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
 	// 弾の作成
 	BulletObject* attackObject;
 	if (m_graphHandle->getBulletHandle() != nullptr) {
-		attackObject = new BulletObject(getCenterX(), getCenterY(), m_graphHandle->getBulletHandle()->getGraphHandle(), gx, gy, m_attackInfo);
+		attackObject = new BulletObject(getCenterX(), getCenterY(), m_graphHandle->getBulletHandle()->getGraphHandles()->getGraphHandle(), gx, gy, m_attackInfo);
 	}
 	else {
 		attackObject = new BulletObject(getCenterX(), getCenterY(), m_bulletColor, gx, gy, m_attackInfo);
@@ -494,18 +500,18 @@ Object* Heart::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer*
 	int index = 0;
 	int slashCountSum = m_attackInfo->slashCountSum() / 3 + 1;
 	SlashObject* attackObject = nullptr;
-	GraphHandles* slashHandles = m_graphHandle->getAirSlashEffectHandle();
+	GraphHandlesWithAtari* slashHandles = m_graphHandle->getAirSlashEffectHandle();
 	if (grand || slashHandles == nullptr) {
 		// 地上にいる、もしくは空中斬撃画像がないなら地上用の画像を使う
 		slashHandles = m_graphHandle->getSlashHandle();
 	}
 	// 攻撃の方向
-	slashHandles->setReverseX(m_leftDirection);
+	slashHandles->getGraphHandles()->setReverseX(m_leftDirection);
 	// cntが攻撃のタイミングならオブジェクト生成
 	if (cnt == m_attackInfo->slashCountSum()) {
 		index = 0;
 		attackObject = new SlashObject(centerX, centerY - height, x2, centerY + height,
-			slashHandles->getGraphHandle(index), slashCountSum, m_attackInfo);
+			slashHandles->getGraphHandles()->getGraphHandle(index), slashCountSum, m_attackInfo);
 		// 効果音
 		if (soundPlayer != nullptr) {
 			soundPlayer->pushSoundQueue(m_attackInfo->slashStartSoundHandle(),
@@ -516,12 +522,12 @@ Object* Heart::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer*
 	else if (cnt == m_attackInfo->slashCountSum() * 2 / 3) {
 		index = 1;
 		attackObject = new SlashObject(centerX, centerY - height, x2, centerY + height,
-			slashHandles->getGraphHandle(index), slashCountSum, m_attackInfo);
+			slashHandles->getGraphHandles()->getGraphHandle(index), slashCountSum, m_attackInfo);
 	}
 	else if (cnt == m_attackInfo->slashCountSum() / 3) {
 		index = 2;
 		attackObject = new SlashObject(centerX, centerY - height, x2, centerY + height,
-			slashHandles->getGraphHandle(index), slashCountSum, m_attackInfo);
+			slashHandles->getGraphHandles()->getGraphHandle(index), slashCountSum, m_attackInfo);
 	}
 	if (attackObject != nullptr) {
 		// 自滅防止
@@ -555,7 +561,7 @@ Character* Siesta::createCopy() {
 
 // 射撃攻撃をする
 Object* Siesta::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
-	ParabolaBullet *attackObject = new ParabolaBullet(getCenterX(), getCenterY(), m_graphHandle->getBulletHandle()->getGraphHandle(), gx, gy, m_attackInfo);
+	ParabolaBullet *attackObject = new ParabolaBullet(getCenterX(), getCenterY(), m_graphHandle->getBulletHandle()->getGraphHandles()->getGraphHandle(), gx, gy, m_attackInfo);
 	// 自滅防止
 	attackObject->setCharacterId(m_id);
 	// チームキル防止
@@ -590,7 +596,7 @@ Object* Siesta::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer
 	int index = 0;
 	int slashCountSum = m_attackInfo->slashCountSum() / 3 + 1;
 	SlashObject* attackObject = nullptr;
-	GraphHandles* slashHandles = m_graphHandle->getSlashHandle();
+	GraphHandles* slashHandles = m_graphHandle->getSlashHandle()->getGraphHandles();
 	// 攻撃の方向
 	slashHandles->setReverseX(m_leftDirection);
 	// cntが攻撃のタイミングならオブジェクト生成
@@ -647,7 +653,7 @@ Character* Hierarchy::createCopy() {
 
 // 射撃攻撃をする
 Object* Hierarchy::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
-	BulletObject* attackObject = new BulletObject(getCenterX(), getCenterY(), m_graphHandle->getBulletHandle()->getGraphHandle(), gx, gy, m_attackInfo);
+	BulletObject* attackObject = new BulletObject(getCenterX(), getCenterY(), m_graphHandle->getBulletHandle()->getGraphHandles()->getGraphHandle(), gx, gy, m_attackInfo);
 	// 自滅防止
 	attackObject->setCharacterId(m_id);
 	// チームキル防止
@@ -701,9 +707,9 @@ void Valkyria::switchPreJump(int cnt) {
 Object* Valkyria::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
 	// 攻撃範囲を決定
 	int attackWide, attackHeight;
-	GetGraphSize(m_graphHandle->getStandSlashHandle()->getHandle(0), &attackWide, &attackHeight);
-	attackWide = (int)(attackWide * m_graphHandle->getStandSlashHandle()->getGraphHandle()->getEx());
-	attackHeight = (int)(attackHeight * m_graphHandle->getStandSlashHandle()->getGraphHandle()->getEx());
+	GetGraphSize(m_graphHandle->getStandSlashHandle()->getGraphHandles()->getHandle(0), &attackWide, &attackHeight);
+	attackWide = (int)(attackWide * m_graphHandle->getStandSlashHandle()->getGraphHandles()->getGraphHandle()->getEx());
+	attackHeight = (int)(attackHeight * m_graphHandle->getStandSlashHandle()->getGraphHandles()->getGraphHandle()->getEx());
 	int x1 = m_x;
 	int x2 = m_x + attackWide;
 
@@ -712,7 +718,7 @@ Object* Valkyria::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlay
 	int index = 0;
 	int slashCountSum = m_attackInfo->slashCountSum() / 3 + 1;
 	SlashObject* attackObject = nullptr;
-	GraphHandles* slashHandles = m_graphHandle->getSlashHandle();
+	GraphHandles* slashHandles = m_graphHandle->getSlashHandle()->getGraphHandles();
 	// 攻撃の方向
 	slashHandles->setReverseX(m_leftDirection);
 	// キャラの身長
@@ -799,7 +805,7 @@ Character* Koharu::createCopy() {
 Object* Koharu::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
 	// バズーカの銃口から出るように見せる
 	gy = getY() + getHeight() - 160;
-	BulletObject* attackObject = new BulletObject(getCenterX(), gy, m_graphHandle->getBulletHandle()->getGraphHandle(), gx, gy, m_attackInfo);
+	BulletObject* attackObject = new BulletObject(getCenterX(), gy, m_graphHandle->getBulletHandle()->getGraphHandles()->getGraphHandle(), gx, gy, m_attackInfo);
 	// 自滅防止
 	attackObject->setCharacterId(m_id);
 	// チームキル防止

--- a/Character.h
+++ b/Character.h
@@ -296,6 +296,9 @@ public:
 	inline int getSlashCountSum() const { return m_attackInfo->slashCountSum(); }
 	inline int getSlashInterval() const { return m_attackInfo->slashInterval(); }
 
+	// 当たり判定の範囲を取得
+	void getAtariArea(int* x1, int* y1, int* x2, int* y2) const;
+
 	// Infoのバージョンを変更する
 	void changeInfoVersion(int version);
 

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -349,7 +349,7 @@ void CharacterAction::afterChangeGraph(int beforeX1, int afterX1, int beforeY1, 
 		dy = ((beforeY2 - afterY2) + (beforeY1 - afterY1)) / 2;
 	}
 
-	m_character_p->moveDown(dy + 1);
+	m_character_p->moveDown(dy);
 
 	int dx = 0;
 	if (m_rightLock) {

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -327,38 +327,52 @@ void CharacterAction::stopMoveDown() {
 }
 
 // 画像のサイズ変更による位置調整 (座標は画像の左上であることに注意)
-void CharacterAction::afterChangeGraph(int beforeWide, int beforeHeight, int afterWide, int afterHeight) {
-	if(afterHeight != beforeHeight) {
-		// 両方に広げる
-		int d = afterHeight - beforeHeight;
-		if (m_downLock) {
-			m_character_p->moveUp((d - 1) / 2);
-		}
-		else if (m_upLock) {
-			m_character_p->moveUp((d + 1) / 2);
+void CharacterAction::afterChangeGraph(int beforeX1, int afterX1, int beforeY1, int afterY1, int beforeX2, int afterX2, int beforeY2, int afterY2) {
+	int dy = 0;
+	if (m_downLock) {
+		if (afterY2 > beforeY2) {
+			dy -= afterY2 - beforeY2;
 		}
 		else {
-			m_character_p->moveUp((d) / 2);
+			dy += beforeY2 - afterY2;
 		}
+	}
+	else if (m_upLock) {
+		if (afterY1 < beforeY1) {
+			dy += beforeY1 - afterY1;
+		}
+		else {
+			dy -= afterY1 - beforeY1;
+		}
+	}
+	else {
+		dy = ((afterY2 - beforeY2) + (afterY1 - beforeY1)) / -2;
 	}
 
-	// 左右どっちにでも行ける、もしくはいけない
-	if(afterWide != beforeWide) {
-		// 両方に広げる
-		int d = afterWide - beforeWide;
-		if (m_grandLeftSlope || m_grandRightSlope) { 
-			m_character_p->moveLeft((d) / 2);
-		}
-		else if (m_rightLock) {
-			m_character_p->moveLeft((d - 1) / 2);
-		}
-		else if (m_leftLock) {
-			m_character_p->moveLeft((d + 1) / 2);
+	m_character_p->moveDown(dy + 1);
+
+	int dx = 0;
+	if (m_rightLock) {
+		if (afterX2 > beforeX2) {
+			dx -= afterX2 - beforeX2;
 		}
 		else {
-			m_character_p->moveLeft((d) / 2);
+			dx += beforeX2 - afterX2;
 		}
 	}
+	else if (m_leftLock) {
+		if (afterX1 < beforeX1) {
+			dx += beforeX1 - afterX1;
+		}
+		else {
+			dx -= afterX1 - beforeX1;
+		}
+	}
+	else {
+		dx = ((afterX2 - beforeX2) + (afterX1 - beforeX1)) / -2;
+	}
+
+	m_character_p->moveRight(dx);
 }
 
 
@@ -455,8 +469,8 @@ void StickAction::switchHandle() {
 	// セット前の画像のサイズ
 	int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
 	m_character_p->getAtariArea(&x1, &y1, &x2, &y2);
-	int wide = x2 - x1, height = y2 - y1;
-	m_character_p->getHandleSize(wide, height);
+	//int wide = x2 - x1, height = y2 - y1;
+	//m_character_p->getHandleSize(wide, height);
 	// やられ画像
 	if (m_grand && m_character_p->getHp() == 0 && m_character_p->haveDeadGraph() && getState() != CHARACTER_STATE::DAMAGE) {
 		m_character_p->switchDead();
@@ -558,12 +572,13 @@ void StickAction::switchHandle() {
 		}
 	}
 	// セット後の画像のサイズ
-	m_character_p->getAtariArea(&x1, &y1, &x2, &y2);
-	int afterWide = x2 - x1, afterHeight = y2 - y1;
-	m_character_p->getHandleSize(afterWide, afterHeight);
+	int afterX1 = 0, afterY1 = 0, afterX2 = 0, afterY2 = 0;
+	m_character_p->getAtariArea(&afterX1, &afterY1, &afterX2, &afterY2);
+	//int afterWide = x2 - x1, afterHeight = y2 - y1;
+	//m_character_p->getHandleSize(afterWide, afterHeight);
 
 	// サイズ変更による位置調整
-	afterChangeGraph(wide, height, afterWide, afterHeight);
+	afterChangeGraph(x1, afterX1, y1, afterY1, x2, afterX2, y2, afterY2);
 
 	m_character_p->setLeftDirection(m_character_p->getLeftDirection());
 }
@@ -828,8 +843,8 @@ CharacterAction* FlightAction::createCopy(std::vector<Character*> characters) {
 // キャラの画像を状態(state)に応じて変更
 void FlightAction::switchHandle() {
 	// セット前の画像のサイズ
-	int wide, height;
-	m_character_p->getHandleSize(wide, height);
+	int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+	m_character_p->getAtariArea(&x1, &y1, &x2, &y2);
 	if (m_grand) { // 地面にいるとき
 		switch (getState()) {
 		case CHARACTER_STATE::STAND: //立ち状態
@@ -878,11 +893,11 @@ void FlightAction::switchHandle() {
 		}
 	}
 	// セット後の画像のサイズ
-	int afterWide, afterHeight;
-	m_character_p->getHandleSize(afterWide, afterHeight);
+	int afterX1 = 0, afterY1 = 0, afterX2 = 0, afterY2 = 0;
+	m_character_p->getAtariArea(&afterX1, &afterY1, &afterX2, &afterY2);
 
 	// サイズ変更による位置調整
-	afterChangeGraph(wide, height, afterWide, afterHeight);
+	afterChangeGraph(x1, afterX1, y1, afterY1, x2, afterX2, y2, afterY2);
 
 	m_character_p->setLeftDirection(m_character_p->getLeftDirection());
 }

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -346,7 +346,10 @@ void CharacterAction::afterChangeGraph(int beforeWide, int beforeHeight, int aft
 	if(afterWide != beforeWide) {
 		// —¼•û‚ÉL‚°‚é
 		int d = afterWide - beforeWide;
-		if (m_rightLock) {
+		if (m_grandLeftSlope || m_grandRightSlope) { 
+			m_character_p->moveLeft((d) / 2);
+		}
+		else if (m_rightLock) {
 			m_character_p->moveLeft((d - 1) / 2);
 		}
 		else if (m_leftLock) {

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -328,55 +328,26 @@ void CharacterAction::stopMoveDown() {
 
 // 画像のサイズ変更による位置調整 (座標は画像の左上であることに注意)
 void CharacterAction::afterChangeGraph(int beforeWide, int beforeHeight, int afterWide, int afterHeight) {
-	// 下へ行けないなら
-	if (m_downLock) {
-		// 上へ動かす
-		m_character_p->moveUp((afterHeight - beforeHeight));
-	}
-	// 上へ行けないなら
-	else if (m_upLock) {
-		// 下へ動かす必要はない（画像が下方向に拡大されるから）
-	}
-	// 上下どっちにでも行ける
-	else {
-		// 両方に広げる
-		int d = afterHeight - beforeHeight;
-		if (d % 2 == 1) {
-			if (d < 0) {
-				m_character_p->moveUp((d - 1) / 2);
-			}
-			else {
-				m_character_p->moveUp((d + 1) / 2);
-			}
+	if(afterHeight != beforeHeight) {
+		// 下へ行けないなら
+		if (m_downLock) {
+			// 上へ動かす
+			m_character_p->moveUp((afterHeight - beforeHeight - 1) / 2);
 		}
 		else {
-			m_character_p->moveUp(d / 2);
+			m_character_p->moveUp((afterHeight - beforeHeight + 1) / 2);
 		}
 	}
 
-	// 右へ行けないなら
-	if (m_rightLock && !m_leftLock) {
-		// 左へ動かす
-		m_character_p->moveLeft((afterWide - beforeWide));
-	}
-	// 左へ行けないなら
-	else if (m_leftLock && !m_rightLock) {
-		// 右へ動かす必要はない（画像が右方向に拡大されるから）
-	}
 	// 左右どっちにでも行ける、もしくはいけない
-	else {
-		// 両方に広げる
-		int d = afterWide - beforeWide;
-		if (d % 2 == 1) {
-			if (d < 0) {
-				m_character_p->moveLeft((d - 1) / 2);
-			}
-			else {
-				m_character_p->moveLeft((d + 1) / 2);
-			}
+	if(afterWide != beforeWide) {
+		// 右へ行けないなら
+		if (m_rightLock && !m_leftLock) {
+			// 左へ動かす
+			m_character_p->moveLeft((afterWide - beforeWide - 1) / 2);
 		}
 		else {
-			m_character_p->moveLeft(d / 2);
+			m_character_p->moveLeft((afterWide - beforeWide + 1) / 2);
 		}
 	}
 }
@@ -473,7 +444,9 @@ void StickAction::action() {
 // 状態に応じて画像セット
 void StickAction::switchHandle() {
 	// セット前の画像のサイズ
-	int wide, height;
+	int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+	m_character_p->getAtariArea(&x1, &y1, &x2, &y2);
+	int wide = x2 - x1, height = y2 - y1;
 	m_character_p->getHandleSize(wide, height);
 	// やられ画像
 	if (m_grand && m_character_p->getHp() == 0 && m_character_p->haveDeadGraph() && getState() != CHARACTER_STATE::DAMAGE) {
@@ -576,7 +549,8 @@ void StickAction::switchHandle() {
 		}
 	}
 	// セット後の画像のサイズ
-	int afterWide, afterHeight;
+	m_character_p->getAtariArea(&x1, &y1, &x2, &y2);
+	int afterWide = x2 - x1, afterHeight = y2 - y1;
 	m_character_p->getHandleSize(afterWide, afterHeight);
 
 	// サイズ変更による位置調整

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -346,7 +346,7 @@ void CharacterAction::afterChangeGraph(int beforeX1, int afterX1, int beforeY1, 
 		}
 	}
 	else {
-		dy = ((afterY2 - beforeY2) + (afterY1 - beforeY1)) / -2;
+		dy = ((beforeY2 - afterY2) + (beforeY1 - afterY1)) / 2;
 	}
 
 	m_character_p->moveDown(dy + 1);
@@ -369,7 +369,7 @@ void CharacterAction::afterChangeGraph(int beforeX1, int afterX1, int beforeY1, 
 		}
 	}
 	else {
-		dx = ((afterX2 - beforeX2) + (afterX1 - beforeX1)) / -2;
+		dx = ((beforeX2 - afterX2) + (beforeX1 - afterX1)) / 2;
 	}
 
 	m_character_p->moveRight(dx);
@@ -469,8 +469,6 @@ void StickAction::switchHandle() {
 	// セット前の画像のサイズ
 	int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
 	m_character_p->getAtariArea(&x1, &y1, &x2, &y2);
-	//int wide = x2 - x1, height = y2 - y1;
-	//m_character_p->getHandleSize(wide, height);
 	// やられ画像
 	if (m_grand && m_character_p->getHp() == 0 && m_character_p->haveDeadGraph() && getState() != CHARACTER_STATE::DAMAGE) {
 		m_character_p->switchDead();
@@ -574,8 +572,6 @@ void StickAction::switchHandle() {
 	// セット後の画像のサイズ
 	int afterX1 = 0, afterY1 = 0, afterX2 = 0, afterY2 = 0;
 	m_character_p->getAtariArea(&afterX1, &afterY1, &afterX2, &afterY2);
-	//int afterWide = x2 - x1, afterHeight = y2 - y1;
-	//m_character_p->getHandleSize(afterWide, afterHeight);
 
 	// サイズ変更による位置調整
 	afterChangeGraph(x1, afterX1, y1, afterY1, x2, afterX2, y2, afterY2);

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -329,25 +329,31 @@ void CharacterAction::stopMoveDown() {
 // 画像のサイズ変更による位置調整 (座標は画像の左上であることに注意)
 void CharacterAction::afterChangeGraph(int beforeWide, int beforeHeight, int afterWide, int afterHeight) {
 	if(afterHeight != beforeHeight) {
-		// 下へ行けないなら
+		// 両方に広げる
+		int d = afterHeight - beforeHeight;
 		if (m_downLock) {
-			// 上へ動かす
-			m_character_p->moveUp((afterHeight - beforeHeight - 1) / 2);
+			m_character_p->moveUp((d - 1) / 2);
+		}
+		else if (m_upLock) {
+			m_character_p->moveUp((d + 1) / 2);
 		}
 		else {
-			m_character_p->moveUp((afterHeight - beforeHeight + 1) / 2);
+			m_character_p->moveUp((d) / 2);
 		}
 	}
 
 	// 左右どっちにでも行ける、もしくはいけない
 	if(afterWide != beforeWide) {
-		// 右へ行けないなら
-		if (m_rightLock && !m_leftLock) {
-			// 左へ動かす
-			m_character_p->moveLeft((afterWide - beforeWide - 1) / 2);
+		// 両方に広げる
+		int d = afterWide - beforeWide;
+		if (m_rightLock) {
+			m_character_p->moveLeft((d - 1) / 2);
+		}
+		else if (m_leftLock) {
+			m_character_p->moveLeft((d + 1) / 2);
 		}
 		else {
-			m_character_p->moveLeft((afterWide - beforeWide + 1) / 2);
+			m_character_p->moveLeft((d) / 2);
 		}
 	}
 }

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -244,7 +244,7 @@ public:
 
 protected:
 	// 画像のサイズ変更による位置調整
-	void afterChangeGraph(int beforeWide, int beforeHeight, int afterWide, int afterHeight);
+	void afterChangeGraph(int beforeX1, int afterX1, int beforeY1, int afterY1, int beforeX2, int afterX2, int beforeY2, int afterY2);
 };
 
 

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -38,9 +38,19 @@ int CharacterDrawer::PREV_HP_COLOR = GetColor(255, 0, 0);
 int CharacterDrawer::DAMAGE_COLOR = GetColor(0, 0, 0);
 
 CharacterDrawer::CharacterDrawer(const CharacterAction* const characterAction) {
-	m_characterAction = characterAction;
+	
 	m_cnt = 0;
 	getGameEx(m_exX, m_exY);
+
+	// デバッグ用
+	m_guideHandle = LoadGraph("picture/stick/atariGuide.png");
+	m_characterAction = characterAction;
+
+}
+
+CharacterDrawer::~CharacterDrawer() {
+	// デバッグ用
+	DeleteGraph(m_guideHandle);
 }
 
 // キャラを描画する
@@ -96,6 +106,14 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int enemyNoticeH
 		// 体力の描画
 		drawHpBar(x - wide, y - height, x + wide, y, character->getHp(), character->getPrevHp(), character->getMaxHp(), DAMAGE_COLOR, PREV_HP_COLOR, HP_COLOR);
 	}
+
+	// デバッグ用
+	int x2 = 0, y2 = 0;
+	character->getAtariArea(&x1, &y1, &x2, &y2);
+	camera->setCamera(&x1, &y1, &ex);
+	camera->setCamera(&x2, &y2, &ex);
+	DrawExtendGraph(x1, y1, x2, y2, m_guideHandle, TRUE);
+
 }
 
 void CharacterDrawer::drawPlayerHpBar(const Character* player, int hpBarGraph) {

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -108,11 +108,13 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int enemyNoticeH
 	}
 
 	// デバッグ用
-	int x2 = 0, y2 = 0;
-	character->getAtariArea(&x1, &y1, &x2, &y2);
-	camera->setCamera(&x1, &y1, &ex);
-	camera->setCamera(&x2, &y2, &ex);
-	DrawExtendGraph(x1, y1, x2, y2, m_guideHandle, TRUE);
+	if (ATARI_DEBUG) {
+		int x2 = 0, y2 = 0;
+		character->getAtariArea(&x1, &y1, &x2, &y2);
+		camera->setCamera(&x1, &y1, &ex);
+		camera->setCamera(&x2, &y2, &ex);
+		DrawExtendGraph(x1, y1, x2, y2, m_guideHandle, TRUE);
+	}
 
 }
 

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -13,6 +13,7 @@ class CharacterDrawer {
 private:
 
 	// デバッグ用
+	const bool ATARI_DEBUG = false;
 	int m_guideHandle;
 
 	// キャラの動きの情報 const関数しか呼ばない

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -12,6 +12,9 @@ void drawHpBar(int x1, int y1, int x2, int y2, int hp, int prevHp, int maxHp, in
 class CharacterDrawer {
 private:
 
+	// デバッグ用
+	int m_guideHandle;
+
 	// キャラの動きの情報 const関数しか呼ばない
 	const CharacterAction* m_characterAction;
 
@@ -32,6 +35,8 @@ private:
 public:
 
 	CharacterDrawer(const CharacterAction* const characterAction);
+
+	~CharacterDrawer();
 
 	// セッタ
 	void setCharacterAction(const CharacterAction* action) { m_characterAction = action; }

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -49,7 +49,7 @@ void World::debug(int x, int y, int color) const {
 		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "itemY=%d", m_itemVector[0]->getY());
 	}
 	//debugObjects(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, m_attackObjects);
-	//m_characterControllers[0]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
+	m_characterControllers[0]->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 3, color);
 	//if (m_movie_p != nullptr) {
 	//	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "Movie: cnt=%d", m_movie_p->getCnt());
 	//}

--- a/Define.h
+++ b/Define.h
@@ -4,7 +4,7 @@
 #include "DxLib.h"
 
 // フルスクリーンならFALSE
-static int WINDOW = FALSE;
+static int WINDOW = TRUE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = TRUE;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 12;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = false;
+const bool TEST_MODE = true;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 13;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 12;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = true;
+const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 13;
 

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -147,6 +147,76 @@ void GraphHandles::draw(int x, int y, int index) {
 
 
 /*
+* 当たり判定の情報付きのGraphHandles
+*/
+GraphHandlesWithAtari::GraphHandlesWithAtari(GraphHandles* graphHandles, const char* graphName, CsvReader* csvReader) {
+	m_graphHandles = graphHandles;
+	map<string, string> data = csvReader->findOne("name", graphName);
+
+	// 横
+	m_defaultWide = true;
+	m_wide = -1;
+	m_x1 = 0, m_x2 = 0;
+	if (!(bool)stoi(data["defaultWide"])) {
+		m_defaultWide = false;
+		m_wide = stoi(data["wide"]);
+		if (m_wide == -1) {
+			m_x1 = stoi(data["x1"]);
+			m_x2 = stoi(data["x2"]);
+		}
+	}
+
+	// 縦
+	m_defaultHeight = true;
+	m_height = -1;
+	m_y1 = 0, m_y2 = 0;
+	if (!(bool)stoi(data["defaultHeight"])) {
+		m_defaultHeight = false;
+		m_height = stoi(data["height"]);
+		if (m_height == -1) {
+			m_y1 = stoi(data["y1"]);
+			m_y2 = stoi(data["y2"]);
+		}
+	}
+}
+
+GraphHandlesWithAtari::~GraphHandlesWithAtari() {
+	delete m_graphHandles;
+}
+
+void GraphHandlesWithAtari::getAtari(int* x1, int* y1, int* x2, int* y2, int index) const {
+	int wide, height;
+	GetGraphSize(m_graphHandles->getHandle(index), &wide, &height);
+	// 横
+	if (m_defaultWide) {
+		*x1 = 0;
+		*x2 = wide;
+	}
+	else if (m_wide != -1) {
+		*x2 = wide / 2 + m_wide / 2;
+		*x1 = wide / 2 - m_wide / 2;
+	}
+	else {
+		*x1 = m_x1;
+		*x2 = m_x2;
+	}
+	// 縦
+	if (m_defaultHeight) {
+		*y1 = 0;
+		*y2 = height;
+	}
+	else if (m_height != -1) {
+		*y2 = height / 2 + m_height / 2;
+		*y1 = height / 2 - m_height / 2;
+	}
+	else {
+		*y1 = m_y1;
+		*y2 = m_y2;
+	}
+}
+
+
+/*
 * キャラクターの目の瞬きの処理をするクラス
 */
 CharacterEyeClose::CharacterEyeClose() {
@@ -179,6 +249,18 @@ void CharacterEyeClose::count() {
 * キャラの画像
 */
 // 画像ロード用
+void loadCharacterGraph(const char* dir, const char* characterName, GraphHandlesWithAtari*& handles, string stateName, map<string, string>& data, double ex, CsvReader* atariReader) {
+	int n = stoi(data[stateName]);
+	if (n > 0) {
+		ostringstream oss;
+		oss << dir << characterName << "/" << stateName;
+		GraphHandles* graphHandles = new GraphHandles(oss.str().c_str(), n, ex, 0.0, true);
+		handles = new GraphHandlesWithAtari(graphHandles, stateName.c_str(), atariReader);
+	}
+	else {
+		handles = nullptr;
+	}
+}
 void loadCharacterGraph(const char* dir, const char* characterName, GraphHandles*& handles, string stateName, map<string, string>& data, double ex) {
 	int n = stoi(data[stateName]);
 	if (n > 0) {
@@ -190,6 +272,7 @@ void loadCharacterGraph(const char* dir, const char* characterName, GraphHandles
 		handles = nullptr;
 	}
 }
+
 // デフォルト値で初期化
 CharacterGraphHandle::CharacterGraphHandle() :
 	CharacterGraphHandle("test", 1.0)
@@ -201,6 +284,10 @@ CharacterGraphHandle::CharacterGraphHandle(const char* characterName, double dra
 	m_ex = drawEx;
 
 	CsvReader reader("data/characterGraph.csv");
+	string path = "data/atari/";
+	path += characterName;
+	path += ".csv";
+	CsvReader atariReader(path.c_str());
 
 	// キャラ名でデータを検索
 	map<string, string> data = reader.findOne("name", characterName);
@@ -208,26 +295,26 @@ CharacterGraphHandle::CharacterGraphHandle(const char* characterName, double dra
 
 	// ロード
 	const char* dir = "picture/stick/";
-	loadCharacterGraph(dir, characterName, m_standHandles, "stand", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_slashHandles, "slash", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_airSlashEffectHandles, "airSlashEffect", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_bulletHandles, "bullet", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_squatHandles, "squat", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_squatBulletHandles, "squatBullet", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_standBulletHandles, "standBullet", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_standSlashHandles, "standSlash", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_runHandles, "run", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_runBulletHandles, "runBullet", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_landHandles, "land", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_jumpHandles, "jump", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_downHandles, "down", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_preJumpHandles, "preJump", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_damageHandles, "damage", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_boostHandles, "boost", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_airBulletHandles, "airBullet", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_airSlashHandles, "airSlash", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_closeHandles, "close", data, m_ex);
-	loadCharacterGraph(dir, characterName, m_deadHandles, "dead", data, m_ex);
+	loadCharacterGraph(dir, characterName, m_standHandles, "stand", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_slashHandles, "slash", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_airSlashEffectHandles, "airSlashEffect", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_bulletHandles, "bullet", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_squatHandles, "squat", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_squatBulletHandles, "squatBullet", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_standBulletHandles, "standBullet", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_standSlashHandles, "standSlash", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_runHandles, "run", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_runBulletHandles, "runBullet", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_landHandles, "land", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_jumpHandles, "jump", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_downHandles, "down", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_preJumpHandles, "preJump", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_damageHandles, "damage", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_boostHandles, "boost", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_airBulletHandles, "airBullet", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_airSlashHandles, "airSlash", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_closeHandles, "close", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_deadHandles, "dead", data, m_ex, &atariReader);
 
 	switchStand();
 }
@@ -255,24 +342,34 @@ CharacterGraphHandle::~CharacterGraphHandle() {
 	if (m_deadHandles != nullptr) { delete m_deadHandles; }
 }
 
+void CharacterGraphHandle::getAtari(int* x1, int* y1, int* x2, int* y2) const {
+	m_dispGraphHandle_p->getAtari(x1, y1, x2, y2, m_dispGraphIndex);
+	*x1 = *x1 * m_ex;
+	*y1 = *y1 * m_ex;
+	*x2 = *x2 * m_ex;
+	*y2 = *y2 * m_ex;
+}
+
 // 画像のサイズをセット
 void CharacterGraphHandle::setGraphSize() {
-	GetGraphSize(m_graphHandle_p->getHandle(), &m_wide, &m_height);
+	GetGraphSize(m_dispGraphHandle_p->getGraphHandles()->getGraphHandle(m_dispGraphIndex)->getHandle(), &m_wide, &m_height);
 	// 画像の拡大率も考慮してサイズを決定
 	m_wide = (int)(m_wide * m_ex);
 	m_height = (int)(m_height * m_ex);
 }
 
-// 画像をセットする 存在しないならそのまま
-void CharacterGraphHandle::setGraph(const GraphHandles* graphHandles, int index) {
-	if (graphHandles == nullptr) { return; }
-	if (index >= graphHandles->getSize() || index < 0) { return; }
-	m_graphHandle_p = graphHandles->getGraphHandle(index);
-	setGraphSize();
+void CharacterGraphHandle::setAtari() {
+	m_dispGraphHandle_p->getAtari(&m_atariX1, &m_atariY1, &m_atariX2, &m_atariY2, m_dispGraphIndex);
 }
-void CharacterGraphHandle::setGraph(GraphHandle* graphHandle) {
-	m_graphHandle_p = graphHandle;
+
+// 画像をセットする 存在しないならそのまま
+void CharacterGraphHandle::setGraph(GraphHandlesWithAtari* graphHandles, int index) {
+	if (graphHandles == nullptr) { return; }
+	if (index >= graphHandles->getGraphHandles()->getSize() || index < 0) { return; }
+	m_dispGraphHandle_p = graphHandles;
+	m_dispGraphIndex = index;
 	setGraphSize();
+	setAtari();
 }
 
 // 立ち画像をセット

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -5,6 +5,7 @@
 #include <string>
 
 class Camera;
+class CsvReader;
 
 /*
 * 画像データ(ハンドル、画像固有の拡大率、向き)をまとめて扱うためのクラス
@@ -85,6 +86,31 @@ public:
 
 
 /*
+* 当たり判定の情報付きのGraphHandles
+*/
+class GraphHandlesWithAtari {
+private:
+
+	GraphHandles* m_graphHandles;
+
+	// 当たり判定
+	bool m_defaultWide, m_defaultHeight;
+	int m_wide, m_height;
+	int m_x1, m_y1, m_x2, m_y2;
+
+public:
+
+	GraphHandlesWithAtari(GraphHandles* graphHandles, const char* graphName, CsvReader* csvReader);
+	~GraphHandlesWithAtari();
+
+	GraphHandles* getGraphHandles() const { return m_graphHandles; }
+
+	void getAtari(int* x1, int* y1, int* x2, int* y2, int index) const;
+
+};
+
+
+/*
 * キャラの眼の瞬きを処理するクラス
 */
 class CharacterEyeClose {
@@ -121,76 +147,80 @@ private:
 class CharacterGraphHandle {
 private:
 	// 表示される画像
-	GraphHandle* m_graphHandle_p;
+	GraphHandlesWithAtari* m_dispGraphHandle_p;
+	int m_dispGraphIndex;
 
 	double m_ex;
 
 	int m_wide, m_height;
+
+	// 当たり判定
+	int m_atariX1, m_atariY1, m_atariX2, m_atariY2;
 
 	// 瞬き
 	CharacterEyeClose m_characterEyeClose;
 
 	// キャラのパーツの画像
 	// 斬撃攻撃画像
-	GraphHandles* m_slashHandles;
+	GraphHandlesWithAtari* m_slashHandles;
 
 	// 空中斬撃攻撃画像
-	GraphHandles* m_airSlashEffectHandles;
+	GraphHandlesWithAtari* m_airSlashEffectHandles;
 
 	// 射撃攻撃画像
-	GraphHandles* m_bulletHandles;
+	GraphHandlesWithAtari* m_bulletHandles;
 
 	// キャラ本体の画像
 	// 立ち画像
-	GraphHandles* m_standHandles;
+	GraphHandlesWithAtari* m_standHandles;
 
 	// しゃがみ画像
-	GraphHandles* m_squatHandles;
+	GraphHandlesWithAtari* m_squatHandles;
 
 	// しゃがみ射撃画像
-	GraphHandles* m_squatBulletHandles;
+	GraphHandlesWithAtari* m_squatBulletHandles;
 
 	// 立ち射撃画像
-	GraphHandles* m_standBulletHandles;
+	GraphHandlesWithAtari* m_standBulletHandles;
 
 	// 立ち斬撃画像
-	GraphHandles* m_standSlashHandles;
+	GraphHandlesWithAtari* m_standSlashHandles;
 
 	// 走り画像
-	GraphHandles* m_runHandles;
+	GraphHandlesWithAtari* m_runHandles;
 
 	// 走り射撃画像
-	GraphHandles* m_runBulletHandles;
+	GraphHandlesWithAtari* m_runBulletHandles;
 
 	// 着地画像
-	GraphHandles* m_landHandles;
+	GraphHandlesWithAtari* m_landHandles;
 
 	// 上昇画像
-	GraphHandles* m_jumpHandles;
+	GraphHandlesWithAtari* m_jumpHandles;
 
 	// 下降画像
-	GraphHandles* m_downHandles;
+	GraphHandlesWithAtari* m_downHandles;
 
 	// ジャンプ前画像
-	GraphHandles* m_preJumpHandles;
+	GraphHandlesWithAtari* m_preJumpHandles;
 
 	// ダメージ画像
-	GraphHandles* m_damageHandles;
+	GraphHandlesWithAtari* m_damageHandles;
 
 	// ブースト画像
-	GraphHandles* m_boostHandles;
+	GraphHandlesWithAtari* m_boostHandles;
 
 	// 空中射撃画像
-	GraphHandles* m_airBulletHandles;
+	GraphHandlesWithAtari* m_airBulletHandles;
 
 	// 空中斬撃画像
-	GraphHandles* m_airSlashHandles;
+	GraphHandlesWithAtari* m_airSlashHandles;
 
 	// 瞬き画像
-	GraphHandles* m_closeHandles;
+	GraphHandlesWithAtari* m_closeHandles;
 
 	// やられ画像
-	GraphHandles* m_deadHandles;
+	GraphHandlesWithAtari* m_deadHandles;
 
 public:
 	// デフォルト値で初期化
@@ -201,38 +231,43 @@ public:
 	~CharacterGraphHandle();
 
 	// 表示する画像を返す
-	inline GraphHandle* getHandle() { return m_graphHandle_p; }
+	inline GraphHandlesWithAtari* getDispGraphHandle() { return m_dispGraphHandle_p; }
+	inline GraphHandle* getHandle() { return m_dispGraphHandle_p->getGraphHandles()->getGraphHandle(m_dispGraphIndex); }
+	inline int getDispGraphIndex() const { return m_dispGraphIndex; }
 	inline int getWide() const { return m_wide; }
 	inline int getHeight() const { return m_height; }
+	void getAtari(int* x1, int* y1, int* x2, int* y2) const;
 
 	// 画像のゲッタ
-	inline GraphHandles* getSlashHandle() { return m_slashHandles; }
-	inline GraphHandles* getAirSlashEffectHandle() { return m_airSlashEffectHandles; }
-	inline GraphHandles* getBulletHandle() { return m_bulletHandles; }
-	inline GraphHandles* getStandHandle() { return m_standHandles; }
-	inline GraphHandles* getStandBulletHandle() { return m_standBulletHandles; }
-	inline GraphHandles* getStandSlashHandle() { return m_standSlashHandles; }
-	inline GraphHandles* getSquatHandle() { return m_squatHandles; }
-	inline GraphHandles* getSquatBulletHandle() { return m_squatBulletHandles; }
-	inline GraphHandles* getRunHandle() { return m_runHandles; }
-	inline GraphHandles* getRunBulletHandle() { return m_runBulletHandles; }
-	inline GraphHandles* getLandHandle() { return m_landHandles; }
-	inline GraphHandles* getJumpHandle() { return m_jumpHandles; }
-	inline GraphHandles* getDownHandle() { return m_downHandles; }
-	inline GraphHandles* getPreJumpHandle() { return m_preJumpHandles; }
-	inline GraphHandles* getDamageHandle() { return m_damageHandles; }
-	inline GraphHandles* getBoostHandle() { return m_boostHandles; }
-	inline GraphHandles* getAirBulletHandle() { return m_airBulletHandles; }
-	inline GraphHandles* getAirSlashHandle() { return m_airSlashHandles; }
-	inline GraphHandles* getCloseHandle() { return m_closeHandles; }
-	inline GraphHandles* getDeadHandle() { return m_deadHandles; }
+	inline GraphHandlesWithAtari* getSlashHandle() { return m_slashHandles; }
+	inline GraphHandlesWithAtari* getAirSlashEffectHandle() { return m_airSlashEffectHandles; }
+	inline GraphHandlesWithAtari* getBulletHandle() { return m_bulletHandles; }
+	inline GraphHandlesWithAtari* getStandHandle() { return m_standHandles; }
+	inline GraphHandlesWithAtari* getStandBulletHandle() { return m_standBulletHandles; }
+	inline GraphHandlesWithAtari* getStandSlashHandle() { return m_standSlashHandles; }
+	inline GraphHandlesWithAtari* getSquatHandle() { return m_squatHandles; }
+	inline GraphHandlesWithAtari* getSquatBulletHandle() { return m_squatBulletHandles; }
+	inline GraphHandlesWithAtari* getRunHandle() { return m_runHandles; }
+	inline GraphHandlesWithAtari* getRunBulletHandle() { return m_runBulletHandles; }
+	inline GraphHandlesWithAtari* getLandHandle() { return m_landHandles; }
+	inline GraphHandlesWithAtari* getJumpHandle() { return m_jumpHandles; }
+	inline GraphHandlesWithAtari* getDownHandle() { return m_downHandles; }
+	inline GraphHandlesWithAtari* getPreJumpHandle() { return m_preJumpHandles; }
+	inline GraphHandlesWithAtari* getDamageHandle() { return m_damageHandles; }
+	inline GraphHandlesWithAtari* getBoostHandle() { return m_boostHandles; }
+	inline GraphHandlesWithAtari* getAirBulletHandle() { return m_airBulletHandles; }
+	inline GraphHandlesWithAtari* getAirSlashHandle() { return m_airSlashHandles; }
+	inline GraphHandlesWithAtari* getCloseHandle() { return m_closeHandles; }
+	inline GraphHandlesWithAtari* getDeadHandle() { return m_deadHandles; }
 
 	// 画像サイズをセット
 	void setGraphSize();
 
+	// 当たり判定をセット
+	void setAtari();
+
 	// 画像をセット、存在しない画像ならそのまま　サイズも決定
-	void setGraph(const GraphHandles* graphHandles, int index);
-	void setGraph(GraphHandle* graphHandle);
+	void setGraph(GraphHandlesWithAtari* graphHandles, int index);
 
 	// 立ち画像をセット
 	void switchStand(int index = 0);

--- a/Item.cpp
+++ b/Item.cpp
@@ -102,10 +102,11 @@ void Item::action() {
 bool Item::atariCharacter(Character* player) {
 
 	// キャラの座標
-	int cx1 = player->getX();
-	int cy1 = player->getY();
-	int cx2 = cx1 + player->getWide();
-	int cy2 = cy1 + player->getHeight();
+	int cx1 = 0;
+	int cy1 = 0;
+	int cx2 = 0;
+	int cy2 = 0;
+	player->getAtariArea(&cx1, &cy1, &cx2, &cy2);
 	
 	// このアイテムの座標
 	int x1 = 0, y1 = 0, x2 = 0, y2 = 0;

--- a/Object.cpp
+++ b/Object.cpp
@@ -126,6 +126,9 @@ bool BoxObject::atari(CharacterController* characterController) {
 	int characterY2 = characterY1 + characterHeight;
 	int characterVx = characterController->getAction()->getVx();
 	int characterVy = characterController->getAction()->getVy();
+	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
+	characterWide = characterX2 - characterX1;
+	characterHeight = characterY2 - characterY1;
 
 	// キャラが上下移動で当たっているか判定
 	if (characterX2 > m_x1 && characterX1 < m_x2) {
@@ -136,14 +139,16 @@ bool BoxObject::atari(CharacterController* characterController) {
 			// キャラは下へ移動できない
 			characterController->setActionDownLock(true);
 			// 密着状態までは移動させる
-			characterController->setCharacterY(m_y1 - characterHeight);
+			int height = characterY2 - characterController->getAction()->getCharacter()->getY();
+			characterController->setCharacterY(m_y1 - height);
 		}
 		// 上に移動中のキャラが下から当たっているか判定
 		else if (characterY1 >= m_y2 && characterY1 + characterVy <= m_y2) {
 			// キャラは上へ移動できない
 			characterController->setActionUpLock(true);
 			// 密着状態までは移動させる
-			characterController->setCharacterY(m_y2);
+			int topD = characterY1 - characterController->getAction()->getCharacter()->getY();
+			characterController->setCharacterY(m_y2 - topD);
 		}
 	}
 
@@ -156,7 +161,8 @@ bool BoxObject::atari(CharacterController* characterController) {
 			if (slope && characterY2 - STAIR_HEIGHT <= m_y1) {
 				// 適切な座標へ
 				characterController->setCharacterX(m_x1 - characterWide / 2 - characterVx);
-				characterController->setCharacterY(m_y1 - characterHeight);
+				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
+				characterController->setCharacterY(m_y1 - height);
 				// 着地
 				characterController->setCharacterGrand(true);
 				characterController->setActionBoost();
@@ -167,7 +173,8 @@ bool BoxObject::atari(CharacterController* characterController) {
 				// キャラは右へ移動できない
 				characterController->setActionRightLock(true);
 				// 密着状態までは移動させる
-				characterController->setCharacterX(m_x1 - characterWide);
+				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x1 - wide);
 			}
 		}
 		// 左に移動中のキャラが右から当たっているか判定
@@ -175,7 +182,8 @@ bool BoxObject::atari(CharacterController* characterController) {
 			if (slope && characterY2 - STAIR_HEIGHT <= m_y1) {
 				// 適切な座標へ
 				characterController->setCharacterX(m_x2 - characterWide / 2 + characterVx);
-				characterController->setCharacterY(m_y1 - characterHeight);
+				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
+				characterController->setCharacterY(m_y1 - height);
 				// 着地
 				characterController->setCharacterGrand(true);
 				characterController->setActionBoost();
@@ -186,7 +194,8 @@ bool BoxObject::atari(CharacterController* characterController) {
 				// キャラは左へ移動できない
 				characterController->setActionLeftLock(true);
 				// 密着状態までは移動させる
-				characterController->setCharacterX(m_x2);
+				int leftD = characterX1 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x2 - leftD);
 			}
 		}
 	}
@@ -202,6 +211,9 @@ void BoxObject::penetration(CharacterController* characterController) {
 	int characterHeight = characterController->getAction()->getCharacter()->getHeight();
 	int characterX2 = characterX1 + characterWide;
 	int characterY2 = characterY1 + characterHeight;
+	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
+	characterWide = characterX2 - characterX1;
+	characterHeight = characterY2 - characterY1;
 	// 万が一オブジェクトの中に入り込んでしまったら
 	bool slope = characterController->getAction()->getGrandLeftSlope() || characterController->getAction()->getGrandRightSlope();
 	if (!slope && characterY2 > m_y1 && characterY1 < m_y2 && characterX2 > m_x1 && characterX1 < m_x2) {
@@ -209,13 +221,15 @@ void BoxObject::penetration(CharacterController* characterController) {
 		if (characterX1 < m_x1 || characterX2 > m_x2) {
 			if ((characterX1 + characterX2) < (m_x1 + m_x2)) {
 				// 密着状態まで移動させる
-				characterController->setCharacterX(m_x1 - characterWide);
+				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x1 - wide);
 				// キャラは右へ移動できない
 				characterController->setActionRightLock(true);
 			}
 			else {
 				// 密着状態まで移動させる
-				characterController->setCharacterX(m_x2);
+				int leftD = characterX1 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x2 - leftD);
 				// キャラは左へ移動できない
 				characterController->setActionLeftLock(true);
 			}
@@ -223,7 +237,8 @@ void BoxObject::penetration(CharacterController* characterController) {
 		else if (characterY1 < m_y1 || characterY2 > m_y2) {
 			if ((characterY1 + characterY2) < (m_y1 + m_y2)) {
 				// 真上へ
-				characterController->setCharacterY(m_y1 - characterHeight);
+				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
+				characterController->setCharacterY(m_y1 - height);
 				// 着地
 				characterController->setCharacterGrand(true);
 				// キャラは下へ移動できない
@@ -231,7 +246,8 @@ void BoxObject::penetration(CharacterController* characterController) {
 			}
 			else {
 				// 真下へ
-				characterController->setCharacterY(m_y2);
+				int topD = characterY1 - characterController->getAction()->getCharacter()->getY();
+				characterController->setCharacterY(m_y2 - topD);
 				// キャラは上へ移動できない
 				characterController->setActionUpLock(true);
 			}
@@ -333,6 +349,11 @@ bool TriangleObject::atari(CharacterController* characterController) {
 	int characterY1_5 = characterController->getAction()->getCharacter()->getCenterY();
 	int characterVx = characterController->getAction()->getVx();
 	int characterVy = characterController->getAction()->getVy();
+	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
+	characterWide = characterX2 - characterX1;
+	characterHeight = characterY2 - characterY1;
+	characterX1_5 = characterX1 + characterWide / 2;
+	characterY1_5 = characterY1 + characterHeight / 2;
 
 	// キャラが上下移動で当たっているか判定
 	if (characterX2 > m_x1 && characterX1 < m_x2) {
@@ -349,7 +370,8 @@ bool TriangleObject::atari(CharacterController* characterController) {
 			// キャラは下へ移動できない
 			characterController->setActionDownLock(true);
 			// 密着状態までは移動させる
-			characterController->setCharacterY(getY(characterX1_5) - characterHeight);
+			int height = characterY2 - characterController->getAction()->getCharacter()->getY();
+			characterController->setCharacterY(getY(characterX1_5) - height);
 		}
 		// 下に移動中のキャラが上から当たっているか判定
 		else if (characterY2 <= getY(characterX1_5) && characterY2 + characterVy >= getY(characterX1_5)) {
@@ -364,14 +386,16 @@ bool TriangleObject::atari(CharacterController* characterController) {
 			// キャラは下へ移動できない
 			characterController->setActionDownLock(true);
 			// 密着状態までは移動させる
-			characterController->setCharacterY(getY(characterX1_5) - characterHeight);
+			int height = characterY2 - characterController->getAction()->getCharacter()->getY();
+			characterController->setCharacterY(getY(characterX1_5) - height);
 		}
 		// 上に移動中のキャラが下から当たっているか判定
 		else if (characterY1 >= m_y2 && characterY1 + characterVy <= m_y2) {
 			// キャラは上へ移動できない
 			characterController->setActionUpLock(true);
 			// 密着状態までは移動させる
-			characterController->setCharacterY(m_y2);
+			int topD = characterY1 - characterController->getAction()->getCharacter()->getY();
+			characterController->setCharacterY(m_y2 - topD);
 		}
 	}
 
@@ -388,7 +412,8 @@ bool TriangleObject::atari(CharacterController* characterController) {
 		// キャラは下へ移動できない
 		characterController->setActionDownLock(true);
 		// 適切な高さへ移動
-		characterController->setCharacterY(getY(characterX1_5) - characterHeight);
+		int height = characterY2 - characterController->getAction()->getCharacter()->getY();
+		characterController->setCharacterY(getY(characterX1_5) - height);
 	}
 
 	// 坂の鋭角（先端）の当たり判定
@@ -399,7 +424,8 @@ bool TriangleObject::atari(CharacterController* characterController) {
 				// キャラは右へ移動できない
 				characterController->setActionRightLock(true);
 				// 密着状態までは移動させる
-				characterController->setCharacterX(m_x1 - characterWide);
+				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x1 - wide);
 			}
 		}
 		else {
@@ -408,7 +434,8 @@ bool TriangleObject::atari(CharacterController* characterController) {
 				// キャラは左へ移動できない
 				characterController->setActionLeftLock(true);
 				// 密着状態までは移動させる
-				characterController->setCharacterX(m_x2);
+				int leftD = characterX1 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x2 - leftD);
 			}
 		}
 	}
@@ -421,7 +448,8 @@ bool TriangleObject::atari(CharacterController* characterController) {
 				// キャラは左へ移動できない
 				characterController->setActionLeftLock(true);
 				// 密着状態までは移動させる
-				characterController->setCharacterX(m_x2);
+				int leftD = characterX1 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x2 - leftD);
 			}
 		}
 		else {
@@ -430,7 +458,8 @@ bool TriangleObject::atari(CharacterController* characterController) {
 				// キャラは右へ移動できない
 				characterController->setActionRightLock(true);
 				// 密着状態までは移動させる
-				characterController->setCharacterX(m_x1 - characterWide);
+				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x1 - wide);
 			}
 		}
 	}
@@ -462,13 +491,19 @@ void TriangleObject::penetration(CharacterController* characterController) {
 	int characterY1_5 = characterController->getAction()->getCharacter()->getCenterY();
 	int characterX2 = characterX1 + characterWide;
 	int characterY2 = characterY1 + characterHeight;
+	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
+	characterWide = characterX2 - characterX1;
+	characterHeight = characterY2 - characterY1;
+	characterX1_5 = characterX1 + characterWide / 2;
+	characterY1_5 = characterY1 + characterHeight / 2;
 	int slopeY = getY(characterX1_5);
 	// 万が一オブジェクトの中に入り込んでしまったら
 	if (characterY2 > slopeY && characterY1 < m_y2 && characterX2 > m_x1 && characterX1 < m_x2) {
 		if (characterY1 < slopeY || characterY2 > m_y2) {
 			if ((characterY1 + characterY2) < (slopeY + m_y2)) {
 				// 真上へ
-				characterController->setCharacterY(slopeY - characterHeight);
+				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
+				characterController->setCharacterY(slopeY - height);
 				// 着地
 				characterController->setCharacterGrand(true);
 				// キャラは下へ移動できない
@@ -476,7 +511,8 @@ void TriangleObject::penetration(CharacterController* characterController) {
 			}
 			else {
 				// 真下へ
-				characterController->setCharacterY(m_y2);
+				int topD = characterY1 - characterController->getAction()->getCharacter()->getY();
+				characterController->setCharacterY(m_y2 - topD);
 				// キャラは上へ移動できない
 				characterController->setActionUpLock(true);
 			}
@@ -485,13 +521,15 @@ void TriangleObject::penetration(CharacterController* characterController) {
 		else if (characterX1 < m_x1 || characterX2 > m_x2) {
 			if ((characterX1 + characterX2) < (m_x1 + m_x2)) {
 				// 密着状態まで移動させる
-				characterController->setCharacterX(m_x1 - characterWide);
+				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x1 - wide);
 				// キャラは右へ移動できない
 				characterController->setActionRightLock(true);
 			}
 			else {
 				// 密着状態まで移動させる
-				characterController->setCharacterX(m_x2);
+				int leftD = characterX1 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x2 - leftD);
 				// キャラは左へ移動できない
 				characterController->setActionLeftLock(true);
 			}
@@ -608,6 +646,7 @@ bool BulletObject::atari(CharacterController* characterController) {
 	int characterY1 = characterController->getAction()->getCharacter()->getY();
 	int characterX2 = characterX1 + characterController->getAction()->getCharacter()->getWide();
 	int characterY2 = characterY1 + characterController->getAction()->getCharacter()->getHeight();
+	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
 
 	// 当たり判定
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2 && characterController->getAction()->ableDamage()) {
@@ -773,6 +812,7 @@ bool SlashObject::atari(CharacterController* characterController) {
 	int characterY1 = characterController->getAction()->getCharacter()->getY();
 	int characterX2 = characterX1 + characterController->getAction()->getCharacter()->getWide();
 	int characterY2 = characterY1 + characterController->getAction()->getCharacter()->getHeight();
+	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
 
 	// 当たり判定
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2 && characterController->getAction()->ableDamage()) {
@@ -858,6 +898,7 @@ bool BombObject::atari(CharacterController* characterController) {
 	int characterY1 = characterController->getAction()->getCharacter()->getY();
 	int characterX2 = characterX1 + characterController->getAction()->getCharacter()->getWide();
 	int characterY2 = characterY1 + characterController->getAction()->getCharacter()->getHeight();
+	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
 
 	// 当たり判定
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2 && characterController->getAction()->ableDamage()) {
@@ -948,6 +989,7 @@ bool DoorObject::atari(CharacterController* characterController) {
 	int characterY1 = characterController->getAction()->getCharacter()->getY();
 	int characterX2 = characterX1 + characterController->getAction()->getCharacter()->getWide();
 	int characterY2 = characterY1 + characterController->getAction()->getCharacter()->getHeight();
+	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
 
 	// 当たり判定
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2) {

--- a/Object.cpp
+++ b/Object.cpp
@@ -159,16 +159,7 @@ bool BoxObject::atari(CharacterController* characterController) {
 		if (characterX2 <= m_x1 && characterX2 + characterVx >= m_x1) {
 			// 段差とみなして乗り越える
 			if (slope && characterY2 - STAIR_HEIGHT <= m_y1) {
-				// 適切な座標へ
-				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
-				characterController->setCharacterX(m_x1 - wide + characterVx);
-				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
-				characterController->setCharacterY(m_y1 - height);
-				// 着地
-				characterController->setCharacterGrand(true);
-				characterController->setActionBoost();
-				// キャラは下へ移動できない
-				characterController->setActionDownLock(true);
+
 			}
 			else {
 				// キャラは右へ移動できない
@@ -181,16 +172,7 @@ bool BoxObject::atari(CharacterController* characterController) {
 		// 左に移動中のキャラが右から当たっているか判定
 		else if (characterX1 >= m_x2 && characterX1 + characterVx <= m_x2) {
 			if (slope && characterY2 - STAIR_HEIGHT <= m_y1) {
-				// 適切な座標へ
-				int leftD = characterX1 - characterController->getAction()->getCharacter()->getX();
-				characterController->setCharacterX(m_x2 - leftD - characterVx - 1);
-				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
-				characterController->setCharacterY(m_y1 - height);
-				// 着地
-				characterController->setCharacterGrand(true);
-				characterController->setActionBoost();
-				// キャラは下へ移動できない
-				characterController->setActionDownLock(true);
+
 			}
 			else {
 				// キャラは左へ移動できない
@@ -365,11 +347,13 @@ bool TriangleObject::atari(CharacterController* characterController) {
 		if (characterY2 - 1 <= getY(characterX1_5 - characterVx) && characterY2 + 1 >= getY(characterX1_5 - characterVx)) {
 			// 前のフレームでは着地していたので、引き続き着地
 			characterController->setCharacterGrand(true);
-			if (m_leftDown) {
-				characterController->setCharacterGrandRightSlope(true);
-			}
-			else {
-				characterController->setCharacterGrandLeftSlope(true);
+			if (characterX1_5 > m_x1 && characterX1_5 < m_x2) {
+				if (m_leftDown) {
+					characterController->setCharacterGrandRightSlope(true);
+				}
+				else {
+					characterController->setCharacterGrandLeftSlope(true);
+				}
 			}
 			// キャラは下へ移動できない
 			characterController->setActionDownLock(true);
@@ -381,11 +365,13 @@ bool TriangleObject::atari(CharacterController* characterController) {
 		else if (characterY2 <= getY(characterX1_5) && characterY2 + characterVy >= getY(characterX1_5)) {
 			// 着地
 			characterController->setCharacterGrand(true);
-			if (m_leftDown) {
-				characterController->setCharacterGrandRightSlope(true);
-			}
-			else {
-				characterController->setCharacterGrandLeftSlope(true);
+			if (characterX1_5 > m_x1 && characterX1_5 < m_x2) {
+				if (m_leftDown) {
+					characterController->setCharacterGrandRightSlope(true);
+				}
+				else {
+					characterController->setCharacterGrandLeftSlope(true);
+				}
 			}
 			// キャラは下へ移動できない
 			characterController->setActionDownLock(true);
@@ -407,11 +393,13 @@ bool TriangleObject::atari(CharacterController* characterController) {
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 <= m_y2 && characterY2 >= getY(characterX1_5)) {
 		// 着地
 		characterController->setCharacterGrand(true);
-		if (m_leftDown) {
-			characterController->setCharacterGrandRightSlope(true);
-		}
-		else {
-			characterController->setCharacterGrandLeftSlope(true);
+		if (characterX1_5 > m_x1 && characterX1_5 <= m_x2) {
+			if (m_leftDown) {
+				characterController->setCharacterGrandRightSlope(true);
+			}
+			else {
+				characterController->setCharacterGrandLeftSlope(true);
+			}
 		}
 		// キャラは下へ移動できない
 		characterController->setActionDownLock(true);

--- a/Object.cpp
+++ b/Object.cpp
@@ -160,7 +160,8 @@ bool BoxObject::atari(CharacterController* characterController) {
 			// 段差とみなして乗り越える
 			if (slope && characterY2 - STAIR_HEIGHT <= m_y1) {
 				// 適切な座標へ
-				characterController->setCharacterX(m_x1 - characterWide / 2 - characterVx);
+				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x1 - wide + characterVx);
 				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
 				characterController->setCharacterY(m_y1 - height);
 				// 着地
@@ -181,7 +182,8 @@ bool BoxObject::atari(CharacterController* characterController) {
 		else if (characterX1 >= m_x2 && characterX1 + characterVx <= m_x2) {
 			if (slope && characterY2 - STAIR_HEIGHT <= m_y1) {
 				// 適切な座標へ
-				characterController->setCharacterX(m_x2 - characterWide / 2 + characterVx);
+				int leftD = characterX1 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x2 - leftD - characterVx);
 				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
 				characterController->setCharacterY(m_y1 - height);
 				// 着地
@@ -499,7 +501,24 @@ void TriangleObject::penetration(CharacterController* characterController) {
 	int slopeY = getY(characterX1_5);
 	// 万が一オブジェクトの中に入り込んでしまったら
 	if (characterY2 > slopeY && characterY1 < m_y2 && characterX2 > m_x1 && characterX1 < m_x2) {
-		if (characterY1 < slopeY || characterY2 > m_y2) {
+		// キャラが横にはみ出しているなら
+		if ((characterX1 < m_x1 || characterX2 > m_x2) && (characterX1_5 > m_x2 || characterX1_5 < m_x1)) {
+			if ((characterX1 + characterX2) < (m_x1 + m_x2)) {
+				// 密着状態まで移動させる
+				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x1 - wide);
+				// キャラは右へ移動できない
+				characterController->setActionRightLock(true);
+			}
+			else {
+				// 密着状態まで移動させる
+				int leftD = characterX1 - characterController->getAction()->getCharacter()->getX();
+				characterController->setCharacterX(m_x2 - leftD);
+				// キャラは左へ移動できない
+				characterController->setActionLeftLock(true);
+			}
+		}
+		else if (characterY1 < slopeY || characterY2 > m_y2) {
 			if ((characterY1 + characterY2) < (slopeY + m_y2)) {
 				// 真上へ
 				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
@@ -515,23 +534,6 @@ void TriangleObject::penetration(CharacterController* characterController) {
 				characterController->setCharacterY(m_y2 - topD);
 				// キャラは上へ移動できない
 				characterController->setActionUpLock(true);
-			}
-		}
-		// キャラが横にはみ出しているなら
-		else if (characterX1 < m_x1 || characterX2 > m_x2) {
-			if ((characterX1 + characterX2) < (m_x1 + m_x2)) {
-				// 密着状態まで移動させる
-				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
-				characterController->setCharacterX(m_x1 - wide);
-				// キャラは右へ移動できない
-				characterController->setActionRightLock(true);
-			}
-			else {
-				// 密着状態まで移動させる
-				int leftD = characterX1 - characterController->getAction()->getCharacter()->getX();
-				characterController->setCharacterX(m_x2 - leftD);
-				// キャラは左へ移動できない
-				characterController->setActionLeftLock(true);
 			}
 		}
 	}

--- a/Object.cpp
+++ b/Object.cpp
@@ -183,7 +183,7 @@ bool BoxObject::atari(CharacterController* characterController) {
 			if (slope && characterY2 - STAIR_HEIGHT <= m_y1) {
 				// 適切な座標へ
 				int leftD = characterX1 - characterController->getAction()->getCharacter()->getX();
-				characterController->setCharacterX(m_x2 - leftD - characterVx);
+				characterController->setCharacterX(m_x2 - leftD - characterVx - 1);
 				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
 				characterController->setCharacterY(m_y1 - height);
 				// 着地
@@ -219,8 +219,10 @@ void BoxObject::penetration(CharacterController* characterController) {
 	// 万が一オブジェクトの中に入り込んでしまったら
 	bool slope = characterController->getAction()->getGrandLeftSlope() || characterController->getAction()->getGrandRightSlope();
 	if (!slope && characterY2 > m_y1 && characterY1 < m_y2 && characterX2 > m_x1 && characterX1 < m_x2) {
+		int overlapX = min(characterX2 - m_x1, m_x2 - characterX1);
+		int overlapY = min(characterY2 - m_y1, m_y2 - characterY1);
 		// キャラが横にはみ出しているなら
-		if (characterX1 < m_x1 || characterX2 > m_x2) {
+		if (overlapX < overlapY) {
 			if ((characterX1 + characterX2) < (m_x1 + m_x2)) {
 				// 密着状態まで移動させる
 				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
@@ -236,7 +238,7 @@ void BoxObject::penetration(CharacterController* characterController) {
 				characterController->setActionLeftLock(true);
 			}
 		}
-		else if (characterY1 < m_y1 || characterY2 > m_y2) {
+		else {
 			if ((characterY1 + characterY2) < (m_y1 + m_y2)) {
 				// 真上へ
 				int height = characterY2 - characterController->getAction()->getCharacter()->getY();
@@ -359,8 +361,8 @@ bool TriangleObject::atari(CharacterController* characterController) {
 
 	// キャラが上下移動で当たっているか判定
 	if (characterX2 > m_x1 && characterX1 < m_x2) {
-		// 下りているときはこの条件式がtrueになる
-		if (characterY2 == getY(characterX1_5 - characterVx)) {
+		// 下りているときはこの条件式がtrueになる 誤差+-1は許容
+		if (characterY2 - 1 <= getY(characterX1_5 - characterVx) && characterY2 + 1 >= getY(characterX1_5 - characterVx)) {
 			// 前のフレームでは着地していたので、引き続き着地
 			characterController->setCharacterGrand(true);
 			if (m_leftDown) {
@@ -501,8 +503,10 @@ void TriangleObject::penetration(CharacterController* characterController) {
 	int slopeY = getY(characterX1_5);
 	// 万が一オブジェクトの中に入り込んでしまったら
 	if (characterY2 > slopeY && characterY1 < m_y2 && characterX2 > m_x1 && characterX1 < m_x2) {
+		int overlapX = min(characterX2 - m_x1, m_x2 - characterX1);
+		int overlapY = min(characterY2 - slopeY, m_y2 - characterY1);
 		// キャラが横にはみ出しているなら
-		if ((characterX1 < m_x1 || characterX2 > m_x2) && (characterX1_5 > m_x2 || characterX1_5 < m_x1)) {
+		if (overlapX < overlapY) {
 			if ((characterX1 + characterX2) < (m_x1 + m_x2)) {
 				// 密着状態まで移動させる
 				int wide = characterX2 - characterController->getAction()->getCharacter()->getX();
@@ -518,7 +522,7 @@ void TriangleObject::penetration(CharacterController* characterController) {
 				characterController->setActionLeftLock(true);
 			}
 		}
-		else if (characterY1 < slopeY || characterY2 > m_y2) {
+		else {
 			if ((characterY1 + characterY2) < (slopeY + m_y2)) {
 				// 真上へ
 				int height = characterY2 - characterController->getAction()->getCharacter()->getY();

--- a/Object.h
+++ b/Object.h
@@ -84,6 +84,9 @@ public:
 	void setSoundHandle(int soundHandle_p) { m_soundHandle_p = soundHandle_p; }
 	virtual inline void setTextDisp(const bool textDisp) {}
 
+	// slopeかどうか
+	virtual bool slopeFlag() const { return false; }
+
 	// 座標XにおけるY1座標（傾きから算出する）
 	virtual int getY(int x) const { return m_y1; }
 
@@ -209,6 +212,9 @@ public:
 	Object* createCopy();
 
 	void debug(int x, int y, int color) const;
+
+	// slopeかどうか
+	bool slopeFlag() const { return true; }
 
 	// 座標XにおけるY1座標（傾きから算出する）
 	int getY(int x) const;

--- a/World.cpp
+++ b/World.cpp
@@ -832,11 +832,11 @@ void World::controlCharacter() {
 		controller->init();
 
 		// オブジェクトとの当たり判定
-		atariCharacterAndObject(controller, m_stageObjects);
+		atariCharacterAndObject(controller, m_stageObjects, true);
+		atariCharacterAndObject(controller, m_stageObjects, false); // 1回目で斜面にいるかがわかり、それによって処理が変わるため2回目が必要
 		if (controller->getAction()->getCharacter()->getHp() > 0) {
-			atariCharacterAndObject(controller, m_attackObjects);
+			atariCharacterAndObject(controller, m_attackObjects, false);
 		}
-		atariCharacterAndObject(controller, m_stageObjects); // 2回目呼ぶのは妥協案　1回目で斜面にいるかがわかり、それによって処理が変わるため2回目が必要
 		if (controller->getAction()->getCharacter()->getId() == m_playerId) {
 			atariCharacterAndDoor(controller, m_doorObjects);
 		}
@@ -915,9 +915,10 @@ void World::controlItem() {
 }
 
 //  Battle：キャラクターとオブジェクトの当たり判定
-void World::atariCharacterAndObject(CharacterController* controller, vector<Object*>& objects) {
+void World::atariCharacterAndObject(CharacterController* controller, vector<Object*>& objects, bool slope) {
 	// 壁や床オブジェクトの処理 (当たり判定と動き)
 	for (unsigned int i = 0; i < objects.size(); i++) {
+		if (objects[i]->slopeFlag() != slope) { continue; }
 		// 当たり判定をここで行う
 		if (objects[i]->atari(controller)) {
 			const Character* character = controller->getAction()->getCharacter();
@@ -1085,11 +1086,11 @@ bool World::moveGoalCharacter() {
 		controller->init();
 
 		// オブジェクトとの当たり判定
-		atariCharacterAndObject(controller, m_stageObjects);
+		atariCharacterAndObject(controller, m_stageObjects, true);
+		atariCharacterAndObject(controller, m_stageObjects, false); // 1回目で斜面にいるかがわかり、それによって処理が変わるため2回目が必要
 		if (controller->getAction()->getCharacter()->getHp() > 0) {
-			atariCharacterAndObject(controller, m_attackObjects);
+			atariCharacterAndObject(controller, m_attackObjects, false);
 		}
-		atariCharacterAndObject(controller, m_stageObjects); // 2回目呼ぶのは妥協案　1回目で斜面にいるかがわかり、それによって処理が変わるため2回目が必要
 
 		// 目標地点へ移動する操作 originalのハートはフリーズ
 		if (!m_duplicationFlag || m_characterControllers[i]->getAction()->getCharacter()->getId() != m_playerId) {

--- a/World.h
+++ b/World.h
@@ -294,8 +294,8 @@ private:
 	// Battle：アイテムの動き
 	void controlItem();
 
-	// Battle：キャラクターとオブジェクトの当たり判定
-	void atariCharacterAndObject(CharacterController* controller, std::vector<Object*>& objects);
+	// Battle：キャラクターとオブジェクトの当たり判定 slope=trueならslopeが対象falseならそれ以外
+	void atariCharacterAndObject(CharacterController* controller, std::vector<Object*>& objects, bool slope);
 
 	// Battle：キャラクターと扉の当たり判定
 	void atariCharacterAndDoor(CharacterController* controller, std::vector<Object*>& objects);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
画像のサイズでキャラの当たり判定が決まっているが、これでは着地時などに当たり判定が変わり着地→浮遊を繰り返す現象などを引き起こす。

csvファイルでキャラごと、画像ごとに当たり判定を指定できるようにする。

# やったこと

csvファイルの仕様
```
各キャラの当たり判定の範囲を指定する。

ファイル名：「data/atari/キャラ名.csv」とする。

state := 画像の名前

defaultWide := 1なら当たり判定＝画像の大きさとなり、wide、x1、x2は必要なし

defaultHeight := 1なら当たり判定＝画像の大きさとなり、height、y1、y2は必要なし

wide := 横幅 指定しないなら-1で、x1とx2が必要

height := 縦幅 指定しないなら-1で、y1とy2が必要

x1 := 画像の左端を0としたとき、当たり判定の左端の座標

y1 := 画像の上端を0としたとき、当たり判定の上端の座標

x2 := 画像の左端を0としたとき、当たり判定の右端の座標

y2 := 画像の上端を0としたとき、当たり判定の下端の座標
```

上記の情報をGraphHandlesWithAtariで保持する。

今までは当たり判定時に画像のサイズを取得していたが、改修後はGraphHandlesWithAtariのgetAtari関数で四隅の座標を取得する。

CharacterAction::afterChangeGraphも大きく改修。四隅の座標がどのように変化するかによってキャラの座標を調整する。

今回の改修にともない、以下のバグも修正された。
- 坂を上りBoxObjectに移る際ワープする現象を解消
- 坂を下る際一瞬宙に浮くことがある現象を解消

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [x] デバッグモードで確認


https://github.com/kuriuminoki/DuplicationHeart/assets/92528385/84373447-ed8c-4fee-bf41-33d8fb1649c8



# 懸念点
記入欄
