### PR TITLE
チャプター名を表示する機能追加

### DIFF
--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -112,11 +112,14 @@ void ControlBar::play(int handX, int handY) {
 }
 
 // •`‰æ
-void ControlBar::draw(int handX, int handY) {
+void ControlBar::draw(int handX, int handY, string appendix) {
 	int d = (int)(10 * m_exX);
 
 	ostringstream oss;
-	oss << m_name << " : " << m_nowValue;
+	oss << m_name << " " << m_nowValue;
+	if (appendix != "") {
+		oss << "F" << appendix;
+	}
 	DrawStringToHandle(m_drawX1 - m_buttonWide - d, m_drawY1 - d - m_fontSize, oss.str().c_str(), WHITE, m_font);
 
 	// ‰¹—Ê’²ß—Ìˆæ

--- a/PausePage.h
+++ b/PausePage.h
@@ -78,7 +78,7 @@ public:
 	void play(int handX, int handY);
 
 	// •`‰æ
-	void draw(int handX, int handY);
+	void draw(int handX, int handY, std::string appendix = "");
 	
 	// ƒQƒbƒ^
 	inline int getNowValue() { return m_nowValue; }

--- a/Story.cpp
+++ b/Story.cpp
@@ -11,6 +11,16 @@
 using namespace std;
 
 
+string getChapterName(int storyNum) {
+	// story››.csv‚ğƒ[ƒh
+	ostringstream oss;
+	oss << "data/story/story" << storyNum << ".csv";
+	CsvReader2 csvReader2(oss.str().c_str());
+	string s = csvReader2.getDomainData("NAME:")[0]["name"];
+	return s;
+}
+
+
 Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer, EventData* eventData) {
 	m_world_p = world;
 	m_nowEvent = nullptr;

--- a/Story.h
+++ b/Story.h
@@ -1,6 +1,7 @@
 #ifndef STORY_H_INCLUDED
 #define STORY_H_INCLUDED
 
+#include <string>
 #include <vector>
 
 class Event;
@@ -9,6 +10,9 @@ class World;
 class SoundPlayer;
 class CharacterLoader;
 class ObjectLoader;
+
+
+std::string getChapterName(int storyNum);
 
 
 // ÉXÉgÅ[ÉäÅ|

--- a/Title.cpp
+++ b/Title.cpp
@@ -7,6 +7,7 @@
 #include "Define.h"
 #include "Control.h"
 #include "Sound.h"
+#include "Story.h"
 #include "DxLib.h"
 
 #include <sstream>
@@ -34,6 +35,7 @@ SelectSaveData::SelectSaveData() {
 	double exX, exY;
 	getGameEx(exX, exY);
 	m_font = CreateFontToHandle(nullptr, (int)(50 * exX), 3);
+	int maxStoryNum = 0;
 	for (int i = 0; i < GAME_DATA_SUM; i++) {
 		string text;
 		ostringstream oss;
@@ -47,12 +49,19 @@ SelectSaveData::SelectSaveData() {
 		m_dataButton[i] = new Button(text, (int)(100 * exX), (int)(300 * exY + (i * 150 * exY)), (int)(500 * exX), (int)(100 * exY), WHITE, GRAY2, m_font, BLACK);
 		m_dataInitButton[i] = new Button("削除", (int)(650 * exX), (int)(300 * exY + (i * 150 * exY)), (int)(100 * exX), (int)(100 * exY), LIGHT_RED, RED, m_font, BLACK);
 		int latestStoryNum = m_gameData[i]->getLatestStoryNum();
+		maxStoryNum = max(maxStoryNum, latestStoryNum);
 		if (latestStoryNum > 1) {
 			m_startStoryNum[i] = new ControlBar(900, 350 + (i * 150), 1600, 400 + (i * 150), 1, latestStoryNum, latestStoryNum, "チャプター");
 		}
 		else {
 			m_startStoryNum[i] = nullptr;
 		}
+	}
+
+	// チャプター名を取得
+	for (int i = 0; i < maxStoryNum; i++) {
+		string s = getChapterName(i + 1);
+		m_chapterNames.push_back(s);
 	}
 
 	// 背景
@@ -141,7 +150,8 @@ void SelectSaveData::draw(int handX, int handY) {
 		m_dataButton[i]->draw(handX, handY);
 		m_dataInitButton[i]->draw(handX, handY);
 		if (m_startStoryNum[i] != nullptr) {
-			m_startStoryNum[i]->draw(handX, handY);
+			int n = m_startStoryNum[i]->getNowValue();
+			m_startStoryNum[i]->draw(handX, handY, m_chapterNames[n - 1]);
 		}
 	}
 

--- a/Title.h
+++ b/Title.h
@@ -1,6 +1,9 @@
 #ifndef TITLE_H_INCLUDED
 #define TITLE_H_INCLUDED
 
+#include <string>
+#include <vector>
+
 
 class SoundPlayer;
 class Button;
@@ -45,6 +48,9 @@ private:
 
 	// 背景
 	TitleBackGround* m_haikei;
+
+	// チャプター名
+	std::vector<std::string> m_chapterNames;
 
 public:
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り。

各story.csvファイルにチャプター名を記載しておき、それをロードしセーブデータ選択画面で表示する。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
