### PR TITLE
ボスの修正とＨＰバー表示の修正&event1009の完成

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -1024,7 +1024,7 @@ void SunAI::moveOrder(int& right, int& left, int& up, int& down) {
 	int x = m_characterAction_p->getCharacter()->getCenterX();
 	int y = m_characterAction_p->getCharacter()->getCenterY();
 
-	if ((x < m_gx && m_characterAction_p->getLeftLock()) || (x > m_gx && m_characterAction_p->getRightLock())) {
+	if ((x > m_gx && m_characterAction_p->getLeftLock()) || (x < m_gx && m_characterAction_p->getRightLock())) {
 		m_gx = x, m_gy = y;
 		m_try = false;
 	}
@@ -1075,5 +1075,11 @@ void SunAI::setGoalToTarget() {
 	// target‚É‚Â‚¢‚Ä‚¢‚­
 	int NEAR_TARGET_X = 1500, NEAR_TARGET_Y = 400;
 	m_gx = m_characterAction_p->getCharacter()->getCenterX() + GetRand(NEAR_TARGET_X) - NEAR_TARGET_X / 2;
-	m_gy = m_target_p->getCenterY() + GetRand(NEAR_TARGET_Y) - (NEAR_TARGET_Y - 100);
+	m_gy = m_target_p->getCenterY() + GetRand(NEAR_TARGET_Y) - (NEAR_TARGET_Y / 2);
+	if (m_characterAction_p->getLeftLock()) {
+		m_gx += NEAR_TARGET_X / 2;
+	}
+	else if (m_characterAction_p->getRightLock()) {
+		m_gx -= NEAR_TARGET_X / 2;
+	}
 }

--- a/Character.cpp
+++ b/Character.cpp
@@ -77,12 +77,17 @@ CharacterInfo::CharacterInfo(const char* characterName) {
 	string filePath = "sound/stick/";
 	string fileName;
 	fileName = filePath + data["jumpSound"];
-	m_jumpSound = LoadSoundMem(fileName.c_str());
+	if (fileName != "null") {
+		m_jumpSound = LoadSoundMem(fileName.c_str());
+	}
 	fileName = filePath + data["passiveSound"];
-	m_passiveSound = LoadSoundMem(fileName.c_str());
+	if (fileName != "null") {
+		m_passiveSound = LoadSoundMem(fileName.c_str());
+	}
 	fileName = filePath + data["landSound"];
-	m_landSound = LoadSoundMem(fileName.c_str());
-	fileName = filePath + data["runSound"];
+	if (fileName != "null") {
+		m_landSound = LoadSoundMem(fileName.c_str());
+	}
 }
 
 CharacterInfo::~CharacterInfo() {
@@ -939,12 +944,12 @@ Object* ParabolaOnly::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
 Sun::Sun(const char* name, int hp, int x, int y, int groupId) :
 	Heart(name, hp, x, y, groupId)
 {
-	m_bossFlag = true;
+
 }
 Sun::Sun(const char* name, int hp, int x, int y, int groupId, AttackInfo* attackInfo) :
 	Heart(name, hp, x, y, groupId, attackInfo)
 {
-	m_bossFlag = true;
+
 }
 
 Character* Sun::createCopy() {

--- a/Event.cpp
+++ b/Event.cpp
@@ -132,6 +132,9 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	else if (param0 == "ChangeInfoVersion") {
 		element = new ChangeInfoVersionEvent(world, param);
 	}
+	else if (param0 == "ChangeBossFlag") {
+		element = new ChangeBossFlagEvent(world, param);
+	}
 	else if (param0 == "ChangeCharacterPoint") {
 		element = new ChangeCharacterPointEvent(world, param);
 	}
@@ -167,6 +170,9 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	}
 	else if (param0 == "WaitSkill") {
 		element = new WaitSkillEvent(world, param);
+	}
+	else if (param0 == "SetBgm") {
+		element = new SetBgmEvent(world, param);
 	}
 	else if (param0 == "BattleForever") {
 		element = new BattleForever(world, param);
@@ -466,6 +472,25 @@ void ChangeInfoVersionEvent::setWorld(World* world) {
 }
 
 
+// キャラのBossFlagを変更する
+ChangeBossFlagEvent::ChangeBossFlagEvent(World* world, std::vector<string> param) :
+	EventElement(world)
+{
+	m_param = param;
+	m_bossFlag = (bool)stoi(param[1]);
+	m_character_p = m_world_p->getCharacterWithName(param[2]);
+}
+EVENT_RESULT ChangeBossFlagEvent::play() {
+	// 対象のキャラのGroupIdを変更する
+	m_character_p->setBossFlag(m_bossFlag);
+	return EVENT_RESULT::SUCCESS;
+}
+void ChangeBossFlagEvent::setWorld(World* world) {
+	EventElement::setWorld(world);
+	m_character_p = m_world_p->getCharacterWithName(m_param[2]);
+}
+
+
 // キャラの座標を変える
 ChangeCharacterPointEvent::ChangeCharacterPointEvent(World* world, std::vector<string> param) :
 	EventElement(world)
@@ -736,6 +761,20 @@ EVENT_RESULT WaitSkillEvent::play() {
 		return EVENT_RESULT::SUCCESS;
 	}
 	return EVENT_RESULT::NOW;
+}
+
+
+SetBgmEvent::SetBgmEvent(World* world, std::vector<std::string> param) :
+	EventElement(world)
+{
+	m_filePath = param[1];
+}
+
+// プレイ
+EVENT_RESULT SetBgmEvent::play() {
+	m_world_p->getSoundPlayer()->setBGM(m_filePath);
+	m_world_p->getSoundPlayer()->playBGM();
+	return EVENT_RESULT::SUCCESS;
 }
 
 

--- a/Event.h
+++ b/Event.h
@@ -431,6 +431,33 @@ public:
 	void setWorld(World* world);
 };
 
+// キャラのbossFlagを変える
+class ChangeBossFlagEvent :
+	public EventElement
+{
+private:
+
+	// パラメータ
+	std::vector<std::string> m_param;
+
+	bool m_bossFlag;
+
+	// 対象のキャラ
+	Character* m_character_p;
+
+public:
+	ChangeBossFlagEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
+	// 世界を設定しなおす
+	void setWorld(World* world);
+};
+
 // キャラの座標を変える
 class ChangeCharacterPointEvent :
 	public EventElement
@@ -685,6 +712,23 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
+};
+
+class SetBgmEvent :
+	public EventElement
+{
+	std::string m_filePath;
+
+public:
+
+	SetBgmEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
 };
 
 // 永遠にbattle テスト用

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 18;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = true;
+const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -169,7 +169,7 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 
 	// 各Actionを描画
 	vector<const CharacterAction*> actions = m_world->getActions();
-	int player = 0;
+	int player = -1;
 	const CharacterAction* bossCharacterAction = nullptr;
 	size = actions.size();
 	for (unsigned int i = 0; i < size; i++) {
@@ -184,7 +184,7 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 			m_characterDrawer->setCharacterAction(actions[i]);
 			int enemyNotice = -1, groupId = actions[i]->getCharacter()->getGroupId();
 			// 中立と味方なら通知しない
-			if (groupId != -1 && groupId != actions[player]->getCharacter()->getGroupId()) {
+			if (groupId != -1 && player != -1 && groupId != actions[player]->getCharacter()->getGroupId()) {
 				enemyNotice = m_enemyNotice;
 			}
 			// カメラを使ってキャラを描画
@@ -194,8 +194,10 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 		}
 	}
 	// プレイヤーは手前に描画
-	m_characterDrawer->setCharacterAction(actions[player]);
-	m_characterDrawer->drawCharacter(camera, -1, bright);
+	if (player != -1) {
+		m_characterDrawer->setCharacterAction(actions[player]);
+		m_characterDrawer->drawCharacter(camera, -1, bright);
+	}
 
 	// 各Objectを描画
 	objects = m_world->getFrontObjects();
@@ -220,14 +222,16 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 	}
 
 	// ハートの情報
