### PR TITLE
ボス（サン）の追加

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -24,6 +24,7 @@ const char* FlightAI::BRAIN_NAME = "FlightAI";
 const char* FollowFlightAI::BRAIN_NAME = "FollowFlightAI";
 const char* HierarchyAI::BRAIN_NAME = "HierarchyAI";
 const char* FrenchAI::BRAIN_NAME = "FrenchAI";
+const char* SunAI::BRAIN_NAME = "SunAI";
 
 // クラス名からBrainを作成する関数
 Brain* createBrain(const string brainName, const Camera* camera_p) {
@@ -60,6 +61,9 @@ Brain* createBrain(const string brainName, const Camera* camera_p) {
 	}
 	else if (brainName == FrenchAI::BRAIN_NAME) {
 		brain = new FrenchAI();
+	}
+	else if (brainName == SunAI::BRAIN_NAME) {
+		brain = new SunAI();
 	}
 	return brain;
 }
@@ -986,4 +990,60 @@ void FrenchAI::moveOrder(int& right, int& left, int& up, int& down) {
 		return;
 	}
 	NormalAI::moveOrder(right, left, up, down);
+}
+
+
+/*
+* Boss1: サン
+*/
+SunAI::SunAI() :
+	FlightAI()
+{
+
+}
+
+Brain* SunAI::createCopy(std::vector<Character*> characters, const Camera* camera) {
+	SunAI* res = new SunAI();
+	copyTarget(characters, getTargetId(), res);
+	setParam(res);
+	return res;
+}
+
+// 移動（上下左右の入力）
+void SunAI::moveOrder(int& right, int& left, int& up, int& down) {
+	if (m_characterAction_p->getState() != CHARACTER_STATE::INIT) {
+		FlightAI::moveOrder(right, left, up, down);
+	}
+}
+
+// ジャンプの制御
+int SunAI::jumpOrder() {
+	if (m_characterAction_p->getState() != CHARACTER_STATE::INIT) {
+		return FlightAI::jumpOrder();
+	}
+	return 0;
+}
+
+// しゃがみの制御
+int SunAI::squatOrder() {
+	if (m_characterAction_p->getState() != CHARACTER_STATE::INIT) {
+		return FlightAI::squatOrder();
+	}
+	return 0;
+}
+
+// 近距離攻撃
+int SunAI::slashOrder() {
+	if (m_characterAction_p->getState() != CHARACTER_STATE::INIT) {
+		return FlightAI::slashOrder();
+	}
+	return 0;
+}
+
+// 遠距離攻撃
+int SunAI::bulletOrder() {
+	if (m_characterAction_p->getState() != CHARACTER_STATE::INIT) {
+		return FlightAI::bulletOrder();
+	}
+	return 0;
 }

--- a/Brain.h
+++ b/Brain.h
@@ -59,6 +59,8 @@ public:
 	// 目標地点へ移動するだけ 達成済みならtrueで何もしない
 	virtual bool moveGoalOrder(int& right, int& left, int& up, int& down, int& jump) { return true; }
 
+	virtual void setGoalToTarget() = 0;
+
 	// 攻撃対象を決める(AIクラスでオーバライドする。)
 	virtual void searchTarget(const Character* character) { }
 
@@ -121,6 +123,7 @@ public:
 	int squatOrder();
 	int slashOrder();
 	int bulletOrder();
+	void setGoalToTarget() {}
 };
 
 
@@ -151,6 +154,7 @@ public:
 	int squatOrder() { return 0; }
 	int slashOrder() { return 0; }
 	int bulletOrder() { return 0; }
+	void setGoalToTarget() {}
 };
 
 
@@ -193,7 +197,7 @@ protected:
 	int m_moveCnt;
 
 	// 移動を諦めるまでの時間
-	const int GIVE_UP_MOVE_CNT = 300;
+	const int GIVE_UP_MOVE_CNT = 180;
 
 public:
 	static const char* BRAIN_NAME;
@@ -227,6 +231,7 @@ public:
 	int squatOrder();
 	int slashOrder();
 	int bulletOrder();
+	void setGoalToTarget();
 
 	// 攻撃対象を決める(targetのままか、characterに変更するか)
 	void searchTarget(const Character* character);
@@ -363,7 +368,7 @@ public:
 class FlightAI :
 	public NormalAI
 {
-private:
+protected:
 	// 壁にぶつかったとき、trueにして上か下へ移動する。trueのとき天井や床にぶつかっていたら逆へ移動
 	bool m_try;
 public:
@@ -378,6 +383,8 @@ public:
 
 	// 目標地点へ移動するだけ 達成済みならtrueで何もしない
 	bool moveGoalOrder(int& right, int& left, int& up, int& down, int& jump);
+
+	void setGoalToTarget();
 };
 
 
