### PR TITLE
チャプター１１～１４の作成

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -429,7 +429,7 @@ int NormalAI::bulletOrder() {
 	// ƒ‰ƒ“ƒ_ƒ€‚ÅŽËŒ‚
 	int rapid = m_characterAction_p->getCharacter()->getAttackInfo()->bulletRapid();
 	if (GetRand(rapid) == 0) {
-		return 1;
+		return m_characterAction_p->getBulletCnt() + 1;
 	}
 	return 0;
 }
@@ -929,6 +929,9 @@ Brain* HierarchyAI::createCopy(std::vector<Character*> characters, const Camera*
 	copyTarget(characters, getTargetId(), res);
 	setParam(res);
 	return res;
+}
+int HierarchyAI::bulletOrder() {
+	return m_characterAction_p->getBulletCnt() + 1;
 }
 void HierarchyAI::bulletTargetPoint(int& x, int& y) {
 	x = GetRand(600) - 300 + m_characterAction_p->getCharacter()->getCenterX();

--- a/Brain.h
+++ b/Brain.h
@@ -419,7 +419,7 @@ public:
 
 	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
 
-	int bulletOrder() { return 1; }
+	int bulletOrder();
 	void bulletTargetPoint(int& x, int& y);
 
 	void moveOrder(int& right, int& left, int& up, int& down) { return; }

--- a/Event.h
+++ b/Event.h
@@ -63,7 +63,7 @@ public:
 	virtual bool skillAble() { return true; }
 
 	// クリア時に前のセーブポイントへ戻る必要があるか
-	virtual bool needBackPrevSave() { return false; }
+	virtual int needBackPrevSave() { return 0; }
 
 	// セッタ
 	virtual void setWorld(World* world) { m_world_p = world; }
@@ -96,8 +96,8 @@ private:
 	// イベントの進捗(EventElementのインデックス)
 	int m_nowElement;
 
-	// 前のセーブポイントへ戻る要求
-	bool m_backPrevSaveFlag;
+	// 前のセーブポイントへ戻る要求 戻るならいくつ戻るか返す(>0)
+	int m_backPrevSave;
 
 	// 世界のバージョン
 	int m_version;
@@ -121,10 +121,10 @@ public:
 	// Worldを設定しなおす
 	void setWorld(World* world);
 
-	bool getBackPrevSaveFlag() const { return m_backPrevSaveFlag; }
+	int getBackPrevSave() const { return m_backPrevSave; }
 
 	// 前のセーブポイントへ戻ったことを教えてもらう
-	void doneBackPrevSave() { m_backPrevSaveFlag = false; }
+	void doneBackPrevSave() { m_backPrevSave = 0; }
 
 private:
 	void createFire(std::vector<std::string> param, World* world, SoundPlayer* soundPlayer);
@@ -550,6 +550,8 @@ private:
 	
 	int m_areaNum;
 
+	int m_backPrevSave;
+
 public:
 	PlayerDeadEvent(World* world, std::vector<std::string> param);
 
@@ -557,7 +559,7 @@ public:
 	EVENT_RESULT play();
 
 	// クリア時に前のセーブポイントへ戻る必要があるか
-	bool needBackPrevSave() { return true; }
+	int needBackPrevSave() { return m_backPrevSave; }
 };
 
 // 特定のエリアへ強制的に移動する
@@ -573,6 +575,9 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
 };
 
 // 世界の描画をする・しない
@@ -588,6 +593,9 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
 };
 
 // キャラの追加
@@ -611,6 +619,9 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
 };
 
 // 待機
@@ -621,6 +632,24 @@ class WaitEvent :
 	int m_time;
 public:
 	WaitEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+};
