### PR TITLE
操作キャラの変更機能を実装

### DIFF
--- a/Brain.h
+++ b/Brain.h
@@ -80,7 +80,8 @@ public:
 	virtual const char* getFollowName() const { return ""; }
 	virtual const Character* getFollow() const { return nullptr; }
 
-	virtual void setTarget(Character* character) {  }
+	virtual void setFollow(const Character* character){  }
+	virtual void setTarget(const Character* character) {  }
 
 	// 追跡対象の近くにいるか判定
 	virtual bool checkAlreadyFollow() { return true; }
@@ -220,7 +221,7 @@ public:
 	void setGx(int gx) { m_gx = gx; }
 	void setGy(int gy) { m_gy = gy; }
 	void setMoveCnt(int cnt) { m_moveCnt = cnt; }
-	void setTarget(Character* character) { m_target_p = character; }
+	void setTarget(const Character* character) { m_target_p = character; }
 	void setCharacterAction(const CharacterAction* characterAction);
 
 	void bulletTargetPoint(int& x, int& y);
@@ -281,7 +282,7 @@ public:
 	const Character* getFollow() const;
 
 	// 追跡対象をセット
-	void setFollow(Character* character) { m_follow_p = character; }
+	void setFollow(const Character* character) { m_follow_p = character; }
 
 	// 移動の目標地点設定
 	void moveOrder(int& right, int& left, int& up, int& down);

