### PR TITLE
お金の機能を追加

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -440,7 +440,9 @@ void NormalAI::setGoalToTarget() {
 	if (!m_characterAction_p->getCharacter()->haveBulletAttack()) {
 		NEAR_TARGET = 500; // ‹ß‹——£UŒ‚‚µ‚©‚È‚¢‚©‚ç‚æ‚è‹ß‚Ã‚­
 	}
-	m_gx = m_target_p->getCenterX() + GetRand(NEAR_TARGET) - NEAR_TARGET / 2;
+	int targetX1 = 0, targetY1 = 0, targetX2 = 0, targetY2 = 0;
+	m_target_p->getAtariArea(&targetX1, &targetY1, &targetX2, &targetY2);
+	m_gx = (targetX1 + targetX2) / 2 + GetRand(NEAR_TARGET) - NEAR_TARGET / 2;
 }
 
 // UŒ‚‘ÎÛ‚ðŒˆ‚ß‚é(target‚Ì‚Ü‚Ü‚©Acharacter‚É•ÏX‚·‚é‚©)
@@ -855,8 +857,10 @@ void FlightAI::setGoalToTarget() {
 		NEAR_TARGET_X = 500; // ‹ß‹——£UŒ‚‚µ‚©‚È‚¢‚©‚ç‚æ‚è‹ß‚Ã‚­
 		NEAR_TARGET_Y = 300;
 	}
-	m_gx = m_target_p->getCenterX() + GetRand(NEAR_TARGET_X) - NEAR_TARGET_X / 2;
-	m_gy = m_target_p->getCenterY() + GetRand(NEAR_TARGET_Y) - (NEAR_TARGET_Y - 200);
+	int targetX1 = 0, targetY1 = 0, targetX2 = 0, targetY2 = 0;
+	m_target_p->getAtariArea(&targetX1, &targetY1, &targetX2, &targetY2);
+	m_gx = (targetX1 + targetX2) / 2 + GetRand(NEAR_TARGET_X) - NEAR_TARGET_X / 2;
+	m_gy = targetY1 + GetRand(NEAR_TARGET_Y) - (NEAR_TARGET_Y - 200);
 }
 
 

--- a/Character.h
+++ b/Character.h
@@ -241,6 +241,9 @@ protected:
 	// 顔画像
 	FaceGraphHandle* m_faceHandle;
 
+	// 獲得したお金 Worldに渡したら0にする
+	int m_money;
+
 public:
 	// コンストラクタ
 	Character();
@@ -273,6 +276,7 @@ public:
 	inline CharacterGraphHandle* getCharacterGraphHandle() const { return m_graphHandle; }
 	inline AttackInfo* getAttackInfo() const { return m_attackInfo; }
 	inline CharacterInfo* getCharacterInfo() const { return m_characterInfo; }
+	inline int getMoney() const { return m_money; }
 
 	// セッタ
 	inline void setHp(int hp) { m_hp = (hp > m_characterInfo->maxHp()) ? m_characterInfo->maxHp() : hp; m_prevHp = m_hp; }
@@ -295,6 +299,7 @@ public:
 	inline void setDuplicationFlag(bool flag) { m_duplicationFlag = flag; }
 	inline void setAttackInfo(AttackInfo* attackInfo) { m_attackInfo = attackInfo; }
 	inline void setCharacterInfo(CharacterInfo* characterInfo) { m_characterInfo = characterInfo; }
+	inline void setMoney(int money) { m_money = money; }
 
 	// CharacterInfoからキャラのスペックを取得
 	inline std::string getName() const { return m_characterInfo->name(); }

