### PR TITLE
Bombのダメージ計算を修正

### DIFF
--- a/Object.cpp
+++ b/Object.cpp
@@ -896,7 +896,15 @@ bool BombObject::atari(CharacterController* characterController) {
 
 	// “–‚½‚è”»’è
 	if (characterX2 > m_x1 && characterX1 < m_x2 && characterY2 > m_y1 && characterY1 < m_y2 && characterController->getAction()->ableDamage()) {
-		double damageRate = calcDamageRate(characterController->getAction()->getCharacter()->getCenterX(), characterController->getAction()->getCharacter()->getCenterY());
+		double damageRate = 1.0;
+		int x = characterX1, y = abs(characterY1 - m_y);
+		if (abs(characterX2 - m_x) < abs(characterX1 - m_x)) {
+			x = characterX2;
+		}
+		if (abs(characterY2 - m_y) < abs(characterY1 - m_y)) {
+			y = characterY2;
+		}
+		damageRate = calcDamageRate(x, y);
 		int bombImpact = (int)(damageRate * BOMB_IMPACT);
 		if (characterX1 + characterX2 < m_x1 + m_x2) {
 			characterController->damage(-bombImpact, -bombImpact, (int)(m_damage * damageRate));
@@ -946,8 +954,8 @@ void BombObject::action() {
 double BombObject::calcDamageRate(int x, int y) {
 	x -= m_x;
 	y -= m_y;
-	double distance = sqrt(x * x + y + y);
-	return (m_distance - distance) / m_distance;
+	double distance = sqrt(x * x + y * y);
+	return min(1.0, (m_distance - distance) / m_distance);
 }
 
 bool BombObject::ableDamage() {


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
掛け算を間違えて足し算にしており、爆発で即死することがあったので修正。

また、キャラと爆心地の距離の計算を修正。キャラの中心からの距離ではなくキャラの左端か右端の近い方を距離とする。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