--- a/Character.h
+++ b/Character.h
@@ -187,6 +187,10 @@ private:
 * プレイヤーやエネミーの基底クラス
 */
 class Character {
+public:
+
+	const int SKILL_MAX = 100;
+
 protected:
 	static int characterId;
 
@@ -211,7 +215,6 @@ protected:
 	int m_dispHpCnt;
 
 	// スキルゲージ 最大100
-	const int SKILL_MAX = 100;
 	int m_skillGage;
 
 	// 無敵ならtrue

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -177,22 +177,23 @@ public:
 	void finishBoost();
 	inline void setGrandRightSlope(bool grand) { m_grandRightSlope = grand; }
 	inline void setGrandLeftSlope(bool grand) { m_grandLeftSlope = grand; }
-	void setRunCnt(int runCnt) { m_runCnt = runCnt; }
-	void setJumpCnt(int preJumpCnt) { m_preJumpCnt = preJumpCnt; }
-	void setMoveRight(bool moveRight) { m_moveRight = moveRight; }
-	void setMoveLeft(bool moveLeft) { m_moveLeft = moveLeft; }
-	void setMoveUp(bool moveUp) { m_moveUp = moveUp; }
-	void setMoveDown(bool moveDown) { m_moveDown = moveDown; }
-	void setVx(int vx) { m_vx = vx; }
-	void setVy(int vy) { m_vy = vy; }
-	void setBulletCnt(int bulletCnt) { m_bulletCnt = bulletCnt; }
-	void setSlashCnt(int slashCnt) { m_slashCnt = slashCnt; }
-	void setAttackLeftDirection(bool attackLeftDirection) { m_attackLeftDirection = attackLeftDirection; }
-	void setLandCnt(int landCnt) { m_landCnt = landCnt; }
-	void setBoostCnt(int boostCnt) { m_boostCnt = boostCnt; }
-	void setBoostDone(int boostDone) { m_boostDone = boostDone; }
-	void setDamageCnt(int damageCnt) { m_damageCnt = damageCnt; }
-	void setHeavy(bool heavy) { m_heavy = heavy; }
+	inline void setRunCnt(int runCnt) { m_runCnt = runCnt; }
+	inline void setJumpCnt(int preJumpCnt) { m_preJumpCnt = preJumpCnt; }
+	inline void setMoveRight(bool moveRight) { m_moveRight = moveRight; }
+	inline void setMoveLeft(bool moveLeft) { m_moveLeft = moveLeft; }
+	inline void setMoveUp(bool moveUp) { m_moveUp = moveUp; }
+	inline void setMoveDown(bool moveDown) { m_moveDown = moveDown; }
+	inline void setVx(int vx) { m_vx = vx; }
+	inline void setVy(int vy) { m_vy = vy; }
+	inline void setBulletCnt(int bulletCnt) { m_bulletCnt = bulletCnt; }
+	inline void setSlashCnt(int slashCnt) { m_slashCnt = slashCnt; }
+	inline void setAttackLeftDirection(bool attackLeftDirection) { m_attackLeftDirection = attackLeftDirection; }
+	inline void setLandCnt(int landCnt) { m_landCnt = landCnt; }
+	inline void setBoostCnt(int boostCnt) { m_boostCnt = boostCnt; }
+	inline void setBoostDone(int boostDone) { m_boostDone = boostDone; }
+	inline void setDamageCnt(int damageCnt) { m_damageCnt = damageCnt; }
+	inline void setHeavy(bool heavy) { m_heavy = heavy; }
+	inline void setSoundPlayer(SoundPlayer* soundPlayer) { m_soundPlayer_p = soundPlayer; }
 
 	// ç°É_ÉÅÅ[ÉWÇéÛÇØÇƒÇ¢ÇƒìÆÇØÇ»Ç¢
 	inline bool damageFlag() const { return m_state == CHARACTER_STATE::DAMAGE; }

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -328,6 +328,8 @@ private:
 	// aŒ‚UŒ‚‚É‚æ‚éˆÚ“®‘¬“x
 	const int SLASH_MOVE_SPEED = 25;
 
+	bool m_slashNow;
+
 public:
 	static const char* ACTION_NAME;
 	const char* getActionName() const { return this->ACTION_NAME; }
@@ -340,6 +342,7 @@ public:
 
 	int getPreJumpMax() const { return PRE_JUMP_MAX; }
 
+	inline void setSlashNow(bool slashNow) { m_slashNow = slashNow; }
 	void setGrand(bool grand);
 
 	// aŒ‚ŠJn‚Ìˆ—

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -5,6 +5,7 @@
 #include "Control.h"
 #include "Brain.h"
 #include "ControllerRecorder.h"
+#include "Sound.h"
 #include "Define.h"
 #include "DxLib.h"
 #include <algorithm>
@@ -170,6 +171,9 @@ void CharacterController::setActionUpLock(bool lock) {
 void CharacterController::setActionDownLock(bool lock) {
 	m_characterAction->setDownLock(lock);
 }
+void CharacterController::setActionSound(SoundPlayer* soundPlayer) {
+	m_characterAction->setSoundPlayer(soundPlayer);
+}
 
 // キャラクターのセッタ
 void CharacterController::setCharacterX(int x) {
@@ -188,13 +192,23 @@ void CharacterController::init() {
 }
 
 // 攻撃対象を変更
-void CharacterController::searchTargetCandidate(Character* character) {
+void CharacterController::searchTargetCandidate(const Character* character) {
 	m_brain->searchTarget(character);
 }
 
 // 追跡対象を変更
-void CharacterController::searchFollowCandidate(Character* character) {
+void CharacterController::searchFollowCandidate(const Character* character) {
 	m_brain->searchFollow(character);
+}
+
+// 攻撃対象を強制変更
+void CharacterController::setBrainTarget(const Character* character) {
+	m_brain->setTarget(character);
+}
+
+// 追跡対象を強制変更
+void CharacterController::setBrainFollow(const Character* character) {
+	m_brain->setFollow(character);
 }
 
 // 行動の結果反映

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -12,6 +12,7 @@ class Object;
 class Camera;
 class Brain;
 class ControllerRecorder;
+class SoundPlayer;
 
 
 /*
@@ -90,6 +91,7 @@ public:
 	void setActionLeftLock(bool lock);
 	void setActionUpLock(bool lock);
 	void setActionDownLock(bool lock);
+	void setActionSound(SoundPlayer* soundPlayer);
 
 	// キャラクターのセッタ
 	void setCharacterX(int x);
@@ -100,10 +102,16 @@ public:
 	void init();
 
 	// 攻撃対象を変更
-	void searchTargetCandidate(Character* character);
+	void searchTargetCandidate(const Character* character);
 
 	// 追跡対象を変更
-	void searchFollowCandidate(Character* character);
+	void searchFollowCandidate(const Character* character);
+
+	// 攻撃対象を強制変更
+	void setBrainTarget(const Character* character);
+
+	// 追跡対象を強制変更
+	void setBrainFollow(const Character* character);
 
 	// 操作や当たり判定の結果を反映（実際にキャラを動かす）毎フレーム行う
 	void action();

--- a/Control.cpp
+++ b/Control.cpp
@@ -69,6 +69,11 @@ int controlD() {
 	return Key[KEY_INPUT_D];
 }
 
+// Eキー（キャラチェンジ）
+int controlE() {
+	return Key[KEY_INPUT_E];
+}
+
 // Fキー（スキル発動）
 int controlF() {
 	return Key[KEY_INPUT_F];

--- a/Control.h
+++ b/Control.h
@@ -22,6 +22,9 @@ int controlA();
 // Dキー（右キー）
 int controlD();
 
+// Eキー（キャラチェンジ）
+int controlE();
+
 // Fキー（スキル発動）
 int controlF();
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -112,6 +112,9 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	if (param0 == "LockArea") {
 		element = new LockAreaEvent(world, param);
 	}
+	else if (param0 == "LockControlCharacter") {
+		element = new LockControlCharacterEvent(world, param);
+	}
 	else if (param0 == "Invincible") {
 		element = new InvincibleEvent(world, param);
 	}
@@ -162,6 +165,9 @@ void Event::createElement(vector<string> param, World* world, SoundPlayer* sound
 	}
 	else if (param0 == "BlindWorld") {
 		element = new BlindWorldEvent(world, param);
+	}
+	else if (param0 == "ChangeControlCharacter") {
+		element = new ChangeControlCharacterEvent(world, param);
 	}
 	else if (param0 == "PushCharacter") {
 		element = new PushCharacterEvent(world, param, m_version);
@@ -320,6 +326,18 @@ LockAreaEvent::LockAreaEvent(World* world, std::vector<std::string> param):
 }
 EVENT_RESULT LockAreaEvent::play() {
 	m_world_p->setAreaLock(m_lock);
+	return EVENT_RESULT::SUCCESS;
+}
+
+
+// 操作キャラ変更を禁止する
+LockControlCharacterEvent::LockControlCharacterEvent(World* world, std::vector<std::string> param) :
+	EventElement(world)
+{
+	m_lock = param[1] == "1" ? true : false;
+}
+EVENT_RESULT LockControlCharacterEvent::play() {
+	m_world_p->setControlCharacterLock(m_lock);
 	return EVENT_RESULT::SUCCESS;
 }
 
@@ -696,6 +714,18 @@ BlindWorldEvent::BlindWorldEvent(World* world, std::vector<std::string> param) :
 }
 EVENT_RESULT BlindWorldEvent::play() {
 	m_world_p->setBlindFlag(m_flag);
+	return EVENT_RESULT::SUCCESS;
+}
+
+
+// 操作キャラの変更
+ChangeControlCharacterEvent::ChangeControlCharacterEvent(World* world, std::vector<std::string> param) :
+	EventElement(world)
+{
+	m_name = param[1];
+}
+EVENT_RESULT ChangeControlCharacterEvent::play() {
+	m_world_p->changePlayer(m_world_p->getCharacterWithName(m_name));
 	return EVENT_RESULT::SUCCESS;
 }
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -44,6 +44,7 @@ Event::Event(int eventNum, World* world, SoundPlayer* soundPlayer, int version) 
 	m_world_p = world;
 	m_soundPlayer_p = soundPlayer;
 	m_version = version;
+	m_backPrevSave = 0;
 
 	ostringstream oss;
 	oss << "data/event/event" << m_eventNum << ".csv";

--- a/Event.h
+++ b/Event.h
@@ -243,7 +243,32 @@ public:
 	// プレイ
 	EVENT_RESULT play();
 
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
 };
+
+
+// 操作キャラ変更を禁止する
+class LockControlCharacterEvent :
+	public EventElement
+{
+private:
+
+	// 禁止ならtrue
+	bool m_lock;
+
+public:
+	LockControlCharacterEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
+};
+
 
 // キャラを無敵にする
 class InvincibleEvent :
@@ -655,6 +680,26 @@ public:
 
 	// ハートのスキル発動が可能かどうか
 	bool skillAble() { return false; }
+};
+
+class ChangeControlCharacterEvent :
+	public EventElement
+{
+private:
+
+	// 変更先のキャラ名
+	std::string m_name;
+
+public:
+
+	ChangeControlCharacterEvent(World* world, std::vector<std::string> param);
+
+	// プレイ
+	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return false; }
+
 };
 
 // キャラの追加

--- a/Event.h
+++ b/Event.h
@@ -60,7 +60,7 @@ public:
 	virtual EVENT_RESULT play() = 0;
 
 	// ハートのスキル発動が可能かどうか
-	virtual bool skillAble() { return true; }
+	virtual bool skillAble() { return false; }
 
 	// クリア時に前のセーブポイントへ戻る必要があるか
 	virtual int needBackPrevSave() { return 0; }
@@ -243,9 +243,6 @@ public:
 	// プレイ
 	EVENT_RESULT play();
 
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
-
 };
 
 
@@ -263,9 +260,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 
 };
 
@@ -290,9 +284,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 
 	// 世界を設定しなおす
 	void setWorld(World* world);
@@ -319,9 +310,6 @@ public:
 	// プレイ
 	EVENT_RESULT play();
 
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
-
 	// 世界を設定しなおす
 	void setWorld(World* world);
 };
@@ -340,9 +328,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 
 };
 
@@ -366,9 +351,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 
 	// 世界を設定しなおす
 	void setWorld(World* world);
@@ -395,9 +377,6 @@ public:
 	// プレイ
 	EVENT_RESULT play();
 
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
-
 	// 世界を設定しなおす
 	void setWorld(World* world);
 };
@@ -421,9 +400,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 
 	// 世界を設定しなおす
 	void setWorld(World* world);
@@ -449,9 +425,6 @@ public:
 	// プレイ
 	EVENT_RESULT play();
 
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
-
 	// 世界を設定しなおす
 	void setWorld(World* world);
 };
@@ -476,9 +449,6 @@ public:
 	// プレイ
 	EVENT_RESULT play();
 
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
-
 	// 世界を設定しなおす
 	void setWorld(World* world);
 };
@@ -502,9 +472,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 
 	// 世界を設定しなおす
 	void setWorld(World* world);
@@ -534,9 +501,6 @@ public:
 	// プレイ
 	EVENT_RESULT play();
 
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
-
 	// 世界を設定しなおす
 	void setWorld(World* world);
 };
@@ -561,6 +525,9 @@ public:
 
 	// 世界を設定しなおす
 	void setWorld(World* world);
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return true; }
 };
 
 // 特定のグループが全滅するまで戦う
@@ -580,6 +547,9 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return true; }
 };
 
 // 会話イベント
@@ -596,9 +566,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 
 	// セッタ
 	void setWorld(World* world);
@@ -621,9 +588,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 };
 
 // 特定のエリアでプレイヤーがやられるイベント
@@ -644,6 +608,9 @@ public:
 
 	// クリア時に前のセーブポイントへ戻る必要があるか
 	int needBackPrevSave() { return m_backPrevSave; }
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return true; }
 };
 
 // 特定のエリアへ強制的に移動する
@@ -659,9 +626,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 };
 
 // 世界の描画をする・しない
@@ -677,9 +641,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 };
 
 class ChangeControlCharacterEvent :
@@ -696,10 +657,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
-
 };
 
 // キャラの追加
@@ -723,9 +680,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 };
 
 // 待機
@@ -739,9 +693,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
 };
 
 // スキル発動まで戦闘を続けるイベント
@@ -757,6 +708,9 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return true; }
 };
 
 class SetBgmEvent :
@@ -770,10 +724,6 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
-
-	// ハートのスキル発動が可能かどうか
-	bool skillAble() { return false; }
-
 };
 
 // 永遠にbattle テスト用
@@ -785,6 +735,9 @@ public:
 
 	// プレイ
 	EVENT_RESULT play();
+
+	// ハートのスキル発動が可能かどうか
+	bool skillAble() { return true; }
 };
 
 #endif

--- a/Game.cpp
+++ b/Game.cpp
@@ -21,9 +21,9 @@ using namespace std;
 
 
 // どこまで
-const int FINISH_STORY = 21;
+const int FINISH_STORY = 22;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = true;
+const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 
@@ -609,7 +609,7 @@ bool Game::play() {
 	// スキル発動
 	if (controlF() == 1 && skillUsable()) {
 		m_world->setSkillFlag(true);
-		m_skill = new HeartSkill(1, m_world, m_soundPlayer);
+		m_skill = new HeartSkill(m_story->getLoop(), m_world, m_soundPlayer);
 	}
 
 	// これ以上ストーリーを進ませない（テスト用）
@@ -685,6 +685,7 @@ bool Game::play() {
 	}
 	// エリア移動
 	else if (m_world->getBrightValue() == 0 && CheckSoundMem(m_world->getDoorSound()) == 0) {
+		m_world->changePlayer(m_world->getCharacterWithName("ハート"));
 		int fromAreaNum = m_world->getAreaNum();
 		int toAreaNum = m_world->getNextAreaNum();
 		m_gameData->asignedWorld(m_world, false);

--- a/Game.cpp
+++ b/Game.cpp
@@ -731,15 +731,12 @@ bool Game::afterSkillUsableStoryNum() const {
 
 // スキル発動可能かチェック
 bool Game::skillUsable() {
-	if (TEST_MODE) {
-		return true;
-	}
 	// スキル発動 Fキーかつスキル未発動状態かつ発動可能なイベント中（もしくはイベント中でない）かつエリア移動中でない
-	if (afterSkillUsableStoryNum()) { // ストーリーの最初は発動できない
+	if (afterSkillUsableStoryNum() || TEST_MODE) { // ストーリーの最初は発動できない
 		if (m_skill == nullptr) { // スキル未発動時
 			if (m_story->skillAble() && m_world->getBrightValue() == 255) { // 特定のイベント時やエリア移動中はダメ
 				Character* character = m_world->getCharacterWithName("ハート");
-				if (character->getHp() > 0 && character->getSkillGage() == character->getMaxSkillGage()) {
+				if (character->getHp() > 0 && character->getSkillGage() == character->getMaxSkillGage() && m_world->getControlCharacterName() == "ハート") {
 					character->setSkillGage(0);
 					return true;
 				}

--- a/Game.cpp
+++ b/Game.cpp
@@ -654,10 +654,7 @@ bool Game::play() {
 	}
 	else if (m_skill != nullptr) { // スキル発動中で、最後のループ中
 		if (m_skill->play()) {
-			// スキル終了
-			delete m_skill;
-			m_skill = nullptr;
-			m_world->setSkillFlag(false);
+			endSkill();
 		}
 	}
 
@@ -673,6 +670,7 @@ bool Game::play() {
 	// 前のセーブポイントへ戻ることが要求された
 	int prevStoryNum = m_story->getBackPrevSave();
 	if (prevStoryNum > 0) {
+		endSkill();
 		backPrevSave(prevStoryNum - 1);
 		m_story->doneBackPrevSave();
 		return true;
@@ -728,6 +726,15 @@ bool Game::ableDraw() {
 // スキル発動できるところまでストーリーが進んでいるか
 bool Game::afterSkillUsableStoryNum() const {
 	return m_gameData->getStoryNum() >= SKILL_USEABLE_STORY;
+}
+
+// スキル終了
+void Game::endSkill() {
+	if (m_skill != nullptr) {
+		delete m_skill;
+		m_skill = nullptr;
+		m_world->setSkillFlag(false);
+	}
 }
 
 // スキル発動可能かチェック

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 22;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = false;
+const bool TEST_MODE = true;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 21;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = false;
+const bool TEST_MODE = true;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -739,18 +739,28 @@ void Game::endSkill() {
 
 // スキル発動可能かチェック
 bool Game::skillUsable() {
-	// スキル発動 Fキーかつスキル未発動状態かつ発動可能なイベント中（もしくはイベント中でない）かつエリア移動中でない
-	if (afterSkillUsableStoryNum() || TEST_MODE) { // ストーリーの最初は発動できない
-		if (m_skill == nullptr) { // スキル未発動時
-			if (m_story->skillAble() && m_world->getBrightValue() == 255) { // 特定のイベント時やエリア移動中はダメ
+
+	// ストーリーの最初は発動できない
+	if (afterSkillUsableStoryNum() || TEST_MODE) { 
+		// スキル発動中、重複して発動はダメ
+		if (m_skill == nullptr) {
+			// 特定のイベント時やエリア移動中はダメ
+			if (m_story->skillAble() && 
+				m_world->getBrightValue() == 255 && 
+				m_world->getControlCharacterName() == "ハート" &&
+				m_world->getConversation() == nullptr &&
+				m_world->getObjectConversation() == nullptr) 
+			{
+				// ハート自身がスキル発動可能な状態か
 				Character* character = m_world->getCharacterWithName("ハート");
-				if (character->getHp() > 0 && character->getSkillGage() == character->getMaxSkillGage() && m_world->getControlCharacterName() == "ハート") {
+				if (character->getHp() > 0 && character->getSkillGage() == character->getMaxSkillGage()){
 					character->setSkillGage(0);
 					return true;
 				}
 			}
 		}
 	}
+
 	return false;
 }
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 22;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = true;
+const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 

--- a/Game.h
+++ b/Game.h
@@ -268,6 +268,11 @@ public:
 
 // ハートのスキル
 class HeartSkill {
+public:
+
+	// 何秒間か
+	const int DUPLICATION_TIME = 600;
+
 private:
 	// 複製の数
 	int m_loopNum;
@@ -280,9 +285,6 @@ private:
 
 	// 複製
 	World* m_duplicationWorld;
-
-	// 何秒間か
-	const int DUPLICATION_TIME = 600;
 
 	// DUPLICATION_TIMEまでカウントする
 	int m_cnt;
@@ -304,6 +306,7 @@ public:
 	inline int getLoopNum() const { return m_loopNum; }
 	inline int getLoopNow() const { return m_loopNow; }
 	inline World* getWorld() const { return m_loopNow < m_loopNum ? m_duplicationWorld : m_world_p; }
+	inline int getOriginalCnt() const { return m_cnt; }
 	inline double getCnt() const { return ((double)DUPLICATION_TIME / 60.0) - ((double)m_cnt / 60.0); }
 
 	// スキル進行中 スキル終了時にtrue

--- a/Game.h
+++ b/Game.h
@@ -387,6 +387,9 @@ public:
 
 private:
 
+	// ƒXƒLƒ‹‚ÌI—¹
+	void endSkill();
+
 	bool skillUsable();
 
 };

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -88,7 +88,7 @@ void GameDrawer::draw() {
 			int cnt1 = (int)skill->getCnt();
 			int cnt2 = (int)((skill->getCnt() * 10) - cnt1 * 10);
 			oss << now + 1 << "/" << num << "F" << cnt1 << "." << cnt2;
-			DrawStringToHandle((int)(700 * m_exX), (int)(50 * m_exY), oss.str().c_str(), BLACK, m_skillHandle);
+			DrawStringToHandle((int)(900 * m_exX), (int)(30 * m_exY), oss.str().c_str(), BLACK, m_skillHandle);
 		}
 	}
 

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -21,6 +21,9 @@ GameDrawer::GameDrawer(const Game* game) {
 
 	m_skillHandle = CreateFontToHandle(nullptr, (int)(SKILL_SIZE * m_exX), 10);
 
+	m_skillInfoHandle = LoadGraph("picture/battleMaterial/skillInfo.png");
+	m_skillInfoBackHandle = LoadGraph("picture/battleMaterial/skillInfoBack.png");
+
 	m_gameoverHandle = LoadGraph("picture/system/gameover.png");
 
 	m_noticeSaveDataHandle = LoadGraph("picture/system/noticeSaveDone.png");
@@ -35,6 +38,8 @@ GameDrawer::GameDrawer(const Game* game) {
 GameDrawer::~GameDrawer() {
 	delete m_worldDrawer;
 	DeleteFontToHandle(m_skillHandle);
+	DeleteGraph(m_skillInfoHandle);
+	DeleteGraph(m_skillInfoBackHandle);
 	DeleteGraph(m_gameoverHandle);
 	DeleteGraph(m_noticeSaveDataHandle);
 }
@@ -87,6 +92,14 @@ void GameDrawer::draw() {
 			ostringstream oss;
 			int cnt1 = (int)skill->getCnt();
 			int cnt2 = (int)((skill->getCnt() * 10) - cnt1 * 10);
+			int x1 = (int)(850 * m_exX);
+			int y1 = (int)(10 * m_exY);
+			int x2 = (int)(1500 * m_exX);
+			int y2 = (int)(150 * m_exY);
+			int centerX = (x1 + x2) / 2;
+			int dx = (int)((1500 - 850) * (skill->DUPLICATION_TIME - skill->getOriginalCnt()) * m_exX) / skill->DUPLICATION_TIME / 2;
+			DrawExtendGraph(centerX - dx, y1, centerX + dx, y2, m_skillInfoBackHandle, TRUE);
+			DrawExtendGraph(x1, y1, x2, y2, m_skillInfoHandle, TRUE);
 			oss << now + 1 << "/" << num << "F" << cnt1 << "." << cnt2;
 			DrawStringToHandle((int)(900 * m_exX), (int)(30 * m_exY), oss.str().c_str(), BLACK, m_skillHandle);
 		}

--- a/GameDrawer.h
+++ b/GameDrawer.h
@@ -18,6 +18,10 @@ private:
 	const int SKILL_SIZE = 100;
 	int m_skillHandle;
 
+	// スキルの情報の枠
+	int m_skillInfoHandle;
+	int m_skillInfoBackHandle;
+
 	// ゲームオーバーの画像
 	int m_gameoverHandle;
 

--- a/Story.cpp
+++ b/Story.cpp
@@ -118,6 +118,7 @@ void Story::loadCsvData(const char* fileName, World* world, SoundPlayer* soundPl
 			oss << "data/story/version" << m_version << ".csv";
 			loadCsvData(oss.str().c_str(), world, soundPlayer);
 		}
+		m_loop = stoi(versionData[0]["loop"]);
 	}
 
 	// Story‚Ì‰Šúó‘Ô

--- a/Story.h
+++ b/Story.h
@@ -19,6 +19,9 @@ std::string getChapterName(int storyNum);
 class Story {
 private:
 
+	// ‰½T–Ú‚Ì¢ŠE‚©
+	int m_loop;
+
 	// ‘ÎÛ‚Ì¢ŠE
 	World* m_world_p;
 
@@ -82,6 +85,7 @@ public:
 	inline ObjectLoader* getObjectLoader() const { return m_objectLoader; }
 	inline const World* getWorld() const { return m_world_p; }
 	int getBackPrevSave() const;
+	int getLoop() const { return m_loop; }
 
 	// ƒZƒbƒ^
 	void setWorld(World* world);

--- a/World.cpp
+++ b/World.cpp
@@ -458,6 +458,11 @@ bool World::playerDead() {
 	return m_player_p->getHp() <= 0;
 }
 
+// 今操作しているキャラの名前
+string World::getControlCharacterName() const {
+	return m_playerChanger->getNowPlayer()->getCharacterInfo()->name();
+}
+
 // プレイヤーのHPをMAXにする
 void World::playerHpReset() {
 	m_player_p->setHp(m_player_p->getMaxHp());
@@ -798,7 +803,9 @@ void World::battle() {
 	updateAnimation();
 
 	// キャラ変更
-	changePlayer(m_playerChanger->play(m_soundPlayer_p, m_characterControllers));
+	if (!m_duplicationFlag && !m_skillFlag) {
+		changePlayer(m_playerChanger->play(m_soundPlayer_p, m_characterControllers));
+	}
 
 }
 

--- a/World.cpp
+++ b/World.cpp
@@ -153,6 +153,7 @@ World::World() {
 	m_cameraMinEx *= m_exX;
 
 	m_areaLock = false;
+	m_controlCharacterLock = false;
 
 	m_date = 0;
 
@@ -227,6 +228,8 @@ World::World(const World* original) :
 	m_playerId = original->getPlayerId();
 	m_date = original->getDate();
 	m_money = original->getMoney();
+	m_areaLock = original->getAreaLock();
+	m_controlCharacterLock = original->getControlCharacterLock();
 
 	// エリアをコピー (コピー元と共有するもの)
 	m_soundPlayer_p = original->getSoundPlayer();
@@ -703,6 +706,12 @@ void World::setPlayerFollowerPoint() {
 }
 
 void World::changePlayer(const Character* nextPlayer) {
+
+	// 禁止されている
+	if (m_controlCharacterLock) {
+		return;
+	}
+
 	// 変更できるキャラがいない
 	if (nextPlayer == nullptr || nextPlayer->getId() == m_playerChanger->getNowPlayer()->getId()) { 
 		return;
@@ -1011,6 +1020,8 @@ void World::controlObject() {
 // Battle：アイテムの動き
 void World::controlItem() {
 
+	if (m_itemVector.size() == 0) { return; }
+	// 今操作しているキャラが当たり判定の対象
 	Character* targetCharacter = nullptr;
 	for (unsigned int i = 0; i < m_characters.size(); i++) {
 		if (m_characters[i]->getId() == m_playerChanger->getNowPlayer()->getId()) { 

--- a/World.h
+++ b/World.h
@@ -256,6 +256,9 @@ public:
 	// プレイヤーのHPが0ならtrue
 	bool playerDead();
 
+	// 今操作しているキャラがハートか
+	std::string getControlCharacterName() const;
+
 	// プレイヤーのHPをMAXにする
 	void playerHpReset();
 

--- a/World.h
+++ b/World.h
@@ -256,11 +256,11 @@ public:
 	// プレイヤーのHPが0ならtrue
 	bool playerDead();
 
-	// 今操作しているキャラがハートか
-	std::string getControlCharacterName() const;
-
 	// プレイヤーのHPをMAXにする
 	void playerHpReset();
+
+	// 今操作しているキャラがハートか
+	std::string getControlCharacterName() const;
 
 	// スキル発動：ハートをFreezeにする
 	void setSkillFlag(bool skillFlag);
@@ -297,6 +297,9 @@ public:
 
 	// データ管理：カメラの位置をリセット
 	void cameraPointInit();
+
+	// Battle: 操作キャラの切り替え
+	void changePlayer(const Character* nextPlayer);
 
 	// プレイヤーを特定の座標へ移動
 	void setPlayerPoint(CharacterData* characterData);
@@ -335,9 +338,6 @@ private:
 
 	// Battle：キャラの更新（攻撃対象の変更）
 	void updateCharacter();
-
-	// Battle: 操作キャラの切り替え
-	void changePlayer(const Character* nextPlayer);
 
 	// Battle：キャラクターの動き
 	void controlCharacter();

--- a/World.h
+++ b/World.h
@@ -155,6 +155,9 @@ private:
 	// ドアに入った時の効果音
 	int m_doorSound;
 
+	// キャラ切り替え時の効果音
+	int m_characterChangeSound;
+
 	// カメラのズームイン・アウトの効果音
 	int m_cameraInSound;
 	int m_cameraOutSound;
@@ -210,6 +213,7 @@ public:
 	inline int getCharacterDeadSound() const { return m_characterDeadSound; }
 	inline int getBombSound() const { return m_bombSound; }
 	inline int getDoorSound() const { return m_doorSound; }
+	inline int getCharacterChangeSound() const { return m_characterChangeSound; }
 	inline bool getSkillFlag() const { return m_skillFlag; }
 	inline int getBossDeadEffextCnt() const { return m_bossDeadEffectCnt; }
 	inline int getMoney() const { return m_money; }

--- a/World.h
+++ b/World.h
@@ -25,6 +25,36 @@ class ObjectLoader;
 class SoundPlayer;
 
 
+/*
+* 操作するキャラを切り替えるクラス
+*/
+class PlayerChanger {
+private:
+
+	// 今操作しているキャラがＮＰＣだったときのBrain名
+	std::string m_prevBrainName;
+
+	// 今操作しているキャラ
+	const Character* m_nowCharacter_p;
+
+public:
+
+	PlayerChanger(std::vector<CharacterController*> controllers_p, const Character* player_p);
+
+	// 切り替え後のキャラを返す 切り替えできないならnullptr
+	const Character* play(SoundPlayer* soundPlayer_p, std::vector<CharacterController*> controllers_p);
+
+	// 操作キャラを変更
+	void changeCharacter(std::string prevBrainName, const Character* nextCharacter_p);
+
+	inline std::string getPrevBrainName() const { return m_prevBrainName; }
+	inline const Character* getNowPlayer() const { return m_nowCharacter_p; }
+};
+
+
+/*
+* キャラが存在し行動する世界
+*/
 class World {
 private:
 
@@ -85,6 +115,9 @@ private:
 
 	// プレイヤー 毎回for文でID検索しない用
 	Character* m_player_p;
+
+	// キャラ切り替え処理
+	PlayerChanger* m_playerChanger;
 
 	// 戦闘のためにキャラを動かすコントローラ Worldがデリートする
 	std::vector<CharacterController*> m_characterControllers;
@@ -299,6 +332,9 @@ private:
 
 	// Battle：キャラの更新（攻撃対象の変更）
 	void updateCharacter();
+
+	// Battle: 操作キャラの切り替え
+	void changePlayer(const Character* nextPlayer);
 
 	// Battle：キャラクターの動き
 	void controlCharacter();

--- a/World.h
+++ b/World.h
@@ -103,6 +103,9 @@ private:
 	// エリア移動が禁止されているならtrue
 	bool m_areaLock;
 
+	// 操作キャラの変更が禁止されているならtrue
+	bool m_controlCharacterLock;
+
 	// 描画用のカメラ Worldがデリートする
 	Camera* m_camera;
 
@@ -217,6 +220,8 @@ public:
 	inline bool getSkillFlag() const { return m_skillFlag; }
 	inline int getBossDeadEffextCnt() const { return m_bossDeadEffectCnt; }
 	inline int getMoney() const { return m_money; }
+	inline bool getAreaLock() const { return m_areaLock; }
+	inline bool getControlCharacterLock() const { return m_controlCharacterLock; }
 
 	// Drawer用のゲッタ
 	std::vector<const CharacterAction*> getActions() const;
@@ -238,6 +243,7 @@ public:
 	inline void setConversation(Conversation* conversation) { m_conversation_p = conversation; }
 	inline void setMovie(Movie* movie) { m_movie_p = movie; }
 	inline void setAreaLock(bool lock) { m_areaLock = lock; }
+	inline void setControlCharacterLock(bool lock) { m_controlCharacterLock = lock; }
 	inline void setDate(int date) { m_date = date; }
 	inline void setBlindFlag(bool blindFlag) { m_blindFlag = blindFlag; }
 	inline void setMoney(int money) { m_money = money; }

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -55,6 +55,7 @@ WorldDrawer::WorldDrawer(const World* world) {
 	m_objectDrawer = new ObjectDrawer(nullptr);
 	m_animationDrawer = new AnimationDrawer(nullptr);
 	m_conversationDrawer = new ConversationDrawer(nullptr);
+	m_moneyBoxGraph = LoadGraph("picture/battleMaterial/moneyBox.png");
 	m_hpBarGraph = LoadGraph("picture/battleMaterial/hpBar.png");
 	m_skillBarGraph = LoadGraph("picture/battleMaterial/skillBar.png");
 	m_bossHpBarGraph = LoadGraph("picture/battleMaterial/bossHpBar.png");
@@ -71,6 +72,7 @@ WorldDrawer::~WorldDrawer() {
 	delete m_objectDrawer;
 	delete m_animationDrawer;
 	delete m_conversationDrawer;
+	DeleteGraph(m_moneyBoxGraph);
 	DeleteGraph(m_hpBarGraph);
 	DeleteGraph(m_skillBarGraph);
 	DeleteGraph(m_bossHpBarGraph);
@@ -249,9 +251,10 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 	}
 
 	// ‚¨‹à
+	DrawExtendGraph((int)(1600 * m_exX), (int)(10 * m_exY), (int)(1900 * m_exX), (int)(80 * m_exY), m_moneyBoxGraph, TRUE);
 	int money = m_world->getMoney();
 	ostringstream oss;
 	oss << "F" << money;
-	DrawStringToHandle((int)(1700 * m_exX), (int)(20 * m_exY), oss.str().c_str(), BLACK, m_font);
+	DrawStringToHandle((int)(1650 * m_exX), (int)(20 * m_exY), oss.str().c_str(), BLACK, m_font);
 
 }

--- a/WorldDrawer.h
+++ b/WorldDrawer.h
@@ -45,6 +45,9 @@ private:
 	int m_eveningHaikei;
 	int m_nightHaikei;
 
+	// ‚¨‹à‚Ì•`‰æ˜g
+	int m_moneyBoxGraph;
+
 	// ƒLƒƒƒ‰•`‰æ—p
 	CharacterDrawer* m_characterDrawer;
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
- [x] #140 
- [x] #193 
- [x] #194 
- [x] #197 

プレイヤーを切り替えるわけではない。切り替えるのは以下のみ
- カメラがフォーカスするキャラ
- 1体のBrainをキーボード操作Brain、もともとキーボード操作Brainだった1体をＮＰＣのBrainに変更
- Brainの追跡対象を操作キャラにする（仲間はすべて対象）

- スキル発動時の複製の作成処理（切り替え中はスキル発動できないので必要ないかも）
- プレイヤー以外が操作キャラになっているときの制限
  - スキル発動不可
  - エリア移動も不可
  - 強制的にハートへ操作を戻すイベントを実装。
  - 切り替え不可にするイベントを実装（エリア移動をロックするのと同じ要領）

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認

# 懸念点
- 操作がハート以外の時にセーブされると面倒なので、操作をハートに戻すイベントの挿入を忘れないこと。
- WaitSkillEventでストーリーが進行しなくなるバグが１度だけ発生。再現できないためいったん諦める。再度タイトルからやり直したら回避できる。