@@ -486,6 +493,10 @@ public:
 
 	// 遠距離攻撃
 	int bulletOrder();
+
+	void bulletTargetPoint(int& x, int& y);
+
+	void setGoalToTarget();
 
 };
 

--- a/Brain.h
+++ b/Brain.h
@@ -56,6 +56,9 @@ public:
 	// 遠距離攻撃
 	virtual int bulletOrder() = 0;
 
+	// 目標地点へ移動するだけ 達成済みならtrueで何もしない
+	virtual bool moveGoalOrder(int& right, int& left, int& up, int& down, int& jump) { return true; }
+
 	// 攻撃対象を決める(AIクラスでオーバライドする。)
 	virtual void searchTarget(const Character* character) { }
 
@@ -80,8 +83,6 @@ public:
 	// 追跡対象の近くにいるか判定
 	virtual bool checkAlreadyFollow() { return true; }
 
-	// 目標地点へ移動するだけ 達成済みならtrueで何もしない
-	virtual bool moveGoalOrder(int& right, int& left, int& up, int& down, int& jump) { return true; }
 };
 
 
@@ -452,6 +453,40 @@ public:
 	void moveOrder(int& right, int& left, int& up, int& down);
 	int jumpOrder() { return 0; }
 	int squatOrder() { m_squatCnt = 0; return 0; }
+};
+
+
+/*
+* Boss1: サン
+*/
+class SunAI :
+	public FlightAI
+{
+private:
+
+public:
+	static const char* BRAIN_NAME;
+	const char* getBrainName() const { return this->BRAIN_NAME; }
+
+	SunAI();
+
+	Brain* createCopy(std::vector<Character*> characters, const Camera* camera);
+
+	// 移動（上下左右の入力）
+	void moveOrder(int& right, int& left, int& up, int& down);
+
+	// ジャンプの制御
+	int jumpOrder();
+
+	// しゃがみの制御
+	int squatOrder();
+
+	// 近距離攻撃
+	int slashOrder();
+
+	// 遠距離攻撃
+	int bulletOrder();
+
 };
 
 

--- a/Character.cpp
+++ b/Character.cpp
@@ -686,6 +686,8 @@ Character* Hierarchy::createCopy() {
 
 // ŽËŒ‚UŒ‚‚ð‚·‚é
 Object* Hierarchy::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
+	//gx = GetRand(600) - 300 + getCenterX();
+	//gy = getCenterY() - GetRand(300);
 	BulletObject* attackObject = new BulletObject(getCenterX(), getCenterY(), m_graphHandle->getBulletHandle()->getGraphHandles()->getGraphHandle(), gx, gy, m_attackInfo);
 	// Ž©–Å–hŽ~
 	attackObject->setCharacterId(m_id);

--- a/Character.h
+++ b/Character.h
@@ -226,6 +226,9 @@ protected:
 	// 一時的に動けない状態（ハートのスキル発動など）
 	bool m_freeze;
 
+	// ボスならtrue
+	bool m_bossFlag;
+
 	// キャラの情報
 	CharacterInfo* m_characterInfo;
 
@@ -264,7 +267,8 @@ public:
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline bool getLeftDirection() const { return m_leftDirection; }
-	inline int getFreeze() const { return m_freeze; }
+	inline bool getFreeze() const { return m_freeze; }
+	inline bool getBossFlag() const { return m_bossFlag; }
 	FaceGraphHandle* getFaceHandle() const { return m_faceHandle; }
 	inline CharacterGraphHandle* getCharacterGraphHandle() const { return m_graphHandle; }
 	inline AttackInfo* getAttackInfo() const { return m_attackInfo; }
@@ -285,6 +289,7 @@ public:
 	inline void setId(int id) { m_id = id; }
 	inline void setGroupId(int id) { m_groupId = id; }
 	inline void setFreeze(bool freeze) { m_freeze = freeze; }
+	inline void setBossFlag(bool bossFlag) { m_bossFlag = bossFlag; }
 	// キャラの向き変更は、画像の反転も行う
 	void setLeftDirection(bool leftDirection);
 	inline void setDuplicationFlag(bool flag) { m_duplicationFlag = flag; }
@@ -355,6 +360,10 @@ public:
 	virtual void switchAirSlash(int cnt = 0);
 	// やられ画像をセット
 	virtual void switchDead(int cnt = 0);
+	// ボスの初期アニメーションをセット
+	virtual void switchInit(int cnt = 0);
+	// 追加画像をセット
+	virtual void switchSpecial1(int cnt = 0);
 
 	// HP減少
 	void damageHp(int value);
@@ -585,6 +594,31 @@ public:
 
 	// 射撃攻撃をする
 	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer);
