### PR TITLE
ダメージの当たり判定を分離＆当たり判定の修正

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -271,6 +271,31 @@ void Character::getHandleSize(int& wide, int& height) const {
 // “–‚½‚è”»’è‚Ì”ÍˆÍ‚ðŽæ“¾
 void Character::getAtariArea(int* x1, int* y1, int* x2, int* y2) const {
 	m_graphHandle->getAtari(x1, y1, x2, y2);
+	if (m_leftDirection) {
+		int wide = getWide();
+		*x1 = wide - *x1;
+		*x2 = wide - *x2;
+		int tmp = *x1;
+		*x1 = *x2;
+		*x2 = tmp;
+	}
+	*x1 = *x1 + m_x;
+	*y1 = *y1 + m_y;
+	*x2 = *x2 + m_x;
+	*y2 = *y2 + m_y;
+}
+
+// “–‚½‚è”»’è‚Ì”ÍˆÍ‚ðŽæ“¾
+void Character::getDamageArea(int* x1, int* y1, int* x2, int* y2) const {
+	m_graphHandle->getDamage(x1, y1, x2, y2);
+	if (m_leftDirection) {
+		int wide = getWide();
+		*x1 = wide - *x1;
+		*x2 = wide - *x2;
+		int tmp = *x1;
+		*x1 = *x2;
+		*x2 = tmp;
+	}
 	*x1 = *x1 + m_x;
 	*y1 = *y1 + m_y;
 	*x2 = *x2 + m_x;
@@ -295,6 +320,16 @@ int Character::getWide() const {
 }
 int Character::getHeight() const {
 	return m_graphHandle->getHeight();
+}
+int Character::getAtariCenterX() const {
+	int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+	getAtariArea(&x1, &y1, &x2, &y2);
+	return (x1 + x2) / 2;
+}
+int Character::getAtariCenterY() const {
+	int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+	getAtariArea(&x1, &y1, &x2, &y2);
+	return (y1 + y2) / 2;
 }
 
 void Character::setLeftDirection(bool leftDirection) { 
@@ -568,14 +603,14 @@ Object* Siesta::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer
 	int centerX = getCenterX();
 	int height = getHeight();
 	int x1 = centerX;
-	int x2 = centerX;
+	int x2 = x1;
 	if (leftDirection) { // ¶Œü‚«‚ÉUŒ‚
-		x1 += 50;
-		x2 -= m_attackInfo->slashLenX();
+		x1 += 100;
+		x2 = x1 - m_attackInfo->slashLenX();
 	}
 	else { // ‰EŒü‚«‚ÉUŒ‚
-		x1 -= 50;
-		x2 += m_attackInfo->slashLenX();
+		x1 -= 100;
+		x2 = x1 + m_attackInfo->slashLenX();
 	}
 
 	// UŒ‚‚Ì‰æ‘œ‚ÆŽ‘±ŽžŠÔ(cnt‚ðl—¶‚µ‚ÄŒˆ’è)

--- a/Character.h
+++ b/Character.h
@@ -298,6 +298,7 @@ public:
 
 	// 当たり判定の範囲を取得
 	void getAtariArea(int* x1, int* y1, int* x2, int* y2) const;
+	void getDamageArea(int* x1, int* y1, int* x2, int* y2) const;
 
 	// Infoのバージョンを変更する
 	void changeInfoVersion(int version);
@@ -307,6 +308,8 @@ public:
 	int getCenterY() const;
 	int getWide() const;
 	int getHeight() const;
+	int getAtariCenterX() const;
+	int getAtariCenterY() const;
 	// 今描画する画像を取得
 	GraphHandle* getGraphHandle() const;
 	void getHandleSize(int& wide, int& height) const;

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -57,6 +57,7 @@ CharacterAction::CharacterAction(Character* character, SoundPlayer* soundPlayer_
 	m_soundPlayer_p = soundPlayer_p;
 
 	//初期状態
+	m_prevLeftDirection = m_character_p->getLeftDirection();
 	m_state = CHARACTER_STATE::STAND;
 	m_characterVersion = character->getVersion();
 	m_characterMoveSpeed = character->getMoveSpeed();
@@ -161,6 +162,10 @@ void CharacterAction::setCharacterFreeze(bool freeze) {
 
 // 行動前の処理 毎フレーム行う
 void CharacterAction::init() {
+
+	// 前のフレームのleftDirectionを保存しておく
+	m_prevLeftDirection = m_character_p->getLeftDirection();
+
 	// いったん全方向に動けるようにする
 	m_rightLock = false;
 	m_leftLock = false;
@@ -468,7 +473,10 @@ void StickAction::action() {
 void StickAction::switchHandle() {
 	// セット前の画像のサイズ
 	int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+	bool nowLeftDirection = m_character_p->getLeftDirection();
+	m_character_p->setLeftDirection(m_prevLeftDirection);
 	m_character_p->getAtariArea(&x1, &y1, &x2, &y2);
+	
 	// やられ画像
 	if (m_grand && m_character_p->getHp() == 0 && m_character_p->haveDeadGraph() && getState() != CHARACTER_STATE::DAMAGE) {
 		m_character_p->switchDead();
@@ -569,6 +577,9 @@ void StickAction::switchHandle() {
 			break;
 		}
 	}
+
+	m_character_p->setLeftDirection(nowLeftDirection);
+
 	// セット後の画像のサイズ
 	int afterX1 = 0, afterY1 = 0, afterX2 = 0, afterY2 = 0;
 	m_character_p->getAtariArea(&afterX1, &afterY1, &afterX2, &afterY2);
@@ -576,7 +587,6 @@ void StickAction::switchHandle() {
 	// サイズ変更による位置調整
 	afterChangeGraph(x1, afterX1, y1, afterY1, x2, afterX2, y2, afterY2);
 
-	m_character_p->setLeftDirection(m_character_p->getLeftDirection());
 }
 
 // 歩く ダメージ中、しゃがみ中、壁ぶつかり中は不可
@@ -840,7 +850,10 @@ CharacterAction* FlightAction::createCopy(std::vector<Character*> characters) {
 void FlightAction::switchHandle() {
 	// セット前の画像のサイズ
 	int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+	bool nowLeftDirection = m_character_p->getLeftDirection();
+	m_character_p->setLeftDirection(m_prevLeftDirection);
 	m_character_p->getAtariArea(&x1, &y1, &x2, &y2);
+
 	if (m_grand) { // 地面にいるとき
 		switch (getState()) {
 		case CHARACTER_STATE::STAND: //立ち状態
@@ -888,6 +901,9 @@ void FlightAction::switchHandle() {
 			break;
 		}
 	}
+
+	m_character_p->setLeftDirection(nowLeftDirection);
+
 	// セット後の画像のサイズ
 	int afterX1 = 0, afterY1 = 0, afterX2 = 0, afterY2 = 0;
 	m_character_p->getAtariArea(&afterX1, &afterY1, &afterX2, &afterY2);
@@ -895,7 +911,6 @@ void FlightAction::switchHandle() {
 	// サイズ変更による位置調整
 	afterChangeGraph(x1, afterX1, y1, afterY1, x2, afterX2, y2, afterY2);
 
-	m_character_p->setLeftDirection(m_character_p->getLeftDirection());
 }
 
 // 物理演算 毎フレーム行う

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -36,6 +36,9 @@ protected:
 	// 動かすキャラクター
 	Character* m_character_p;
 
+	// 前のフレームのleftDirection
+	bool m_prevLeftDirection;
+
 	// キャラのバージョン イベントでrunSpeedの変更した場合に対処するため
 	int m_characterVersion;
 	int m_characterMoveSpeed;

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -43,14 +43,16 @@ CharacterDrawer::CharacterDrawer(const CharacterAction* const characterAction) {
 	getGameEx(m_exX, m_exY);
 
 	// デバッグ用
-	m_guideHandle = LoadGraph("picture/stick/atariGuide.png");
+	m_atariGuideHandle = LoadGraph("picture/stick/atariGuide.png");
+	m_damageGuideHandle = LoadGraph("picture/stick/damageGuide.png");
 	m_characterAction = characterAction;
 
 }
 
 CharacterDrawer::~CharacterDrawer() {
 	// デバッグ用
-	DeleteGraph(m_guideHandle);
+	DeleteGraph(m_atariGuideHandle);
+	DeleteGraph(m_damageGuideHandle);
 }
 
 // キャラを描画する
@@ -109,11 +111,18 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int enemyNoticeH
 
 	// デバッグ用
 	if (ATARI_DEBUG) {
+		// 壁や床との当たり判定
 		int x2 = 0, y2 = 0;
 		character->getAtariArea(&x1, &y1, &x2, &y2);
 		camera->setCamera(&x1, &y1, &ex);
 		camera->setCamera(&x2, &y2, &ex);
-		DrawExtendGraph(x1, y1, x2, y2, m_guideHandle, TRUE);
+		DrawExtendGraph(x1, y1, x2, y2, m_atariGuideHandle, TRUE);
+
+		// ダメージの当たり判定
+		character->getDamageArea(&x1, &y1, &x2, &y2);
+		camera->setCamera(&x1, &y1, &ex);
+		camera->setCamera(&x2, &y2, &ex);
+		DrawExtendGraph(x1, y1, x2, y2, m_damageGuideHandle, TRUE);
 	}
 
 }

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -13,7 +13,7 @@ class CharacterDrawer {
 private:
 
 	// デバッグ用
-	const bool ATARI_DEBUG = true;
+	const bool ATARI_DEBUG = false;
 	int m_atariGuideHandle;
 	int m_damageGuideHandle;
 

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -13,8 +13,9 @@ class CharacterDrawer {
 private:
 
 	// デバッグ用
-	const bool ATARI_DEBUG = false;
-	int m_guideHandle;
+	const bool ATARI_DEBUG = true;
+	int m_atariGuideHandle;
+	int m_damageGuideHandle;
 
 	// キャラの動きの情報 const関数しか呼ばない
 	const CharacterAction* m_characterAction;

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 18;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = true;
+const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -21,9 +21,9 @@ using namespace std;
 
 
 // どこまで
-const int FINISH_STORY = 15;
+const int FINISH_STORY = 18;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = false;
+const bool TEST_MODE = true;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -86,6 +86,34 @@ public:
 
 
 /*
+* “–‚½‚è”»’è‚Ìî•ñ
+*/
+class AtariArea {
+private:
+	// “–‚½‚è”»’è
+	bool m_defaultWide, m_defaultHeight;
+	int m_wide, m_height;
+	int m_x1, m_y1, m_x2, m_y2;
+	bool m_x1none, m_y1none, m_x2none, m_y2none;
+
+public:
+	AtariArea(CsvReader* csvReader, const char* graphName, const char* prefix);
+
+	bool getDefaultWide() const { return m_defaultWide; }
+	bool getDefaultHeight() const { return m_defaultHeight; }
+	bool getWide() const { return m_wide; }
+	bool getHeight() const { return m_height; }
+	bool getX1() const { return m_x1; }
+	bool getY1() const { return m_y1; }
+	bool getX2() const { return m_x2; }
+	bool getY2() const { return m_y2; }
+
+	void getArea(int* x1, int* y1, int* x2, int* y2, int wide, int height) const;
+
+};
+
+
+/*
 * “–‚½‚è”»’è‚Ìî•ñ•t‚«‚ÌGraphHandles
 */
 class GraphHandlesWithAtari {
@@ -94,9 +122,8 @@ private:
 	GraphHandles* m_graphHandles;
 
 	// “–‚½‚è”»’è
-	bool m_defaultWide, m_defaultHeight;
-	int m_wide, m_height;
-	int m_x1, m_y1, m_x2, m_y2;
+	AtariArea* m_atariArea;
+	AtariArea* m_damageArea;
 
 public:
 
@@ -106,6 +133,7 @@ public:
 	GraphHandles* getGraphHandles() const { return m_graphHandles; }
 
 	void getAtari(int* x1, int* y1, int* x2, int* y2, int index) const;
+	void getDamage(int* x1, int* y1, int* x2, int* y2, int index) const;
 
 };
 
@@ -237,6 +265,7 @@ public:
 	inline int getWide() const { return m_wide; }
 	inline int getHeight() const { return m_height; }
 	void getAtari(int* x1, int* y1, int* x2, int* y2) const;
+	void getDamage(int* x1, int* y1, int* x2, int* y2) const;
 
 	// ‰æ‘œ‚ÌƒQƒbƒ^
 	inline GraphHandlesWithAtari* getSlashHandle() { return m_slashHandles; }

--- a/Object.cpp
+++ b/Object.cpp
@@ -640,7 +640,7 @@ bool BulletObject::atari(CharacterController* characterController) {
 	int characterY1 = characterController->getAction()->getCharacter()->getY();
 	int characterX2 = characterX1 + characterController->getAction()->getCharacter()->getWide();
 	int characterY2 = characterY1 + characterController->getAction()->getCharacter()->getHeight();
-	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
+	characterController->getAction()->getCharacter()->getDamageArea(&characterX1, &characterY1, &characterX2, &characterY2);
 
 	// “–‚½‚è”»’è
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2 && characterController->getAction()->ableDamage()) {
@@ -806,7 +806,7 @@ bool SlashObject::atari(CharacterController* characterController) {
 	int characterY1 = characterController->getAction()->getCharacter()->getY();
 	int characterX2 = characterX1 + characterController->getAction()->getCharacter()->getWide();
 	int characterY2 = characterY1 + characterController->getAction()->getCharacter()->getHeight();
-	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
+	characterController->getAction()->getCharacter()->getDamageArea(&characterX1, &characterY1, &characterX2, &characterY2);
 
 	// “–‚½‚è”»’è
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2 && characterController->getAction()->ableDamage()) {
@@ -892,7 +892,7 @@ bool BombObject::atari(CharacterController* characterController) {
 	int characterY1 = characterController->getAction()->getCharacter()->getY();
 	int characterX2 = characterX1 + characterController->getAction()->getCharacter()->getWide();
 	int characterY2 = characterY1 + characterController->getAction()->getCharacter()->getHeight();
-	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
+	characterController->getAction()->getCharacter()->getDamageArea(&characterX1, &characterY1, &characterX2, &characterY2);
 
 	// “–‚½‚è”»’è
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2 && characterController->getAction()->ableDamage()) {

--- a/World.cpp
+++ b/World.cpp
@@ -736,7 +736,7 @@ void World::updateCamera() {
 	for (unsigned int i = 0; i < size; i++) {
 		// 今フォーカスしているキャラの座標に合わせる
 		if (m_focusId == m_characters[i]->getId()) {
-			m_camera->setGPoint(m_characters[i]->getCenterX(), m_characters[i]->getCenterY());
+			m_camera->setGPoint(m_characters[i]->getAtariCenterX(), m_characters[i]->getAtariCenterY());
 		}
 		// フォーカスしているキャラ以外なら距離を調べる
 		else if (m_characters[i]->getHp() > 0) {


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
ボス戦実装の前段階として、ダメージの当たり判定を壁や床の当たり判定と分離する。

これによって弱点を持つボスを実装できる。

また、当たり判定について以下の不具合を修正。
- キャラが左を向くと当たり判定がおかしくなるのを修正。
- カメラはキャラの画像ではなく、壁床の当たり判定の中央を追従するように変更。
- 

# やったこと
キャラが左を向くと当たり判定がおかしくなるバグ
- 当たり判定について、x1, y1, x2, y2を直接指定すると、当然左右非対称の当たり判定にもできる。その時、キャラの向きを変えるとワープしてしまう。
- キャラが左向きなら当たり判定の範囲を調節する。
- また、CharacterActionは前のフレームのキャラの向きを保存しておき、画像の変化だけではなくキャラの向きの変化も利用して当たり判定の範囲の変化を取得し、座標を調節する。

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [x] デバッグモードで確認

https://github.com/kuriuminoki/DuplicationHeart/assets/92528385/c87be06b-74b7-4410-8c6d-9999632e0b36


# 懸念点
記入欄