-	const Character* playerCharacter = actions[player]->getCharacter();
-	const int x = 30;
-	const int y = 30;
-	const int wide = 700;
-	const int height = 70;
-	m_characterDrawer->drawPlayerHpBar(x, y, wide, height, playerCharacter, m_hpBarGraph);
-	if (drawSkillBar) {
-		m_characterDrawer->drawPlayerSkillBar(x, y + height + 10, wide, 30, playerCharacter, m_skillBarGraph);
+	if (player != -1) {
+		const int x = 30;
+		const int y = 30;
+		const int wide = 700;
+		const int height = 70;
+		const Character* playerCharacter = actions[player]->getCharacter();
+		m_characterDrawer->drawPlayerHpBar(x, y, wide, height, playerCharacter, m_hpBarGraph);
+		if (drawSkillBar) {
+			m_characterDrawer->drawPlayerSkillBar(x, y + height + 10, wide, 30, playerCharacter, m_skillBarGraph);
+		}
 	}
 
 	// ボスの情報


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
- サンのＡＩ
- サンの効果音
- BGMをセットするEventElement作成
- ボスのＨＰバーが最初から表示されているのでbossFlagを後からtrueにすることで解消
- プレイヤーのＨＰバーが、プレイヤーがやられた時に表示がおかしくなるバグを修正

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認

# 懸念点
記入欄
