### PR TITLE
テキストの分岐やＨＰ回復、所持金変動の機能追加

### DIFF
--- a/Button.cpp
+++ b/Button.cpp
@@ -19,7 +19,7 @@ Button::Button(string tag, int x, int y, int wide, int height, int color, int co
 }
 
 //ボタンの描画 下にラベルの文字列も表示できる
-void Button::draw(int hand_x, int hand_y) {
+void Button::draw(int hand_x, int hand_y) const {
 	if (overlap(hand_x, hand_y)) {
 		DrawBox(m_x - 5, m_y - 5, m_x + m_wide + 5, m_y + m_height + 5, m_color2, TRUE);
 	}
@@ -39,7 +39,7 @@ void Button::changeFlag(bool f, int new_color) {
 }
 
 //ボタンがマウスカーソルと重なっているか
-bool Button::overlap(int hand_x, int hand_y) {
+bool Button::overlap(int hand_x, int hand_y) const {
 	if (!m_flag) {
 		return false;
 	}

--- a/Button.h
+++ b/Button.h
@@ -51,10 +51,10 @@ public:
 	void changeFlag(bool f, int new_color);
 
 	// マウスが重なっているか確認
-	bool overlap(int hand_x, int hand_y);
+	bool overlap(int hand_x, int hand_y) const;
 
 	// 描画
-	void draw(int hand_x, int hand_y);
+	void draw(int hand_x, int hand_y) const;
 };
 
 

--- a/Text.h
+++ b/Text.h
@@ -11,6 +11,7 @@ class SoundPlayer;
 class World;
 class GraphHandle;
 class GraphHandles;
+class Button;
 
 
 /*
@@ -132,6 +133,14 @@ private:
 	// ファイルポインタ
 	int m_fp;
 
+	// 条件分岐用
+	bool m_if; // trueならifブロック内を実行中
+	std::vector<std::string> m_marks; // マーク
+	int m_font;
+	Button* m_yesButton;
+	Button* m_noButton;
+	bool m_selectFlag; // 今選択待ち
+
 	// 世界
 	World* m_world_p;
 
@@ -211,10 +220,12 @@ public:
 		return m_eventAnime->getAnime();
 	}
 	inline int getAnimeBright() const { return m_eventAnime->getBright(); }
-	const std::vector<Animation*> getAnimations() const { return m_animations; }
-	const GraphHandle* getTextFinishGraph() const { return m_textFinishGraph; }
-	const EventAnime* getEventAnime() const { return m_eventAnime; }
-	const TextAction getTextAction() const { return m_textAction; }
+	inline const std::vector<Animation*> getAnimations() const { return m_animations; }
+	inline const GraphHandle* getTextFinishGraph() const { return m_textFinishGraph; }
+	inline const EventAnime* getEventAnime() const { return m_eventAnime; }
+	inline const TextAction getTextAction() const { return m_textAction; }
+	inline const Button* getYesButton() const { return m_selectFlag ? m_yesButton : nullptr; }
+	inline const Button* getNoButton() const { return m_selectFlag ? m_noButton : nullptr; }
 
 	// セッタ
 	void setWorld(World* world);

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -3,6 +3,7 @@
 #include "GraphHandle.h"
 #include "Animation.h"
 #include "AnimationDrawer.h"
+#include "Button.h"
 #include "DrawTool.h"
 #include "Define.h"
 #include "DxLib.h"
@@ -127,6 +128,12 @@ void ConversationDrawer::draw() {
 	if (textFinish && eventFinish) {
 		int dy = (int)(((m_conversation->getCnt() / 3) % 20 - 10) * m_exY);
 		m_conversation->getTextFinishGraph()->draw(GAME_WIDE - EDGE_X - (int)(100 * m_exX), GAME_HEIGHT - EDGE_DOWN - (int)(50 * m_exY) + dy - TEXT_GRAPH_EDGE, m_conversation->getTextFinishGraph()->getEx());
+		const Button* yesButton = m_conversation->getYesButton();
+		const Button* noButton = m_conversation->getNoButton();
+		int mouseX, mouseY;
+		GetMousePoint(&mouseX, &mouseY);
+		if (yesButton != nullptr) { yesButton->draw(mouseX, mouseY); }
+		if (noButton != nullptr) { noButton->draw(mouseX, mouseY); }
 	}
 
 	// クリックエフェクト

--- a/World.cpp
+++ b/World.cpp
@@ -469,6 +469,14 @@ void World::playerHpReset() {
 	m_player_p->setSkillGage(m_player_p->SKILL_MAX);
 }
 
+void World::cureHpOfHearts(int value) {
+	for (unsigned int i = 0; i < m_characters.size(); i++) {
+		if (m_player_p->getGroupId() == m_characters[i]->getGroupId()) {
+			m_characters[i]->setHp(m_characters[i]->getHp() + value);
+		}
+	}
+}
+
 // ¡‘€ì‚µ‚Ä‚¢‚éƒLƒƒƒ‰‚Ì–¼‘O‚ðŽæ“¾
 string World::getControlCharacterName() const {
 	return m_playerChanger->getNowPlayer()->getCharacterInfo()->name();

--- a/World.h
+++ b/World.h
@@ -269,6 +269,9 @@ public:
 	// プレイヤーのHPをMAXにする
 	void playerHpReset();
 
+	// ハートたちのＨＰを回復する。
+	void cureHpOfHearts(int value);
+
 	// 今操作しているキャラがハートか
 	std::string getControlCharacterName() const;
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
自動販売機でお金を払ってＨＰを回復できるようにする。

- 自動販売機を調べてテキスト開始
- お金を払うか選択肢が出る。
- 払うかどうかでテキストが分岐する。
- 払う場合、お金が足りるかどうかで分岐する。
- お金が足りる状態で払うと選択した場合、お金が減りＨＰが回復する。

# やったこと
txtファイルの書き方：
```
# ハートたちのＨＰを回復
@cure
<回復量>
```

```
# 所持金を変動。マイナスになるなら実行せず、[noMoney]がマークされる。
@money
<変動量>
```

```
# Yes, Noの選択肢を出す。Yesが選ばれたら[yesSelect]がマークされ、Noが選ばれたら[noSelect]がマークされる。
@select
```

```
# 条件分岐 マーク名がマークされていたら@endifまで実行し、そうでないなら@endifまでスキップする。
@if
<マーク名>
~~~
@endif
```

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
