### PR TITLE
スキルゲージの追加

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -18,6 +18,9 @@ using namespace std;
 Animation::Animation(int x, int y, int flameCnt, GraphHandles* graphHandles) {
 	m_x = x;
 	m_y = y;
+	m_vx = 0;
+	m_vy = 0;
+	m_movable = false;
 	m_handles_p = graphHandles;
 	m_flameCnt = flameCnt;
 	m_loopFlag = false;
@@ -26,6 +29,9 @@ Animation::Animation(int x, int y, int flameCnt, GraphHandles* graphHandles) {
 
 Animation* Animation::createCopy() {
 	Animation* res = new Animation(m_x, m_y, m_flameCnt, m_handles_p);
+	res->setVx(m_vx);
+	res->setVy(m_vy);
+	res->setMovable(m_movable);
 	res->setCnt(m_cnt);
 	res->setFinishCnt(m_finishCnt);
 	res->setFinishFlag(m_finishFlag);
@@ -49,6 +55,10 @@ void Animation::changeGraph(GraphHandles* nextGraph, int flameCnt) {
 
 // ƒJƒEƒ“ƒg
 void Animation::count() { 
+	if (m_movable) {
+		m_x += m_vx;
+		m_y += m_vy;
+	}
 	if (m_cnt == m_finishCnt) {
 		if (m_loopFlag) {
 			init();

--- a/Animation.h
+++ b/Animation.h
@@ -17,6 +17,12 @@ private:
 
 	// 座標
 	int m_x, m_y;
+
+	// 速度
+	int m_vx, m_vy;
+
+	// 速度を使う
+	bool m_movable;
 	
 	// カウント
 	int m_cnt;
@@ -41,12 +47,17 @@ public:
 	// ゲッタ
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
+	inline int getVx() const { return m_vx; }
+	inline int getVy() const { return m_vy; }
 	inline bool getFinishFlag() const { return m_finishFlag; }
 	inline int getCnt() const { return m_cnt; }
 
 	// セッタ
 	inline void setX(int x) { m_x = x; }
 	inline void setY(int y) { m_y = y; }
+	inline void setVx(int vx) { m_vx = vx; }
+	inline void setVy(int vy) { m_vy = vy; }
+	inline void setMovable(bool movable) { m_movable = movable; }
 	inline void setCnt(int cnt) { m_cnt = cnt; }
 	inline void setFinishCnt(int finishCnt) { m_finishCnt = finishCnt; }
 	inline void setFinishFlag(bool finishFlag) { m_finishFlag = finishFlag; }

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -356,7 +356,7 @@ int NormalAI::jumpOrder() {
 	int maxJump = m_characterAction_p->getPreJumpMax();
 	int minJump = maxJump / 3;
 
-	if (m_characterAction_p->getPreJumpCnt() == -1) {
+	if (m_characterAction_p->getPreJumpCnt() == -1 && m_characterAction_p->getGrand()) {
 		// ランダムでジャンプ
 		if (m_squatCnt == 0 && GetRand(99) == 0) { m_jumpCnt = GetRand(maxJump - minJump) + minJump; }
 
@@ -406,7 +406,7 @@ int NormalAI::slashOrder() {
 		return 0;
 	}
 	// ランダムで斬撃
-	if (GetRand(50) == 0) {
+	if (GetRand(120) == 0) {
 		return 1;
 	}
 	return 0;

--- a/Character.cpp
+++ b/Character.cpp
@@ -214,6 +214,7 @@ Character::Character(int hp, int x, int y, int groupId) {
 	m_hp = hp;
 	m_prevHp = m_hp;
 	m_dispHpCnt = 0;
+	m_skillGage = SKILL_MAX;
 	m_invincible = false;
 	m_x = x;
 	m_y = y;
@@ -254,6 +255,7 @@ void Character::setParam(Character* character) {
 	character->setLeftDirection(m_leftDirection);
 	character->setHp(m_hp);
 	character->setPrevHp(m_prevHp);
+	character->setSkillGage(m_skillGage);
 	character->setInvincible(m_invincible);
 	character->getCharacterGraphHandle()->setGraph(m_graphHandle->getDispGraphHandle(), m_graphHandle->getDispGraphIndex());
 }

--- a/Character.h
+++ b/Character.h
@@ -210,6 +210,10 @@ protected:
 	// HPバーを表示する残り時間
 	int m_dispHpCnt;
 
+	// スキルゲージ 最大100
+	const int SKILL_MAX = 100;
+	int m_skillGage;
+
 	// 無敵ならtrue
 	bool m_invincible;
 
@@ -253,6 +257,8 @@ public:
 	inline int getVersion() const { return m_version; }
 	inline int getHp() const { return m_hp; }
 	inline int getPrevHp() const { return m_prevHp; }
+	inline int getSkillGage() const { return m_skillGage; }
+	inline int getMaxSkillGage() const { return SKILL_MAX; }
 	inline int getDispHpCnt() const { return m_dispHpCnt; }
 	inline bool getInvincible() const { return m_invincible; }
 	inline int getX() const { return m_x; }
@@ -269,6 +275,9 @@ public:
 	inline void setPrevHp(int prevHp) { 
 		m_prevHp = (prevHp < m_hp) ? m_hp : prevHp;
 		if (m_prevHp == m_hp && m_dispHpCnt > 0) { m_dispHpCnt--; }
+	}
+	inline void setSkillGage(int skillGage) { 
+		m_skillGage = skillGage > SKILL_MAX ? SKILL_MAX : (skillGage < 0 ? 0 : skillGage);
 	}
 	inline void setInvincible(bool invincible) { m_invincible = invincible; }
 	inline void setX(int x) { m_x = x; }

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -57,6 +57,7 @@ CharacterAction::CharacterAction(Character* character, SoundPlayer* soundPlayer_
 	m_soundPlayer_p = soundPlayer_p;
 
 	//初期状態
+	m_cnt = 0;
 	m_prevLeftDirection = m_character_p->getLeftDirection();
 	m_state = CHARACTER_STATE::STAND;
 	m_characterVersion = character->getVersion();
@@ -99,6 +100,7 @@ CharacterAction::CharacterAction() :
 }
 
 void CharacterAction::setParam(CharacterAction* action) {
+	action->setCnt(m_cnt);
 	action->setState(m_state);
 	action->setCharacterVersion(m_characterVersion);
 	action->setCharacterMoveSpeed(m_characterMoveSpeed);
@@ -196,6 +198,13 @@ void CharacterAction::setCharacterFreeze(bool freeze) {
 
 // 行動前の処理 毎フレーム行う
 void CharacterAction::init() {
+
+	m_cnt++;
+
+	// スキルゲージの回復
+	if (m_cnt % 30 == 29) {
+		m_character_p->setSkillGage(m_character_p->getSkillGage() + 1);
+	}
 
 	// 前のフレームのleftDirectionを保存しておく
 	m_prevLeftDirection = m_character_p->getLeftDirection();

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -27,6 +27,10 @@ enum class CHARACTER_STATE {
 */
 class CharacterAction {
 protected:
+
+	// 時間計測
+	int m_cnt;
+
 	// サウンドプレイヤー
 	SoundPlayer* m_soundPlayer_p;
 
@@ -150,6 +154,7 @@ public:
 	virtual int getPreJumpMax() const { return PRE_JUMP_MAX; }
 
 	// セッタ
+	inline void setCnt(int cnt) { m_cnt = cnt; }
 	void setState(CHARACTER_STATE state);
 	inline void setCharacterVersion(int version) { m_characterVersion = version; }
 	inline void setCharacterMoveSpeed(int moveSpeed) { m_characterMoveSpeed = moveSpeed; }

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -127,15 +127,7 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int enemyNoticeH
 
 }
 
-void CharacterDrawer::drawPlayerHpBar(const Character* player, int hpBarGraph) {
-
-	// 座標
-	int x, y, wide, height;
-
-	x = 30;
-	y = 30;
-	wide = 525;
-	height = 150;
+void CharacterDrawer::drawPlayerHpBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph) {
 
 	// 解像度変更に対応
 	x = (int)(x * m_exX);
@@ -151,5 +143,25 @@ void CharacterDrawer::drawPlayerHpBar(const Character* player, int hpBarGraph) {
 
 	// 体力の描画
 	drawHpBar(x + dx, y + dy1, x + wide - dx, y + height - dy2, player->getHp(), player->getPrevHp(), player->getMaxHp(), DAMAGE_COLOR, PREV_HP_COLOR, HP_COLOR);
+
+}
+
+void CharacterDrawer::drawPlayerSkillBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph) {
+
+	// 解像度変更に対応
+	x = (int)(x * m_exX);
+	y = (int)(y * m_exY);
+	wide = (int)(wide * m_exX);
+	height = (int)(height * m_exY);
+
+	DrawExtendGraph(x, y, x + wide, y + height, hpBarGraph, TRUE);
+
+	int dx1 = (int)(155 * m_exX);
+	int dx2 = (int)(50 * m_exX);
+	int dy1 = (int)(10 * m_exY);
+	int dy2 = (int)(10 * m_exY);
+
+	// 体力の描画
+	drawHpBar(x + dx1, y + dy1, x + wide - dx2, y + height - dy2, player->getSkillGage(), player->getSkillGage(), player->getMaxSkillGage(), WHITE, ORANGE, ORANGE);
 
 }

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -13,7 +13,7 @@ class CharacterDrawer {
 private:
 
 	// デバッグ用
-	const bool ATARI_DEBUG = true;
+	const bool ATARI_DEBUG = false;
 	int m_atariGuideHandle;
 	int m_damageGuideHandle;
 

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -45,7 +45,8 @@ public:
 
 	void drawCharacter(const Camera* const camera, int enemyNoticeHandle, int bright = 255);
 
-	void drawPlayerHpBar(const Character* player, int hpBarGraph);
+	void drawPlayerHpBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph);
+	void drawPlayerSkillBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph);
 
 };
 

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -23,10 +23,10 @@
 void Game::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**GAME**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "StoryNum=%d, doorSum=%d", m_gameData->getStoryNum(), m_gameData->getDoorSum());
-	for (int i = 0; i < m_gameData->getDoorSum(); i++) {
-		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE + ((i + 1) * DRAW_FORMAT_STRING_SIZE), color, "from=%d, to=%d", m_gameData->getFrom(i), m_gameData->getTo(i));
-	}
-	//m_story->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
+	//for (int i = 0; i < m_gameData->getDoorSum(); i++) {
+	//	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE + ((i + 1) * DRAW_FORMAT_STRING_SIZE), color, "from=%d, to=%d", m_gameData->getFrom(i), m_gameData->getTo(i));
+	//}
+	m_story->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	m_world->debug(1000, y + DRAW_FORMAT_STRING_SIZE * 3, color);
 }
 
@@ -60,7 +60,8 @@ void World::debug(int x, int y, int color) const {
 * Story
 */
 void Story::debug(int x, int y, int color) {
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "**Story**");
+	DrawFormatString(x, y, color, "**Story**");
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "MustEventSum=%d", m_mustEvent.size());
 }
 
 

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -44,7 +44,7 @@ void debugObjects(int x, int y, int color, std::vector<Object*> objects) {
 void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "areaNum=%d, CharacterSum=%d, ControllerSum=%d, cameraEx=%f", m_areaNum, m_characters.size(), m_characterControllers.size(), m_camera->getEx());
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "itemSum=%d", m_itemVector.size());
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "itemSum=%d, animeSum=%d", m_itemVector.size(), m_animations.size());
 	if (m_itemVector.size() > 0) {
 		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "itemY=%d", m_itemVector[0]->getY());
 	}

--- a/Define.h
+++ b/Define.h
@@ -38,5 +38,6 @@ const int RED = GetColor(255, 0, 0);
 const int LIGHT_RED = GetColor(255, 100, 100);
 const int BLUE = GetColor(0, 0, 255);
 const int LIGHT_BLUE = GetColor(100, 100, 255);
+const int ORANGE = GetColor(255, 165, 0);
 
 #endif

--- a/Event.cpp
+++ b/Event.cpp
@@ -270,7 +270,10 @@ bool CharacterNearFire::fire() {
 		m_areaNum = m_world_p->getAreaNum();
 		m_target_p = m_world_p->getCharacterWithName(m_param[2]);
 	}
-	if (m_target_p == nullptr) { return false; }
+	if (m_target_p == nullptr) { 
+		m_target_p = m_world_p->getCharacterWithName(m_param[2]);
+		return false;
+	}
 	int x = m_character_p->getCenterX();
 	int y = m_character_p->getY() + m_character_p->getHeight();
 	int targetX = m_target_p->getCenterX();

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 18;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = true;
+const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -35,6 +35,7 @@ CharacterData::CharacterData(const char* name) {
 	m_version = 1;
 	m_name = name;
 	m_hp = -1;
+	m_skillGage = 0;
 	m_invincible = false;
 	// id=-1はデータなしを意味する
 	m_id = -1;
@@ -53,6 +54,7 @@ CharacterData::CharacterData(const char* name) {
 void CharacterData::save(FILE* intFp, FILE* strFp) {
 	fwrite(&m_version, sizeof(m_version), 1, intFp);
 	fwrite(&m_hp, sizeof(m_hp), 1, intFp);
+	fwrite(&m_skillGage, sizeof(m_skillGage), 1, intFp);
 	fwrite(&m_invincible, sizeof(m_invincible), 1, intFp);
 	fwrite(&m_id, sizeof(m_id), 1, intFp);
 	fwrite(&m_groupId, sizeof(m_groupId), 1, intFp);
@@ -73,6 +75,7 @@ void CharacterData::save(FILE* intFp, FILE* strFp) {
 void CharacterData::load(FILE* intFp, FILE* strFp) {
 	fread(&m_version, sizeof(m_version), 1, intFp);
 	fread(&m_hp, sizeof(m_hp), 1, intFp);
+	fread(&m_skillGage, sizeof(m_skillGage), 1, intFp);
 	fread(&m_invincible, sizeof(m_invincible), 1, intFp);
 	fread(&m_id, sizeof(m_id), 1, intFp);
 	fread(&m_groupId, sizeof(m_groupId), 1, intFp);
@@ -711,16 +714,23 @@ bool Game::ableDraw() {
 	return !m_story->getInitDark();
 }
 
+// スキル発動できるところまでストーリーが進んでいるか
+bool Game::afterSkillUsableStoryNum() const {
+	return m_gameData->getStoryNum() >= SKILL_USEABLE_STORY;
+}
+
 // スキル発動可能かチェック
 bool Game::skillUsable() {
 	if (TEST_MODE) {
 		return true;
 	}
 	// スキル発動 Fキーかつスキル未発動状態かつ発動可能なイベント中（もしくはイベント中でない）かつエリア移動中でない
-	if (m_gameData->getStoryNum() >= SKILL_USEABLE_STORY) { // ストーリーの最初は発動できない
+	if (afterSkillUsableStoryNum()) { // ストーリーの最初は発動できない
 		if (m_skill == nullptr) { // スキル未発動時
 			if (m_story->skillAble() && m_world->getBrightValue() == 255) { // 特定のイベント時やエリア移動中はダメ
-				if (m_world->getCharacterWithName("ハート")->getHp() > 0) {
+				Character* character = m_world->getCharacterWithName("ハート");
+				if (character->getHp() > 0 && character->getSkillGage() == character->getMaxSkillGage()) {
+					character->setSkillGage(0);
 					return true;
 				}
 			}

--- a/Game.h
+++ b/Game.h
@@ -24,6 +24,9 @@ private:
 	// HP
 	int m_hp;
 
+	// スキルゲージ
+	int m_skillGage;
+
 	// 無敵ならtrue
 	bool m_invincible;
 
@@ -68,6 +71,7 @@ public:
 	inline const char* name() const { return m_name.c_str(); }
 	inline const int version() const { return m_version; }
 	inline int hp() const { return m_hp; }
+	inline int skillGage() const { return m_skillGage; }
 	inline bool invincible() const { return m_invincible; }
 	inline int id() const { return m_id; }
 	inline int groupId() const { return m_groupId; }
@@ -84,6 +88,7 @@ public:
 	// セッタ
 	inline void setVersion(int version) { m_version = version; }
 	inline void setHp(int hp) { m_hp = hp; }
+	inline void getSkillGage(int skillGage) { m_skillGage = skillGage; }
 	inline void setInvincible(bool invincible) { m_invincible = invincible; }
 	inline void setId(int id) { m_id = id; }
 	inline void setGroupId(int groupId) { m_groupId = groupId; }
@@ -319,6 +324,7 @@ private:
 
 class Game {
 private:
+
 	GameData* m_gameData;
 
 	// サウンドプレイヤー
@@ -368,6 +374,9 @@ public:
 
 	// 描画していいならtrue
 	bool ableDraw();
+
+	// スキル発動できるところまでストーリーが進んでいるか
+	bool afterSkillUsableStoryNum() const;
 
 private:
 

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -59,7 +59,7 @@ void GameDrawer::draw() {
 	else {
 		m_worldDrawer->setWorld(m_game->getWorld());
 	}
-	m_worldDrawer->draw();
+	m_worldDrawer->draw(m_game->afterSkillUsableStoryNum());
 
 	// セーブ完了通知
 	int noticeSaveDone = m_game->getGameData()->getNoticeSaveDone();

--- a/World.cpp
+++ b/World.cpp
@@ -147,6 +147,7 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) :
 	m_camera->setEx(m_cameraMaxEx);
 
 	m_characterDeadGraph = new GraphHandles("picture/effect/dead", 5, 1.0, 0, true);
+	m_characterDamageGraph = new GraphHandles("picture/effect/damage", 1, 0.2, 0, true);
 	m_bombGraph = new GraphHandles("picture/effect/bomb", 9, 1.0, 0, true);
 	m_characterDeadSound = LoadSoundMem("sound/battle/dead.wav");
 	m_bombSound = LoadSoundMem("sound/battle/bomb.wav");
@@ -170,6 +171,7 @@ World::World(const World* original) :
 	// エリアをコピー (コピー元と共有するもの)
 	m_soundPlayer_p = original->getSoundPlayer();
 	m_characterDeadGraph = original->getCharacterDeadGraph();
+	m_characterDamageGraph = original->getCharacterDamageGraph();
 	m_bombGraph = original->getBombGraph();
 	m_characterDeadSound = original->getCharacterDeadSound();
 	m_bombSound = original->getBombSound();
@@ -255,6 +257,7 @@ World::~World() {
 	if (!m_duplicationFlag) {
 		DeleteGraph(m_backGroundGraph);
 		delete m_characterDeadGraph;
+		delete m_characterDamageGraph;
 		delete m_bombGraph;
 		DeleteSoundMem(m_characterDeadSound);
 		DeleteSoundMem(m_bombSound);
@@ -795,6 +798,7 @@ void World::updateCamera() {
 //  Battle：アニメーションの更新
 void World::updateAnimation() {
 	for (unsigned int i = 0; i < m_animations.size(); i++) {
+		m_animations[i]->setVy(m_animations[i]->getVy() + 1);
 		m_animations[i]->count();
 		if (m_animations[i]->getFinishFlag()) {
 			delete m_animations[i];
@@ -929,6 +933,7 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 			if (atariAnimation != nullptr) {
 				m_animations.push_back(atariAnimation);
 			}
+			createDamageEffect(x, y, GetRand(3) + 1);
 			// 効果音
 			int soundHandle = objects[i]->getSoundHandle();
 			int panPal = adjustPanSound(x, m_camera->getX());
@@ -1058,6 +1063,17 @@ void World::createBomb(int x, int y, Object* attackObject) {
 		m_soundPlayer_p->pushSoundQueue(m_bombSound, adjustPanSound(x, m_camera->getX()));
 		// 画面の揺れ
 		m_camera->shakingStart(20, 20);
+	}
+}
+
+// Battle: ダメージエフェクト作成
+void World::createDamageEffect(int x, int y, int sum) {
+	for (int i = 0; i < sum; i++) {
+		Animation* animation = new Animation(x + GetRand(100) - 50, y + GetRand(100) - 50, 120, m_characterDamageGraph);
+		animation->setVx(GetRand(30) - 15);
+		animation->setVy(GetRand(30) - 31);
+		animation->setMovable(true);
+		m_animations.push_back(animation);
 	}
 }
 

--- a/World.cpp
+++ b/World.cpp
@@ -508,6 +508,7 @@ void World::asignCharacterData(const char* name, CharacterData* data, int fromAr
 			const Character* c = m_characterControllers[i]->getAction()->getCharacter();
 			data->setVersion(c->getVersion());
 			data->setHp(c->getHp());
+			data->getSkillGage(c->getSkillGage());
 			data->setInvincible(c->getInvincible());
 			data->setId(c->getId());
 			data->setGroupId(c->getGroupId());
@@ -640,6 +641,7 @@ void World::asignedCharacter(Character* character, CharacterData* data, bool cha
 	if (data->id() != -1) {
 		// ‚±‚ÌƒQ[ƒ€‚Å‰“oê‚¶‚á‚È‚¢
 		character->setHp(data->hp());
+		character->setSkillGage(data->skillGage());
 	}
 	character->setInvincible(data->invincible());
 	character->setGroupId(data->groupId());

--- a/World.h
+++ b/World.h
@@ -107,6 +107,9 @@ private:
 	// キャラがやられた時のエフェクト画像
 	GraphHandles* m_characterDeadGraph;
 
+	// キャラがダメージ受けた時のエフェクト画像
+	GraphHandles* m_characterDamageGraph;
+
 	// 爆発の画像
 	GraphHandles* m_bombGraph;
 
@@ -162,6 +165,7 @@ public:
 	inline double getCameraMaxEx() const { return m_cameraMaxEx; }
 	inline double getCameraMinEx() const { return m_cameraMinEx; }
 	inline GraphHandles* getCharacterDeadGraph() const { return m_characterDeadGraph; }
+	inline GraphHandles* getCharacterDamageGraph() const { return m_characterDamageGraph; }
 	inline GraphHandles* getBombGraph() const { return m_bombGraph; }
 	inline int getCharacterDeadSound() const { return m_characterDeadSound; }
 	inline int getBombSound() const { return m_bombSound; }
@@ -309,6 +313,9 @@ private:
 
 	// Battle: 爆発を起こす
 	void createBomb(int x, int y, Object* attackObject);
+
+	// Battle: ダメージエフェクト作成
+	void createDamageEffect(int x, int y, int sum);
 
 };
 

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -54,6 +54,7 @@ WorldDrawer::WorldDrawer(const World* world) {
 	m_animationDrawer = new AnimationDrawer(nullptr);
 	m_conversationDrawer = new ConversationDrawer(nullptr);
 	m_hpBarGraph = LoadGraph("picture/battleMaterial/hpBar.png");
+	m_skillBarGraph = LoadGraph("picture/battleMaterial/skillBar.png");
 	m_noonHaikei = LoadGraph("picture/stageMaterial/noon.jpg");
 	m_eveningHaikei = LoadGraph("picture/stageMaterial/evening.jpg");
 	m_nightHaikei = LoadGraph("picture/stageMaterial/night.jpg");
@@ -66,6 +67,7 @@ WorldDrawer::~WorldDrawer() {
 	delete m_animationDrawer;
 	delete m_conversationDrawer;
 	DeleteGraph(m_hpBarGraph);
+	DeleteGraph(m_skillBarGraph);
 	DeleteGraph(m_noonHaikei);
 	DeleteGraph(m_eveningHaikei);
 	DeleteGraph(m_nightHaikei);
@@ -74,7 +76,7 @@ WorldDrawer::~WorldDrawer() {
 
 
 // •`‰æ‚·‚é
-void WorldDrawer::draw() {
+void WorldDrawer::draw(bool drawSkillBar) {
 	
 	int bright = m_world->getBrightValue();
 	SetDrawBright(bright, bright, bright);
@@ -84,7 +86,7 @@ void WorldDrawer::draw() {
 
 	// íê
 	if (!m_world->getBlindFlag()) {
-		drawBattleField(camera, bright);
+		drawBattleField(camera, bright, drawSkillBar);
 	}
 
 	// ƒ€[ƒr[
@@ -120,7 +122,7 @@ void WorldDrawer::draw() {
 
 
 // íê‚Ì•`‰æ
-void WorldDrawer::drawBattleField(const Camera* camera, int bright) {
+void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSkillBar) {
 	// ”wŒi
 	int groundGraph = m_world->getBackGroundGraph();
 	if (groundGraph != -1) {
@@ -215,7 +217,14 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright) {
 	size = m_world->getCharacters().size();
 	for (unsigned int i = 0; i < size; i++) {
 		if (m_world->getCharacters()[i]->getName() == "ƒn[ƒg") {
-			m_characterDrawer->drawPlayerHpBar(m_world->getCharacters()[i], m_hpBarGraph);
+			const int x = 30;
+			const int y = 30;
+			const int wide = 525;
+			const int height = 150;
+			m_characterDrawer->drawPlayerHpBar(x, y, wide, height, m_world->getCharacters()[i], m_hpBarGraph);
+			if (drawSkillBar) {
+				m_characterDrawer->drawPlayerSkillBar(x, y + height + 10, wide, 30, m_world->getCharacters()[i], m_skillBarGraph);
+			}
 		}
 	}
 }

--- a/WorldDrawer.h
+++ b/WorldDrawer.h
@@ -60,6 +60,9 @@ private:
 	// HPバー
 	int m_hpBarGraph;
 
+	// skillバー
+	int m_skillBarGraph;
+
 	// 会話イベント
 	ConversationDrawer* m_conversationDrawer;
 
@@ -74,11 +77,11 @@ public:
 	void setWorld(World* world) { m_world = world; }
 
 	// 描画する
-	void draw();
+	void draw(bool drawSkillBar);
 
 private:
 
-	void drawBattleField(const Camera* camera, int bright);
+	void drawBattleField(const Camera* camera, int bright, bool drawSkillBar);
 };
 
 #endif


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
スキルは連続で発動できず、クールタイムが存在するようにしたい。

仕様
- 時間経過で再度発動できるようになる。
- セーブデータに含める。
- ＬＩＦＥの下にスキルゲージを表示する。
- ただし、スキルが発動できるようになるチャプターまでは表示しない。

# やったこと
Character::m_skillGageを追加。

いったん、クールタイムは50秒としている。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [x] デバッグモードで確認

# 懸念点
記入欄
