### PR TITLE
FlightActionのバグ修正

### DIFF
--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -931,14 +931,7 @@ void FlightAction::action() {
 	}
 
 	// ダメージ受け状態は最低１秒近くある
-	if (m_damageCnt > 0) { 
-		m_damageCnt--;
-		if (m_damageCnt == 0) {
-			m_vx = 0;
-			m_vy = 0;
-			m_state = CHARACTER_STATE::STAND;
-		}
-	}
+	if (m_damageCnt > 0) { m_damageCnt--; }
 
 	// アニメーション用のカウント
 	if (m_landCnt > 0) { m_landCnt--; }

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -13,7 +13,7 @@ class CharacterDrawer {
 private:
 
 	// デバッグ用
-	const bool ATARI_DEBUG = false;
+	const bool ATARI_DEBUG = true;
 	int m_atariGuideHandle;
 	int m_damageGuideHandle;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 18;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = false;
+const bool TEST_MODE = true;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
FlightActionにバグがあり、heavy=trueのキャラが移動中のときダメージを受けると逆方向への速度が発生する。

# やったこと
StickActionにはないバグだったので、そちらの実装を参考に修正。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [ ] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