--- a/Game.cpp
+++ b/Game.cpp
@@ -517,7 +517,7 @@ Game::Game(const char* saveFilePath, int storyNum) {
 	m_gameData->updateStory(m_story);
 
 	// ƒf[ƒ^‚ð¢ŠE‚É”½‰f
-	m_gameData->asignWorld(m_world, true);
+	m_gameData->asignWorld(m_world, false);
 
 	m_world->cameraPointInit();
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -208,6 +208,8 @@ GameData::GameData() {
 
 	m_soundVolume = 50;
 
+	m_money = 0;
+
 	loadCommon(&m_soundVolume, &GAME_WIDE, &GAME_HEIGHT);
 
 	m_saveFilePath = "";
@@ -312,6 +314,7 @@ bool GameData::save(bool force) {
 		fwrite(&m_areaNum, sizeof(m_areaNum), 1, intFp);
 		fwrite(&m_storyNum, sizeof(m_storyNum), 1, intFp);
 		fwrite(&m_latestStoryNum, sizeof(m_latestStoryNum), 1, intFp);
+		fwrite(&m_money, sizeof(m_money), 1, intFp);
 		for (unsigned int i = 0; i < m_characterData.size(); i++) {
 			m_characterData[i]->save(intFp, strFp);
 		}
@@ -351,6 +354,7 @@ bool GameData::load() {
 	fread(&m_areaNum, sizeof(m_areaNum), 1, intFp);
 	fread(&m_storyNum, sizeof(m_storyNum), 1, intFp);
 	fread(&m_latestStoryNum, sizeof(m_latestStoryNum), 1, intFp);
+	fread(&m_money, sizeof(m_money), 1, intFp);
 	for (unsigned int i = 0; i < m_characterData.size(); i++) {
 		if (feof(intFp) != 0 || feof(strFp) != 0) { break; }
 		m_characterData[i]->load(intFp, strFp);
@@ -447,6 +451,7 @@ void GameData::asignWorld(World* world, bool playerHpReset) {
 	if (playerHpReset) {
 		world->playerHpReset();
 	}
+	world->setMoney(m_money);
 }
 
 // Worldのデータを自身に反映させる
@@ -456,6 +461,7 @@ void GameData::asignedWorld(const World* world, bool notCharacterPoint) {
 		world->asignCharacterData(m_characterData[i]->name(), m_characterData[i], m_areaNum, notCharacterPoint);
 	}
 	world->asignDoorData(m_doorData, m_areaNum);
+	m_money = world->getMoney();
 }
 
 // ストーリーが進んだ時にセーブデータを更新する エリア外（World以外）も考慮する
@@ -466,6 +472,7 @@ void GameData::updateStory(Story* story) {
 	m_storyNum = story->getStoryNum();
 	m_latestStoryNum = max(m_latestStoryNum, m_storyNum);
 	m_soundVolume = story->getWorld()->getSoundPlayer()->getVolume();
+	m_money = story->getWorld()->getMoney();
 	// Storyによって変更・新登場されたキャラ情報を取得
 	CharacterLoader* characterLoader = story->getCharacterLoader();
 	size_t size = m_characterData.size();
@@ -484,6 +491,7 @@ void GameData::resetWorld() {
 		m_characterData[i]->setAreaNum(-1);
 	}
 	m_doorData.clear();
+	m_money = 0;
 }
 
 
@@ -506,6 +514,7 @@ Game::Game(const char* saveFilePath, int storyNum) {
 
 	// 世界
 	m_world = new World(-1, m_gameData->getAreaNum(), m_soundPlayer);
+	m_world->setMoney(m_gameData->getMoney());
 	m_soundPlayer->stopBGM();
 
 	// ストーリー

--- a/Game.h
+++ b/Game.h
@@ -203,6 +203,9 @@ private:
 	// 音量
 	int m_soundVolume;
 
+	// 所持金
+	int m_money;
+
 	// セーブ完了の通知を表示する残り時間
 	int m_noticeSaveDone;
 
@@ -229,6 +232,7 @@ public:
 	inline int getAreaNum() const { return m_areaNum; }
 	inline int getStoryNum() const { return m_storyNum; }
 	inline int getSoundVolume() const { return m_soundVolume; }
+	inline int getMoney() const { return m_money; }
 	inline const char* getSaveFilePath() const { return m_saveFilePath.c_str(); }
 	inline int getDoorSum() const { return (int)m_doorData.size(); }
 	inline int getFrom(int i) const { return m_doorData[i]->from(); }

--- a/Item.cpp
+++ b/Item.cpp
@@ -14,6 +14,7 @@ Item::Item(const char* itemName, int x, int y) {
 	m_itemName = itemName;
 	m_x = x;
 	m_y = y;
+	m_cnt = 0;
 	m_vx = 0;
 	m_vy = 0;
 	m_grand = false;
@@ -32,8 +33,11 @@ Item::~Item() {
 
 // コピー
 void Item::setParam(Item* item) {
+	item->setCnt(m_cnt);
 	item->setGrand(m_grand);
 	item->setAnimation(m_animation->createCopy());
+	item->setVx(m_vx);
+	item->setVy(m_vy);
 }
 
 void Item::setY(int y) {
@@ -74,6 +78,11 @@ void Item::init() {
 // 動き 毎フレーム呼ぶ
 void Item::action() {
 
+	m_cnt++;
+	if (m_cnt > ERASE_CNT) {
+		m_deleteFlag = true;
+	}
+
 	// アニメをリセット
 	if (m_animation->getFinishFlag()) {
 		m_animation->init();
@@ -84,17 +93,20 @@ void Item::action() {
 
 	if (m_grand) {
 		// 着地してる
+		m_vx = 0;
 		m_vy = 0;
 	}
-	
+
 	// 移動
 	m_x += m_vx;
 	m_y += m_vy;
 	m_animation->setX(m_x);
 	m_animation->setY(m_y);
 
-	// 重力
-	m_vy += 1;
+	if (!m_grand) {
+		// 重力
+		m_vy += 1;
+	}
 
 }
 
@@ -144,4 +156,27 @@ Item* CureItem::createCopy() {
 void CureItem::arrangePlayer(Character* player) {
 	// HP回復
 	player->setHp(player->getHp() + m_cureValue);
+}
+
+
+/*
+* お金獲得アイテム
+*/
+MoneyItem::MoneyItem(const char* itemName, int x, int y, int moneyValue) :
+	Item(itemName, x, y)
+{
+	m_moneyValue = moneyValue;
+}
+
+// スキル発動用
+Item* MoneyItem::createCopy() {
+	MoneyItem* item = new MoneyItem(m_itemName.c_str(), m_x, m_y, m_moneyValue);
+	setParam(item);
+	return item;
+}
+
+// プレイヤーに対するアクション
+void MoneyItem::arrangePlayer(Character* player) {
+	// お金獲得
+	player->setMoney(player->getMoney() + m_moneyValue);
 }

--- a/Item.h
+++ b/Item.h
@@ -16,6 +16,8 @@ class GraphHandles;
 class Item {
 protected:
 
+	int m_cnt;
+
 	// 座標
 	int m_x, m_y;
 
@@ -42,6 +44,9 @@ protected:
 
 public:
 
+	// アイテムが消えるまでの時間
+	const int ERASE_CNT = 600;
+
 	// コンストラクタ
 	Item(const char* itemName, int x, int y);
 
@@ -55,6 +60,7 @@ public:
 	void setParam(Item* item);
 
 	// ゲッタ
+	inline int getCnt() const { return m_cnt; }
 	inline int getX() const { return m_x; }
 	inline int getY() const { return m_y; }
 	inline int getVx() const { return m_vx; }
@@ -68,9 +74,12 @@ public:
 	bool getDeleteFlag() const;
 
 	// セッタ
+	inline void setCnt(int cnt) { m_cnt = cnt; }
 	inline void setGrand(bool grand) { m_grand = grand; }
 	void setY(int y);
-	void setAnimation(Animation* animation) { delete m_animation; m_animation = animation; }
+	inline void setVx(int vx) { m_vx = vx; }
+	inline void setVy(int vy) { m_vy = vy; }
+	inline void setAnimation(Animation* animation) { delete m_animation; m_animation = animation; }
 
 	// アイテムの大きさ
 	void getGraphSize(int* wide, int* height) const;
@@ -113,8 +122,30 @@ public:
 	// スキル発動用
 	Item* createCopy();
 
-	// セッタ
-	inline void setCureValue(int cureValue) { m_cureValue = cureValue; }
+	// プレイヤーに対するアクション
+	void arrangePlayer(Character* player);
+
+};
+
+
+/*
+* お金アイテム
+*/
+class MoneyItem :
+	public Item
+{
+private:
+
+	// HPの回復量
+	int m_moneyValue;
+
+public:
+
+	// コンストラクタ
+	MoneyItem(const char* itemName, int x, int y, int moneyValue);
+
+	// スキル発動用
+	Item* createCopy();
 
 	// プレイヤーに対するアクション
 	void arrangePlayer(Character* player);

--- a/Object.cpp
+++ b/Object.cpp
@@ -63,14 +63,29 @@ void Object::decreaseHp(int damageValue) {
 }
 
 // 単純に四角の落下物と衝突しているか
-bool Object::atariDropBox(int x1, int y1, int x2, int y2, int vx, int vy) {
-	// 埋まっている
-	if (x2 > m_x1 && x1 < m_x2 && y2 > m_y1 && y1 < m_y2) {
+bool Object::atariDropBox(int x1, int y1, int x2, int y2, int& vx, int& vy) {
+	// 上から衝突してきた
+	if (x2 + vx >= m_x1 && x1 + vx <= m_x2 && y2 < m_y1 && y2 + vy >= m_y1) {
 		return true;
 	}
-	// 上から衝突してきた
-	if (x2 + vx > m_x1 && x1 + vx < m_x2 && y2 < m_y1 && y2 + vy > m_y1) {
-		return true;
+	// 左右からの衝突
+	if (x2 <= m_x1 && x2 + vx >= m_x1 && y2 > m_y1 && y1 < m_y2) {
+		vx = 0;
+		return false;
+	}
+	if (x1 >= m_x2 && x1 + vx <= m_x2 && y2 > m_y1 && y1 < m_y2) {
+		vx = 0;
+		return false;
+	}
+	// 下からの衝突
+	if (y1 > y2 && y1 + vy <= y2 && x2 > m_x1 && x1 < m_x2) {
+		vy = 0;
+		return false;
+	}
+	// 埋まっている
+	if (x2 > m_x1 && x1 < m_x2 && y2 > m_y1 && y1 < m_y2) {
+		vx = 0; vy = 0;
+		return false;
 	}
 	return false;
 }
@@ -459,15 +474,30 @@ bool TriangleObject::atari(CharacterController* characterController) {
 }
 
 // 単純に四角の落下物と衝突しているか
-bool TriangleObject::atariDropBox(int x1, int y1, int x2, int y2, int vx, int vy) {
+bool TriangleObject::atariDropBox(int x1, int y1, int x2, int y2, int& vx, int& vy) {
 	int y = getY((x1 + x2) / 2);
-	// 埋まっている
-	if (x2 > m_x1 && x1 < m_x2 && y2 > y && y1 < m_y2) {
+	// 上から衝突してきた
+	if (x2 + vx >= m_x1 && x1 + vx <= m_x2 && y2 < y && y2 + vy >= y) {
 		return true;
 	}
-	// 上から衝突してきた
-	if (x2 + vx > m_x1 && x1 + vx < m_x2 && y2 < y && y2 + vy > y) {
-		return true;
+	// 左右からの衝突
+	if (x2 <= m_x1 && x2 + vx >= m_x1 && y2 > y && y1 < m_y2) {
+		vx = 0;
+		return false;
+	}
+	if (x1 >= m_x2 && x1 + vx <= m_x2 && y2 > y && y1 < m_y2) {
+		vx = 0;
+		return false;
+	}
+	// 下からの衝突
+	if (y1 > y2 && y1 + vy <= y2 && x2 > m_x1 && x1 < m_x2) {
+		vy = 0;
+		return false;
+	}
+	// 埋まっている
+	if (x2 > m_x1 && x1 < m_x2 && y2 > y && y1 < m_y2) {
+		vx = 0; vy = 0;
+		return false;
 	}
 	return false;
 }

--- a/Object.h
+++ b/Object.h
@@ -127,7 +127,7 @@ public:
 	virtual bool atari(CharacterController* characterController) = 0;
 
 	// 単純に四角の落下物と衝突しているか
-	virtual bool atariDropBox(int x1, int y1, int x2, int y2, int vx, int vy);
+	virtual bool atariDropBox(int x1, int y1, int x2, int y2, int& vx, int& vy);
 
 	// キャラがオブジェクトに入り込んでいるときの処理
 	virtual void penetration(CharacterController* characterController) {};
@@ -228,7 +228,7 @@ public:
 	bool atari(CharacterController* characterController);
 
 	// 単純に四角の落下物と衝突しているか
-	bool atariDropBox(int x1, int y1, int x2, int y2, int vx, int vy);
+	bool atariDropBox(int x1, int y1, int x2, int y2, int& vx, int& vy);
 
 	// キャラがオブジェクトに入り込んでいるときの処理
 	void penetration(CharacterController* characterController);

--- a/World.h
+++ b/World.h
@@ -133,6 +133,10 @@ private:
 	// ボスがやられた時のエフェクト中
 	int m_bossDeadEffectCnt;
 
+	// 所持金
+	const int MAX_MONEY = 999;
+	int m_money;
+
 public:
 	World();
 	World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer);
@@ -175,6 +179,7 @@ public:
 	inline int getDoorSound() const { return m_doorSound; }
 	inline bool getSkillFlag() const { return m_skillFlag; }
 	inline int getBossDeadEffextCnt() const { return m_bossDeadEffectCnt; }
+	inline int getMoney() const { return m_money; }
 
 	// Drawer用のゲッタ
 	std::vector<const CharacterAction*> getActions() const;
@@ -198,6 +203,7 @@ public:
 	inline void setAreaLock(bool lock) { m_areaLock = lock; }
 	inline void setDate(int date) { m_date = date; }
 	inline void setBlindFlag(bool blindFlag) { m_blindFlag = blindFlag; }
+	inline void setMoney(int money) { m_money = money; }
 
 	// 強制的にエリア移動
 	inline void moveArea(int nextArea) { m_brightValue--; m_nextAreaNum = nextArea; m_resetBgmFlag = true; }

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -12,6 +12,8 @@
 #include "Define.h"
 #include "DxLib.h"
 #include <queue>
+#include <sstream>
+
 
 using namespace std;
 
@@ -60,6 +62,8 @@ WorldDrawer::WorldDrawer(const World* world) {
 	m_eveningHaikei = LoadGraph("picture/stageMaterial/evening.jpg");
 	m_nightHaikei = LoadGraph("picture/stageMaterial/night.jpg");
 	m_enemyNotice = LoadGraph("picture/battleMaterial/enemyNotice.png");
+	getGameEx(m_exX, m_exY);
+	m_font = CreateFontToHandle(nullptr, (int)(50 * m_exX), 10);
 }
 
 WorldDrawer::~WorldDrawer() {
@@ -74,6 +78,7 @@ WorldDrawer::~WorldDrawer() {
 	DeleteGraph(m_eveningHaikei);
 	DeleteGraph(m_nightHaikei);
 	DeleteGraph(m_enemyNotice);
+	DeleteFontToHandle(m_font);
 }
 
 
@@ -242,5 +247,11 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 	if (bossCharacterAction != nullptr) {
 		m_characterDrawer->drawBossHpBar(bX, bY, bWide, bHeight, bossCharacterAction->getCharacter(), m_bossHpBarGraph);
 	}
+
+	// ‚¨‹à
+	int money = m_world->getMoney();
+	ostringstream oss;
+	oss << "F" << money;
+	DrawStringToHandle((int)(1700 * m_exX), (int)(20 * m_exY), oss.str().c_str(), BLACK, m_font);
 
 }

--- a/WorldDrawer.h
+++ b/WorldDrawer.h
@@ -71,6 +71,10 @@ private:
 
 	int m_enemyNotice;
 
+	double m_exX, m_exY;
+
+	int m_font;
+
 public:
 	WorldDrawer(const World* world);
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#190 

# やったこと
- MoneyItemを追加
- GameDataにm_money変数を追加
- Itemの壁や床との当たり判定を修正
  - 埋まると停止、壁にぶつかるとX方向のみ停止、天井にぶつかるとY方向のみ停止
- プレイヤーのＨＰが再起動時にリセットされないように仕様変更
- 所持金は画面左上に表示される。

その他
- FlightAIの目標地点設定方法がイマイチだったので（下へ移動しやすい）修正
  - ターゲットのCenter座標ではなく、ターゲットの当たり判定の中心を考慮するように変更

# やらないこと
- お金の使い道はPRを分ける。

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [x] デバッグモードで確認

# 懸念点
記入欄