+};
+
+
+/*
+* Boss1: サン
+*/
+class Sun :
+	public Heart
+{
+public:
+	// コンストラクタ
+	Sun(const char* name, int hp, int x, int y, int groupId);
+	Sun(const char* name, int hp, int x, int y, int groupId, AttackInfo* attackInfo);
+
+	Character* createCopy();
+
+	// ボスの初期アニメーションをセット
+	void switchInit(int cnt);
+
+	// 射撃攻撃をする
+	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer);
+
+	// 斬撃攻撃をする
+	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
+
 };
 
 

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -48,7 +48,7 @@ CharacterAction* createAction(const string actionName, Character* character, Sou
 		action = new BossFreezeAction(character, soundPlayer_p);
 	}
 	else if (tmp == SunAction::ACTION_NAME) {
-		action = new SunAction(character, soundPlayer_p);
+		action = new SunAction(character, soundPlayer_p, false);
 	}
 
 	action->setHeavy(heavy);
@@ -1289,13 +1289,15 @@ void BossFreezeAction::switchHandle() {
 /*
 * Boss1: サン
 */
-SunAction::SunAction(Character* character, SoundPlayer* soundPlayer_p) :
+SunAction::SunAction(Character* character, SoundPlayer* soundPlayer_p, bool duplicationFlag) :
 	FlightAction(character, soundPlayer_p)
 {
 	m_state = CHARACTER_STATE::INIT;
 	m_initCnt = -60;
 	m_initHp = m_character_p->getHp();
-	m_character_p->setHp(min(1, m_initHp));
+	if (!duplicationFlag) {
+		m_character_p->setHp(min(1, m_initHp));
+	}
 	m_startAnimeCnt = 0;
 }
 
@@ -1303,7 +1305,7 @@ CharacterAction* SunAction::createCopy(vector<Character*> characters) {
 	SunAction* res = nullptr;
 	for (unsigned int i = 0; i < characters.size(); i++) {
 		if (m_character_p->getId() == characters[i]->getId()) {
-			res = new SunAction(characters[i], m_soundPlayer_p);
+			res = new SunAction(characters[i], m_soundPlayer_p, true);
 			// コピーする
 			setParam(res);
 		}
@@ -1336,25 +1338,27 @@ void SunAction::action() {
 		m_startAnimeCnt++;
 		// 隠れ・出現の開始
 		if (m_hideFlag) {
+			// 現在隠れ状態
 			m_bulletCnt = 1;
 			slashAction();
 			damageAction();
 			otherAction();
 			moveAction();
-			if (m_startAnimeCnt > 300 && GetRand(120) == 0) {
+			if (m_startAnimeCnt > 300 && (GetRand(120) == 0 || m_startAnimeCnt == 600)) {
 				m_hideFlag = false;
 				m_initCnt = 0;
 				m_startAnimeCnt = 0;
 			}
 		}
 		else {
+			// 現在出現状態
 			bulletAction();
 			slashAction();
 			damageAction();
 			otherAction();
-			if (m_startAnimeCnt > 300 && GetRand(300) == 0) {
+			if (m_startAnimeCnt > 300 && (GetRand(300) == 0 || m_startAnimeCnt == 600)) {
 				m_hideFlag = true;
-				m_initCnt = NOT_HIDE_CNT;
+				m_initCnt = NOT_HIDE_CNT - 1;
 				m_startAnimeCnt = 0;
 			}
 		}

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -524,7 +524,7 @@ public:
 	static const char* ACTION_NAME;
 	const char* getActionName() const { return this->ACTION_NAME; }
 
-	SunAction(Character* character, SoundPlayer* soundPlayer_p);
+	SunAction(Character* character, SoundPlayer* soundPlayer_p, bool duplicationFlag);
 
 	CharacterAction* createCopy(std::vector<Character*> characters);
 

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -95,8 +95,7 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int enemyNoticeH
 		graphHandle->draw(x, y, ex);
 	}
 
-	// 体力バー
-	if (character->getDispHpCnt() > 0 && character->getName() != "ハート") {
+	if (character->getDispHpCnt() > 0 && character->getName() != "ハート" && !character->getBossFlag()) {
 		// 座標をカメラで調整
 		x = character->getX() + (character->getWide() / 2);
 		y = character->getY();
@@ -137,12 +136,13 @@ void CharacterDrawer::drawPlayerHpBar(int x, int y, int wide, int height, const 
 
 	DrawExtendGraph(x, y, x + wide, y + height, hpBarGraph, TRUE);
 
-	int dx = (int)(40 * m_exX);
-	int dy1 = (int)(80 * m_exY);
+	int dx1 = (int)(230 * m_exX);
+	int dx2 = (int)(40 * m_exX);
+	int dy1 = (int)(15 * m_exY);
 	int dy2 = (int)(15 * m_exY);
 
 	// 体力の描画
-	drawHpBar(x + dx, y + dy1, x + wide - dx, y + height - dy2, player->getHp(), player->getPrevHp(), player->getMaxHp(), DAMAGE_COLOR, PREV_HP_COLOR, HP_COLOR);
+	drawHpBar(x + dx1, y + dy1, x + wide - dx2, y + height - dy2, player->getHp(), player->getPrevHp(), player->getMaxHp(), DAMAGE_COLOR, PREV_HP_COLOR, HP_COLOR);
 
 }
 
@@ -156,12 +156,39 @@ void CharacterDrawer::drawPlayerSkillBar(int x, int y, int wide, int height, con
 
 	DrawExtendGraph(x, y, x + wide, y + height, hpBarGraph, TRUE);
 
-	int dx1 = (int)(155 * m_exX);
-	int dx2 = (int)(50 * m_exX);
+	int dx1 = (int)(200 * m_exX);
+	int dx2 = (int)(65 * m_exX);
 	int dy1 = (int)(10 * m_exY);
 	int dy2 = (int)(10 * m_exY);
 
 	// 体力の描画
-	drawHpBar(x + dx1, y + dy1, x + wide - dx2, y + height - dy2, player->getSkillGage(), player->getSkillGage(), player->getMaxSkillGage(), WHITE, ORANGE, ORANGE);
+	int skillGage = player->getSkillGage();
+	int maxSkillGage = player->getMaxSkillGage();
+	if (skillGage == maxSkillGage) {
+		drawHpBar(x + dx1, y + dy1, x + wide - dx2, y + height - dy2, player->getSkillGage(), player->getSkillGage(), player->getMaxSkillGage(), WHITE, ORANGE, ORANGE);
+	}
+	else {
+		drawHpBar(x + dx1, y + dy1, x + wide - dx2, y + height - dy2, player->getSkillGage(), player->getSkillGage(), player->getMaxSkillGage(), WHITE, DARK_ORANGE, DARK_ORANGE);
+	}
+
+}
+
+void CharacterDrawer::drawBossHpBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph) {
+
+	// 解像度変更に対応
+	x = (int)(x * m_exX);
+	y = (int)(y * m_exY);
+	wide = (int)(wide * m_exX);
+	height = (int)(height * m_exY);
+
+	DrawExtendGraph(x, y, x + wide, y + height, hpBarGraph, TRUE);
+
+	int dx1 = (int)(370 * m_exX);
+	int dx2 = (int)(100 * m_exX);
+	int dy1 = (int)(20 * m_exY);
+	int dy2 = (int)(20 * m_exY);
+
+	// 体力の描画
+	drawHpBar(x + dx1, y + dy1, x + wide - dx2, y + height - dy2, player->getHp(), player->getPrevHp(), player->getMaxHp(), DAMAGE_COLOR, PREV_HP_COLOR, HP_COLOR);
 
 }

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -13,7 +13,7 @@ class CharacterDrawer {
 private:
 
 	// デバッグ用
-	const bool ATARI_DEBUG = true;
+	const bool ATARI_DEBUG = false;
 	int m_atariGuideHandle;
 	int m_damageGuideHandle;
 

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -13,7 +13,7 @@ class CharacterDrawer {
 private:
 
 	// デバッグ用
-	const bool ATARI_DEBUG = false;
+	const bool ATARI_DEBUG = true;
 	int m_atariGuideHandle;
 	int m_damageGuideHandle;
 
@@ -47,6 +47,7 @@ public:
 
 	void drawPlayerHpBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph);
 	void drawPlayerSkillBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph);
+	void drawBossHpBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph);
 
 };
 

--- a/Define.h
+++ b/Define.h
@@ -39,5 +39,6 @@ const int LIGHT_RED = GetColor(255, 100, 100);
 const int BLUE = GetColor(0, 0, 255);
 const int LIGHT_BLUE = GetColor(100, 100, 255);
 const int ORANGE = GetColor(255, 165, 0);
+const int DARK_ORANGE = GetColor(80, 50, 0);
 
 #endif

--- a/Event.cpp
+++ b/Event.cpp
@@ -120,6 +120,9 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	else if (param0 == "MoveGoal") {
 		element = new MoveGoalEvent(world, param);
 	}
+	else if (param0 == "ChangeAction") {
+		element = new ChangeActionEvent(world, param);
+	}
 	else if (param0 == "ChangeBrain") {
 		element = new ChangeBrainEvent(world, param);
 	}
@@ -330,6 +333,29 @@ EVENT_RESULT InvincibleEvent::play() {
 	return EVENT_RESULT::SUCCESS;
 }
 void InvincibleEvent::setWorld(World* world) {
+	EventElement::setWorld(world);
+	m_character_p = m_world_p->getCharacterWithName(m_param[2]);
+}
+
+
+// キャラのBrainを変更する
+ChangeActionEvent::ChangeActionEvent(World* world, vector<string> param) :
+	EventElement(world)
+{
+	m_actionName = param[1];
+	m_character_p = m_world_p->getCharacterWithName(param[2]);
+	m_param = param;
+}
+EVENT_RESULT ChangeActionEvent::play() {
+
+	// 対象のキャラのBrainを変更する
+	CharacterAction* action = createAction(m_actionName, m_character_p, m_world_p->getSoundPlayer());
+
+	m_world_p->getControllerWithName(m_param[2])->setAction(action);
+
+	return EVENT_RESULT::SUCCESS;
+}
+void ChangeActionEvent::setWorld(World* world) {
 	EventElement::setWorld(world);
 	m_character_p = m_world_p->getCharacterWithName(m_param[2]);
 }

--- a/Event.h
+++ b/Event.h
@@ -244,6 +244,7 @@ public:
 	EVENT_RESULT play();
 
 };
+
 // キャラを無敵にする
 class InvincibleEvent :
 	public EventElement
@@ -271,6 +272,7 @@ public:
 	// 世界を設定しなおす
 	void setWorld(World* world);
 };
+
 // キャラの目標地点を設定を変える
 class SetGoalPointEvent :
 	public EventElement
@@ -298,6 +300,7 @@ public:
 	// 世界を設定しなおす
 	void setWorld(World* world);
 };
+
 // 全キャラが目標地点へ移動するまで待機
 class MoveGoalEvent :
 	public EventElement
@@ -317,6 +320,35 @@ public:
 	bool skillAble() { return false; }
 
 };