+
+// スキル発動まで戦闘を続けるイベント
+class WaitSkillEvent :
+	public EventElement
+{
+private:
+
+	bool m_skillFlag;
+
+public:
+	WaitSkillEvent(World* world, std::vector<std::string> param);
 
 	// プレイ
 	EVENT_RESULT play();

--- a/Game.cpp
+++ b/Game.cpp
@@ -21,11 +21,11 @@ using namespace std;
 
 
 // どこまで
-const int FINISH_STORY = 12;
+const int FINISH_STORY = 15;
 // エリア0でデバッグするときはtrueにする
 const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
-const int SKILL_USEABLE_STORY = 13;
+const int SKILL_USEABLE_STORY = 14;
 
 
 /*
@@ -658,8 +658,9 @@ bool Game::play() {
 	if (TEST_MODE) { return false; }
 
 	// 前のセーブポイントへ戻ることが要求された
-	if (m_story->getBackPrevSaveFlag()) {
-		backPrevSave();
+	int prevStoryNum = m_story->getBackPrevSave();
+	if (prevStoryNum > 0) {
+		backPrevSave(prevStoryNum - 1);
 		m_story->doneBackPrevSave();
 		return true;
 	}
@@ -691,12 +692,12 @@ bool Game::play() {
 }
 
 // セーブデータをロード（前のセーブポイントへ戻る）
-void Game::backPrevSave() {
+void Game::backPrevSave(int prevStoryNum) {
 	m_gameData->asignedWorld(m_world, true);
 	// これまでのWorldを削除
 	delete m_world;
 	// 前のセーブデータをロード
-	GameData prevData(m_gameData->getSaveFilePath(), m_gameData->getStoryNum());
+	GameData prevData(m_gameData->getSaveFilePath(), m_gameData->getStoryNum() - prevStoryNum);
 	// 以前のAreaNumでロード
 	m_world = new World(-1, prevData.getAreaNum(), m_soundPlayer);
 	m_gameData->asignWorld(m_world, true);

--- a/Game.h
+++ b/Game.h
@@ -364,7 +364,7 @@ public:
 	bool play();
 
 	// セーブデータをロード（前のセーブポイントへ戻る）
-	void backPrevSave();
+	void backPrevSave(int prevStoryNum);
 
 	// 描画していいならtrue
 	bool ableDraw();

--- a/Object.cpp
+++ b/Object.cpp
@@ -1043,6 +1043,8 @@ void BulletObject::setBulletParam(BulletObject* object) {
 	object->setD(m_d);
 	object->setDamage(m_damage);
 	object->setEffectHandles(m_effectHandles_p);
+	object->setGraphHandle(m_handle);
+	
 }
 Object* ParabolaBullet::createCopy() {
 	ParabolaBullet* res = new ParabolaBullet(m_x1, m_y1, m_handle, m_gx, m_gy);

--- a/Object.h
+++ b/Object.h
@@ -81,6 +81,7 @@ public:
 	void setHp(int hp) { m_hp = hp; }
 	void setDamageCnt(int damageCnt) { m_damageCnt = damageCnt; }
 	void setEffectHandles(GraphHandles* effectHandles_p) { m_effectHandles_p = effectHandles_p; }
+	inline void setGraphHandle(GraphHandle* handle) { m_handle = handle; }
 	void setSoundHandle(int soundHandle_p) { m_soundHandle_p = soundHandle_p; }
 	virtual inline void setTextDisp(const bool textDisp) {}
 

--- a/Story.cpp
+++ b/Story.cpp
@@ -95,6 +95,9 @@ void Story::loadCsvData(const char* fileName, World* world, SoundPlayer* soundPl
 	if (dateData.size() > 0) {
 		m_date = stoi(dateData[0]["num"]);
 	}
+	if (m_date == 0) {
+		m_world_p->setDate(m_date);
+	}
 
 	// 世界のバージョンを取得しロードする 変化ない(updateが0)ならロードしない
 	vector<map<string, string> > versionData = csvReader2.getDomainData("VERSION:");
@@ -193,9 +196,9 @@ void Story::setWorld(World* world) {
 	}
 }
 
-// 前のセーブポイントへ戻る必要があるか
-bool Story::getBackPrevSaveFlag() const {
-	return m_nowEvent != nullptr ? m_nowEvent->getBackPrevSaveFlag() : false;
+// 前のセーブポイントへ戻る必要があるか 戻るならいくつ分戻るか返す(>0)
+int Story::getBackPrevSave() const {
+	return m_nowEvent != nullptr ? m_nowEvent->getBackPrevSave() : false;
 }
 
 // 前のセーブポイントへ戻ったことを教えてもらう

--- a/Story.h
+++ b/Story.h
@@ -77,7 +77,7 @@ public:
 	inline CharacterLoader* getCharacterLoader() const { return m_characterLoader; }
 	inline ObjectLoader* getObjectLoader() const { return m_objectLoader; }
 	inline const World* getWorld() const { return m_world_p; }
-	bool getBackPrevSaveFlag() const;
+	int getBackPrevSave() const;
 
 	// ƒZƒbƒ^
 	void setWorld(World* world);

--- a/World.h
+++ b/World.h
@@ -166,6 +166,7 @@ public:
 	inline int getCharacterDeadSound() const { return m_characterDeadSound; }
 	inline int getBombSound() const { return m_bombSound; }
 	inline int getDoorSound() const { return m_doorSound; }
+	inline bool getSkillFlag() const { return m_skillFlag; }
 
 	// Drawer—p‚ÌƒQƒbƒ^
 	std::vector<const CharacterAction*> getActions() const;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
- スキル発動イベント(WaitSkill)追加
- スキル発動時にヒエラルキーが一点に射撃し続けるバグを修正
- PlayerDeadEventでハートがやられた際2つ以上前のセーブポイントに戻れるようにする。
- スキル発動の瞬間にステージ上の弾丸の画像が消えるバグを修正

# やったこと
- WaitSkillEventの追加
  - スキルを発動し、そのスキルが終了したときにSUCCESSを返す。
- ヒエラルキーの射撃バグ修正のためBrain::bulletOrderを修正
  - 射撃時に1を固定でreturnしていたが、これだとrecorderがずっと同じ入力をし続けているとみなしてしまう。
- PlayerDeadEventでハートがやられた際に何個前のセーブデータまで戻るか指定できるようにした。
- BulletOrder::createCopyで画像のコピーが漏れていたので追加。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認

# 懸念点
まだスキル発動回数に制限がない。
