### PR TITLE
ブースト機能の追加

### DIFF
--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -977,7 +977,12 @@ void FlightAction::action() {
 
 	// アニメーション用のカウント
 	if (m_landCnt > 0) { m_landCnt--; }
-	if (m_boostCnt > 0) { m_boostCnt--; }
+	if (m_boostCnt > 0) { 
+		m_boostCnt--;
+		if (m_boostCnt == 0) {
+			//finishBoost();
+		}
+	}
 
 	// 移動
 	if (m_vx > 0) {// 右
@@ -1090,6 +1095,26 @@ void FlightAction::move(bool right, bool left, bool up, bool down) {
 // ジャンプ cntフレーム目
 void FlightAction::jump(int cnt) {
 	
+}
+
+void FlightAction::setBoost(bool leftDirection) {
+	if ((leftDirection && m_leftLock) || (!leftDirection && m_rightLock)) {
+		return;
+	}
+	if (!damageFlag() && !m_grand && !m_boostDone) {
+		m_boostCnt = BOOST_TIME;
+		finishBullet();
+		finishSlash();
+		if (leftDirection) {
+			m_vx -= BOOST_SPEED;
+			m_boostDone = 2;
+		}
+		else {
+			m_vx += BOOST_SPEED;
+			m_boostDone = 1;
+		}
+		m_character_p->setLeftDirection(leftDirection);
+	}
 }
 
 // 射撃攻撃

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -973,14 +973,21 @@ void FlightAction::action() {
 	}
 
 	// ダメージ受け状態は最低１秒近くある
-	if (m_damageCnt > 0) { m_damageCnt--; }
+	if (m_damageCnt > 0) {
+		m_damageCnt--;
+		if (m_damageCnt == 0 && !m_heavy) {
+			m_vx = 0;
+			m_vy = 0;
+			m_state = CHARACTER_STATE::STAND;
+		}
+	}
 
 	// アニメーション用のカウント
 	if (m_landCnt > 0) { m_landCnt--; }
 	if (m_boostCnt > 0) { 
 		m_boostCnt--;
 		if (m_boostCnt == 0) {
-			//finishBoost();
+			finishBoost();
 		}
 	}
 

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -899,7 +899,10 @@ void FlightAction::switchHandle() {
 	if (m_grand) { // 地面にいるとき
 		switch (getState()) {
 		case CHARACTER_STATE::STAND: //立ち状態
-			if (m_slashCnt > 0) {
+			if (m_runCnt != -1) {
+				m_character_p->switchRun(m_runCnt);
+			}
+			else if (m_slashCnt > 0) {
 				m_character_p->switchAirSlash();
 			}
 			else if (m_bulletCnt > 0) {
@@ -1059,16 +1062,10 @@ void FlightAction::walk(bool right, bool left, bool up, bool down) {
 	// 右へ歩き始める
 	if (!m_rightLock && !m_moveRight && !m_moveLeft && right && (!left || !m_character_p->getLeftDirection()) && !m_squat) { // 右へ歩く
 		startMoveRight();
-		if(m_grand){
-			startMoveUp();
-		}
 	}
 	// 左へ歩き始める
 	if (!m_leftLock && !m_moveRight && !m_moveLeft && left && (!right || m_character_p->getLeftDirection()) && !m_squat) { // 左へ歩く
 		startMoveLeft();
-		if (m_grand) {
-			startMoveUp();
-		}
 	}
 	// 上へ歩き始める
 	if (!m_upLock && !m_moveDown && !m_moveUp && up && !down) { // 上へ歩く

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -159,7 +159,7 @@ public:
 	void setLeftLock(bool lock);
 	void setUpLock(bool lock);
 	void setDownLock(bool lock);
-	void setBoost(bool leftDirection);
+	virtual void setBoost(bool leftDirection);
 	void finishBoost();
 	inline void setGrandRightSlope(bool grand) { m_grandRightSlope = grand; }
 	inline void setGrandLeftSlope(bool grand) { m_grandLeftSlope = grand; }
@@ -372,6 +372,8 @@ public:
 
 	// ジャンプ cntフレーム目
 	void jump(int cnt);
+
+	void setBoost(bool leftDirection);
 
 	// 射撃攻撃
 	Object* bulletAttack(int gx, int gy);

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -72,7 +72,9 @@ protected:
 
 	// ブーストアニメの残り時間 または受け身状態
 	int m_boostCnt;
-	const int BOOST_TIME = 10;
+	const int BOOST_TIME = 30;
+	const int BOOST_SPEED = 6;
+	int m_boostDone;// 0:none 1:right 2:left
 
 	// やられ状態の時間
 	const int DAMAGE_TIME = 20;
@@ -157,7 +159,8 @@ public:
 	void setLeftLock(bool lock);
 	void setUpLock(bool lock);
 	void setDownLock(bool lock);
-	inline void setBoost() { if(!m_grand) m_boostCnt = BOOST_TIME; }
+	void setBoost(bool leftDirection);
+	void finishBoost();
 	inline void setGrandRightSlope(bool grand) { m_grandRightSlope = grand; }
 	inline void setGrandLeftSlope(bool grand) { m_grandLeftSlope = grand; }
 	void setRunCnt(int runCnt) { m_runCnt = runCnt; }
@@ -173,6 +176,7 @@ public:
 	void setAttackLeftDirection(bool attackLeftDirection) { m_attackLeftDirection = attackLeftDirection; }
 	void setLandCnt(int landCnt) { m_landCnt = landCnt; }
 	void setBoostCnt(int boostCnt) { m_boostCnt = boostCnt; }
+	void setBoostDone(int boostDone) { m_boostDone = boostDone; }
 	void setDamageCnt(int damageCnt) { m_damageCnt = damageCnt; }
 	void setHeavy(bool heavy) { m_heavy = heavy; }
 

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -170,9 +170,6 @@ void CharacterController::setActionUpLock(bool lock) {
 void CharacterController::setActionDownLock(bool lock) {
 	m_characterAction->setDownLock(lock);
 }
-void CharacterController::setActionBoost() {
-	m_characterAction->setBoost();
-}
 
 // キャラクターのセッタ
 void CharacterController::setCharacterX(int x) {
@@ -326,9 +323,6 @@ void NormalController::control() {
 		}
 		else {
 			jump = m_brain->jumpOrder();
-			if (jump == 1) {
-				jump;
-			}
 			m_jumpRecorder->writeRecord(jump);
 		}
 		m_jumpRecorder->addTime();
@@ -337,6 +331,11 @@ void NormalController::control() {
 		jump = m_brain->jumpOrder();
 	}
 	m_characterAction->jump(jump);
+
+	// ブースト
+	if (jump == 1 && (rightStick > 0 || leftStick > 0)) {
+		m_characterAction->setBoost(leftStick > rightStick);
+	}
 
 	// しゃがみ
 	int squat = 0;

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -90,7 +90,6 @@ public:
 	void setActionLeftLock(bool lock);
 	void setActionUpLock(bool lock);
 	void setActionDownLock(bool lock);
-	void setActionBoost();
 
 	// キャラクターのセッタ
 	void setCharacterX(int x);

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -85,7 +85,7 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int enemyNoticeH
 	}
 
 	// 描画 ダメージ状態なら点滅
-	if (m_characterAction->getState() == CHARACTER_STATE::DAMAGE && ++m_cnt / 2 % 2 == 1) {
+	if (!m_characterAction->ableDamage() && ++m_cnt / 2 % 2 == 1) {
 		int dark = max(0, bright - 100);
 		SetDrawBright(dark, dark, dark);
 		graphHandle->draw(x, y, ex);

--- a/Object.cpp
+++ b/Object.cpp
@@ -338,8 +338,8 @@ bool TriangleObject::atari(CharacterController* characterController) {
 	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
 	characterWide = characterX2 - characterX1;
 	characterHeight = characterY2 - characterY1;
-	characterX1_5 = characterX1 + characterWide / 2;
-	characterY1_5 = characterY1 + characterHeight / 2;
+	characterX1_5 = (characterX1 + characterX2) / 2;
+	characterY1_5 = (characterY1 + characterY2) / 2;
 
 	// キャラが上下移動で当たっているか判定
 	if (characterX2 > m_x1 && characterX1 < m_x2) {
@@ -486,8 +486,8 @@ void TriangleObject::penetration(CharacterController* characterController) {
 	characterController->getAction()->getCharacter()->getAtariArea(&characterX1, &characterY1, &characterX2, &characterY2);
 	characterWide = characterX2 - characterX1;
 	characterHeight = characterY2 - characterY1;
-	characterX1_5 = characterX1 + characterWide / 2;
-	characterY1_5 = characterY1 + characterHeight / 2;
+	characterX1_5 = (characterX1 + characterX2) / 2;
+	characterY1_5 = (characterY1 + characterY2) / 2;
 	int slopeY = getY(characterX1_5);
 	// 万が一オブジェクトの中に入り込んでしまったら
 	if (characterY2 > slopeY && characterY1 < m_y2 && characterX2 > m_x1 && characterX1 < m_x2) {


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
現状、敵の攻撃を回避するのが難しく、あまり戦略やプレイヤーのテクニックが必要ないゲームになっている。

空中でジャンプボタンを押すと移動方向へ少し加速し、一瞬無敵時間がある「ブースト状態」を追加する。

ブーストは以下の条件で発動できる。
- 空中にいる
- ~~一度発動したら、一度着地するまで再度発動はできない~~
- 一度発動したら、一度終了するまで再度発動はできない。
- ダメージ中・受け身中は不可

ブーストによって以下の変化がある。
- x、y方向へ加速する。
- 10フレームほど無敵時間がある。
- 今実行中の攻撃がキャンセルされる。
- キャラが「ブースト状態」の画像になる。

ブーストは以下の条件で終了する。
- 着地
- 壁にぶつかる
- 移動をやめる

#181 これも対処したい。
- #179 をRevertしたうえで、Damage状態終了の条件にm_heavy=falseであることを加える。

FlightActionの離陸の仕様変更
- 着地状態で横移動すると離陸する仕様だったが、坂道での挙動がおかしくなるので離陸しない仕様に変更。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [x] デバッグモードで確認

# 懸念点
記入欄