+
+// キャラのAIを変える
+class ChangeActionEvent :
+	public EventElement
+{
+private:
+
+	// パラメータ
+	std::vector<std::string> m_param;
+
+	// Actionのクラス名
+	std::string m_actionName;
+
+	// 対象のキャラ
+	Character* m_character_p;
+
+public:
+	ChangeActionEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
+	// 世界を設定しなおす
+	void setWorld(World* world);
+};
+
 // キャラのAIを変える
 class ChangeBrainEvent :
 	public EventElement

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 18;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = false;
+const bool TEST_MODE = true;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -222,7 +222,7 @@ GameData::GameData() {
 	}
 
 	// 主要キャラを設定
-	const int mainSum = 14;
+	const int mainSum = 15;
 	const char* mainCharacters[mainSum] = {
 		"ハート",
 		"シエスタ",
@@ -237,7 +237,8 @@ GameData::GameData() {
 		"アイギス",
 		"コハル",
 		"マスカーラ",
-		"ヴェルメリア"
+		"ヴェルメリア",
+		"サン"
 	};
 	for (int i = 0; i < mainSum; i++) {
 		m_characterData.push_back(new CharacterData(mainCharacters[i]));

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -152,60 +152,69 @@ void GraphHandles::draw(int x, int y, int index) {
 AtariArea::AtariArea(CsvReader* csvReader, const char* graphName, const char* prefix) {
 	map<string, string> data = csvReader->findOne("name", graphName);
 
-	string p = prefix;
-
-	string defaultWide = data[(p + "defaultWide")];
-	string defaultHeight = data[(p + "defaultHeight").c_str()];
-	string wide = data[(p + "wide").c_str()];
-	string height = data[(p + "height").c_str()];
-	string x1 = data[(p + "x1").c_str()];
-	string y1 = data[(p + "y1").c_str()];
-	string x2 = data[(p + "x2").c_str()];
-	string y2 = data[(p + "y2").c_str()];
-
-	// 横
 	m_defaultWide = false;
 	m_wide = -1;
 	m_x1 = 0, m_x2 = 0;
 	m_x1none = true, m_x2none = true;
-	if (defaultWide == "1") {
-		m_defaultWide = true;
-	}
-	else if (wide != "-1") {
-		m_wide = stoi(wide);
-	}
-	else {
-		if (x1 != "null") {
-			m_x1 = stoi(x1);
-			m_x1none = false;
-		}
-		if (x2 != "null") {
-			m_x2 = stoi(x2);
-			m_x2none = false;
-		}
-	}
 
-	// 縦
 	m_defaultHeight = false;
 	m_height = -1;
 	m_y1 = 0, m_y2 = 0;
 	m_y1none = true, m_y2none = true;
-	if (defaultHeight == "1") {
+
+	if (data.size() == 0) {
+		m_defaultWide = true;
 		m_defaultHeight = true;
 	}
-	else if (height != "-1") {
-		m_height = stoi(height);
-	}
 	else {
-		if (y1 != "null") {
-			m_y1 = stoi(y1);
-			m_y1none = false;
+		string p = prefix;
+
+		string defaultWide = data[(p + "defaultWide")];
+		string defaultHeight = data[(p + "defaultHeight").c_str()];
+		string wide = data[(p + "wide").c_str()];
+		string height = data[(p + "height").c_str()];
+		string x1 = data[(p + "x1").c_str()];
+		string y1 = data[(p + "y1").c_str()];
+		string x2 = data[(p + "x2").c_str()];
+		string y2 = data[(p + "y2").c_str()];
+
+		// 横
+		if (defaultWide == "1") {
+			m_defaultWide = true;
 		}
-		if (y2 != "null") {
-			m_y2 = stoi(y2);
-			m_y2none = false;
+		else if (wide != "-1") {
+			m_wide = stoi(wide);
+		}
+		else {
+			if (x1 != "null") {
+				m_x1 = stoi(x1);
+				m_x1none = false;
+			}
+			if (x2 != "null") {
+				m_x2 = stoi(x2);
+				m_x2none = false;
+			}
+		}
+
+		// 縦
+		if (defaultHeight == "1") {
+			m_defaultHeight = true;
+		}
+		else if (height != "-1") {
+			m_height = stoi(height);
+		}
+		else {
+			if (y1 != "null") {
+				m_y1 = stoi(y1);
+				m_y1none = false;
+			}
+			if (y2 != "null") {
+				m_y2 = stoi(y2);
+				m_y2none = false;
+			}
 		}
 	}
+
 }
 
 void AtariArea::getArea(int* x1, int* y1, int* x2, int* y2, int wide, int height) const {
@@ -388,6 +397,8 @@ CharacterGraphHandle::CharacterGraphHandle(const char* characterName, double dra
 	loadCharacterGraph(dir, characterName, m_airSlashHandles, "airSlash", data, m_ex, &atariReader);
 	loadCharacterGraph(dir, characterName, m_closeHandles, "close", data, m_ex, &atariReader);
 	loadCharacterGraph(dir, characterName, m_deadHandles, "dead", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_initHandles, "init", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_special1Handles, "special1", data, m_ex, &atariReader);
 
 	switchStand();
 }
@@ -413,22 +424,24 @@ CharacterGraphHandle::~CharacterGraphHandle() {
 	if (m_airSlashHandles != nullptr) { delete m_airSlashHandles; }
 	if (m_closeHandles != nullptr) { delete m_closeHandles; }
 	if (m_deadHandles != nullptr) { delete m_deadHandles; }
+	if (m_initHandles != nullptr) { delete m_initHandles; }
+	if (m_special1Handles != nullptr) { delete m_special1Handles; }
 }
 
 void CharacterGraphHandle::getAtari(int* x1, int* y1, int* x2, int* y2) const {
 	m_dispGraphHandle_p->getAtari(x1, y1, x2, y2, m_dispGraphIndex);
-	*x1 = *x1 * m_ex;
-	*y1 = *y1 * m_ex;
-	*x2 = *x2 * m_ex;
-	*y2 = *y2 * m_ex;
+	*x1 = (int)(*x1 * m_ex);
+	*y1 = (int)(*y1 * m_ex);
+	*x2 = (int)(*x2 * m_ex);
+	*y2 = (int)(*y2 * m_ex);
 }
 
 void CharacterGraphHandle::getDamage(int* x1, int* y1, int* x2, int* y2) const {
 	m_dispGraphHandle_p->getDamage(x1, y1, x2, y2, m_dispGraphIndex);
-	*x1 = *x1 * m_ex;
-	*y1 = *y1 * m_ex;
-	*x2 = *x2 * m_ex;
-	*y2 = *y2 * m_ex;
+	*x1 = (int)(*x1 * m_ex);
+	*y1 = (int)(*y1 * m_ex);
+	*x2 = (int)(*x2 * m_ex);
+	*y2 = (int)(*y2 * m_ex);
 }
 
 // 画像のサイズをセット
@@ -530,6 +543,14 @@ void CharacterGraphHandle::switchClose(int index) {
 // やられ画像をセット
 void CharacterGraphHandle::switchDead(int index) {
 	setGraph(m_deadHandles, index);
+}
+// ボスの初期アニメーションをセット
+void CharacterGraphHandle::switchInit(int index) {
+	setGraph(m_initHandles, index);
+}
+// 追加画像をセット
+void CharacterGraphHandle::switchSpecial1(int index) {
+	setGraph(m_special1Handles, index);
 }
 
 

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -250,6 +250,12 @@ private:
 	// やられ画像
 	GraphHandlesWithAtari* m_deadHandles;
 
+	// ボスの初期アニメーション
+	GraphHandlesWithAtari* m_initHandles;
+
+	// 追加画像
+	GraphHandlesWithAtari* m_special1Handles;
+
 public:
 	// デフォルト値で初期化
 	CharacterGraphHandle();
@@ -288,6 +294,8 @@ public:
 	inline GraphHandlesWithAtari* getAirSlashHandle() { return m_airSlashHandles; }
 	inline GraphHandlesWithAtari* getCloseHandle() { return m_closeHandles; }
 	inline GraphHandlesWithAtari* getDeadHandle() { return m_deadHandles; }
+	inline GraphHandlesWithAtari* getInitHandle() { return m_initHandles; }
+	inline GraphHandlesWithAtari* getSpecial1Handle() { return m_special1Handles; }
 
 	// 画像サイズをセット
 	void setGraphSize();
@@ -332,6 +340,10 @@ public:
 	void switchClose(int index = 0);
 	// やられ画像をセット
 	void switchDead(int index = 0);
+	// ボスの初期アニメーションをセット
+	void switchInit(int index = 0);
+	// 追加画像をセット
+	void switchSpecial1(int index = 0);
 };
 
 

--- a/World.cpp
+++ b/World.cpp
@@ -276,6 +276,7 @@ vector<const CharacterAction*> World::getActions() const {
 	vector<const CharacterAction*> actions;
 	size_t size = m_characterControllers.size();
 	for (unsigned int i = 0; i < size; i++) {
+		// HPが０かつDeadGraphがないなら表示しない
 		if (m_characterControllers[i]->getAction()->getCharacter()->getHp() > 0 || m_characterControllers[i]->getAction()->getCharacter()->haveDeadGraph()) {
 			actions.push_back(m_characterControllers[i]->getAction());
 		}
@@ -736,7 +737,7 @@ void World::updateCamera() {
 	// キャラとカメラの距離の最大値を調べる
 	int max_dx = 0, max_dy = 0;
 	// 画面内に入れようとする距離の最大　これより離れたキャラは無視
-	const int MAX_DISABLE = 2000;
+	const int MAX_DISABLE = 2500;
 	size_t size = m_characters.size();
 	for (unsigned int i = 0; i < size; i++) {
 		// 今フォーカスしているキャラの座標に合わせる

--- a/World.h
+++ b/World.h
@@ -130,6 +130,9 @@ private:
 	int m_backGroundGraph;
 	int m_backGroundColor;
 
+	// ボスがやられた時のエフェクト中
+	int m_bossDeadEffectCnt;
+
 public:
 	World();
 	World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer);
@@ -171,6 +174,7 @@ public:
 	inline int getBombSound() const { return m_bombSound; }
 	inline int getDoorSound() const { return m_doorSound; }
 	inline bool getSkillFlag() const { return m_skillFlag; }
+	inline int getBossDeadEffextCnt() const { return m_bossDeadEffectCnt; }
 
 	// Drawer用のゲッタ
 	std::vector<const CharacterAction*> getActions() const;
@@ -316,6 +320,9 @@ private:
 
 	// Battle: ダメージエフェクト作成
 	void createDamageEffect(int x, int y, int sum);
+
+	// Battle: ボスがやられたときの爆発エフェクト
+	void createBossDeadEffect();
 
 };
 

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -55,6 +55,7 @@ WorldDrawer::WorldDrawer(const World* world) {
 	m_conversationDrawer = new ConversationDrawer(nullptr);
 	m_hpBarGraph = LoadGraph("picture/battleMaterial/hpBar.png");
 	m_skillBarGraph = LoadGraph("picture/battleMaterial/skillBar.png");
+	m_bossHpBarGraph = LoadGraph("picture/battleMaterial/bossHpBar.png");
 	m_noonHaikei = LoadGraph("picture/stageMaterial/noon.jpg");
 	m_eveningHaikei = LoadGraph("picture/stageMaterial/evening.jpg");
 	m_nightHaikei = LoadGraph("picture/stageMaterial/night.jpg");
@@ -68,6 +69,7 @@ WorldDrawer::~WorldDrawer() {
 	delete m_conversationDrawer;
 	DeleteGraph(m_hpBarGraph);
 	DeleteGraph(m_skillBarGraph);
+	DeleteGraph(m_bossHpBarGraph);
 	DeleteGraph(m_noonHaikei);
 	DeleteGraph(m_eveningHaikei);
 	DeleteGraph(m_nightHaikei);
@@ -168,6 +170,7 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 	// 各Actionを描画
 	vector<const CharacterAction*> actions = m_world->getActions();
 	int player = 0;
+	const CharacterAction* bossCharacterAction = nullptr;
 	size = actions.size();
 	for (unsigned int i = 0; i < size; i++) {
 		if (actions[i]->getCharacter()->getId() == m_world->getPlayerId()) {
@@ -175,6 +178,7 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 		}
 	}
 	for (unsigned int i = 0; i < size; i++) {
+		// プレイヤーは後で手前に描画
 		if (i != player) {
 			// キャラをDrawerにセット
 			m_characterDrawer->setCharacterAction(actions[i]);
@@ -185,6 +189,8 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 			}
 			// カメラを使ってキャラを描画
 			m_characterDrawer->drawCharacter(camera, enemyNotice, bright);
+			// ボスがいるなら保持しておく
+			if (actions[i]->getCharacter()->getBossFlag()) { bossCharacterAction = actions[i]; }
 		}
 	}
 	// プレイヤーは手前に描画
@@ -214,17 +220,23 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 	}
 
 	// ハートの情報
-	size = m_world->getCharacters().size();
-	for (unsigned int i = 0; i < size; i++) {
-		if (m_world->getCharacters()[i]->getName() == "ハート") {
-			const int x = 30;
-			const int y = 30;
-			const int wide = 525;
-			const int height = 150;
-			m_characterDrawer->drawPlayerHpBar(x, y, wide, height, m_world->getCharacters()[i], m_hpBarGraph);
-			if (drawSkillBar) {
-				m_characterDrawer->drawPlayerSkillBar(x, y + height + 10, wide, 30, m_world->getCharacters()[i], m_skillBarGraph);
-			}
-		}
+	const Character* playerCharacter = actions[player]->getCharacter();
+	const int x = 30;
+	const int y = 30;
+	const int wide = 700;
+	const int height = 70;
+	m_characterDrawer->drawPlayerHpBar(x, y, wide, height, playerCharacter, m_hpBarGraph);
+	if (drawSkillBar) {
+		m_characterDrawer->drawPlayerSkillBar(x, y + height + 10, wide, 30, playerCharacter, m_skillBarGraph);
 	}
+
+	// ボスの情報
+	const int bX = 30;
+	const int bY = 950;
+	const int bWide = 1500;
+	const int bHeight = 80;
+	if (bossCharacterAction != nullptr) {
+		m_characterDrawer->drawBossHpBar(bX, bY, bWide, bHeight, bossCharacterAction->getCharacter(), m_bossHpBarGraph);
+	}
+
 }

--- a/WorldDrawer.h
+++ b/WorldDrawer.h
@@ -63,6 +63,9 @@ private:
 	// skillバー
 	int m_skillBarGraph;
 
+	// ボスのHPバー
+	int m_bossHpBarGraph;
+
 	// 会話イベント
 	ConversationDrawer* m_conversationDrawer;
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
仕様
- ボスは近づくまで動かずに待機
- 近づくとEventによって動き始めるが、動き始めは独自のアニメーションが流れる
- ボスは撃破されると爆発がたくさん起きた後非表示になる
- ボスのＨＰは画面下に表示するが、動き始めるまでは非表示

サンの仕様
- HIDE状態と非HIDE状態がある。
- HIDE状態は攻撃が効かない。また、サンも攻撃してこない。
- 非HIDE状態では大量の弾丸の雨を降らせる。また、サンは移動しない。
- ヒエラルキーが仲間にいると倒せるが、いないと厳しいくらいの強さ

# やったこと
ボス
- サンのCharacter, Action, Brainを追加
- ボスに近づくまで動かないのは、動かないActionを初期状態にし、EventElementでActionを変更することで実現
- ボスが動き始めているときの状態はCharacterAction::m_stateのenumで表す。ＨＰバーの表示もm_stateによって制御する。
- ボスが撃破された際のエフェクトについては、Worldで時間をカウントしエフェクト発生や終了時のボスの非表示を制御する。


リファクタリングやその他の変更点
- CharacterAction::m_squatを削除し、 しゃがみ状態はm_stateのenum値で管理するよう変更
- CharacterAction::action()の処理を複数の仮想関数に分割し各処理ごとにオーバーライドできるようにした。
- ハートのHPの表示位置を調整（横方向に伸ばし、縦方向はコンパクトに）
- atari判定のCSVファイルに定義されていない画像は、当たり判定＝画像の大きさで定義しているとみなす。
- カメラが大きい敵をなかなか画面に入れないためカメラを調整

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [x] デバッグモードで確認

# 懸念点
EventElementのCharacter*やsoundPlayerフィールドはm_worldから取得できるから削除できそう
