### PR TITLE
仲間のＨＰ描画＆仲間の復活機能追加

### DIFF
--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -173,6 +173,26 @@ void CharacterDrawer::drawPlayerSkillBar(int x, int y, int wide, int height, con
 
 }
 
+void CharacterDrawer::drawFollowHpBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph, int font) {
+
+	// 解像度変更に対応
+	x = (int)(x * m_exX);
+	y = (int)(y * m_exY);
+	wide = (int)(wide * m_exX);
+	height = (int)(height * m_exY);
+
+	DrawExtendGraph(x, y, x + wide, y + height, hpBarGraph, TRUE);
+
+	int dx = (int)(20 * m_exX);
+	int dy1 = (int)(50 * m_exY);
+	int dy2 = (int)(10 * m_exY);
+
+	// 体力の描画
+	DrawStringToHandle(x, y, player->getName().c_str(), BLACK, font);
+	drawHpBar(x + dx, y + dy1, x + wide - dx, y + height - dy2, player->getHp(), player->getPrevHp(), player->getMaxHp(), DAMAGE_COLOR, PREV_HP_COLOR, HP_COLOR);
+
+}
+
 void CharacterDrawer::drawBossHpBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph) {
 
 	// 解像度変更に対応

--- a/CharacterDrawer.h
+++ b/CharacterDrawer.h
@@ -47,6 +47,7 @@ public:
 
 	void drawPlayerHpBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph);
 	void drawPlayerSkillBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph);
+	void drawFollowHpBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph, int font);
 	void drawBossHpBar(int x, int y, int wide, int height, const Character* player, int hpBarGraph);
 
 };

--- a/Game.cpp
+++ b/Game.cpp
@@ -21,7 +21,7 @@ using namespace std;
 
 
 // どこまで
-const int FINISH_STORY = 22;
+const int FINISH_STORY = 24;
 // エリア0でデバッグするときはtrueにする
 const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号

--- a/World.cpp
+++ b/World.cpp
@@ -698,14 +698,16 @@ void World::setPlayerPoint(CharacterData* characterData) {
 void World::setPlayerFollowerPoint() {
 	// プレイヤーの仲間
 	for (unsigned int i = 0; i < m_characterControllers.size(); i++) {
-		const Character* follow = m_characterControllers[i]->getBrain()->getFollow();
+		const Character* follow = m_characterControllers[i]->getAction()->getCharacter();
 		// 追跡対象がプレイヤーなら
-		if (follow != nullptr && m_playerId == follow->getId()) {
+		if (follow != nullptr && m_player_p->getGroupId() == follow->getGroupId()) {
 			// Controllerに対応するCharacterに変更を加える
 			for (unsigned int j = 0; j < m_characters.size(); j++) {
-				if (m_characterControllers[i]->getAction()->getCharacter()->getId() == m_characters[j]->getId()) {
-					m_characters[j]->setX(m_player_p->getX());
+				if (m_characters[j]->getId() == follow->getId()) {
+					m_characters[j]->setX(m_player_p->getX() + GetRand(50) - 25);
 					m_characters[j]->setY(m_player_p->getY() + m_player_p->getHeight() - m_characters[j]->getHeight());
+					// HP=0なら半分回復して復活
+					if (m_characters[j]->getHp() == 0) { m_characters[j]->setHp(m_characters[j]->getMaxHp() / 2); }
 					break;
 				}
 			}

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -58,6 +58,7 @@ WorldDrawer::WorldDrawer(const World* world) {
 	m_moneyBoxGraph = LoadGraph("picture/battleMaterial/moneyBox.png");
 	m_hpBarGraph = LoadGraph("picture/battleMaterial/hpBar.png");
 	m_skillBarGraph = LoadGraph("picture/battleMaterial/skillBar.png");
+	m_followHpBarGraph = LoadGraph("picture/battleMaterial/followHpBar.png");
 	m_bossHpBarGraph = LoadGraph("picture/battleMaterial/bossHpBar.png");
 	m_noonHaikei = LoadGraph("picture/stageMaterial/noon.jpg");
 	m_eveningHaikei = LoadGraph("picture/stageMaterial/evening.jpg");
@@ -65,6 +66,7 @@ WorldDrawer::WorldDrawer(const World* world) {
 	m_enemyNotice = LoadGraph("picture/battleMaterial/enemyNotice.png");
 	getGameEx(m_exX, m_exY);
 	m_font = CreateFontToHandle(nullptr, (int)(50 * m_exX), 10);
+	m_followerNameFont = CreateFontToHandle(nullptr, (int)(30 * m_exX), 8);
 }
 
 WorldDrawer::~WorldDrawer() {
@@ -75,12 +77,14 @@ WorldDrawer::~WorldDrawer() {
 	DeleteGraph(m_moneyBoxGraph);
 	DeleteGraph(m_hpBarGraph);
 	DeleteGraph(m_skillBarGraph);
+	DeleteGraph(m_followHpBarGraph);
 	DeleteGraph(m_bossHpBarGraph);
 	DeleteGraph(m_noonHaikei);
 	DeleteGraph(m_eveningHaikei);
 	DeleteGraph(m_nightHaikei);
 	DeleteGraph(m_enemyNotice);
 	DeleteFontToHandle(m_font);
+	DeleteFontToHandle(m_followerNameFont);
 }
 
 
@@ -177,6 +181,7 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 	// 各Actionを描画
 	vector<const CharacterAction*> actions = m_world->getActions();
 	int player = -1;
+	vector<int> followers;
 	const CharacterAction* bossCharacterAction = nullptr;
 	size = actions.size();
 	for (unsigned int i = 0; i < size; i++) {
@@ -198,6 +203,12 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 			m_characterDrawer->drawCharacter(camera, enemyNotice, bright);
 			// ボスがいるなら保持しておく
 			if (actions[i]->getCharacter()->getBossFlag()) { bossCharacterAction = actions[i]; }
+			// 仲間も保持
+			if (player != -1 && actions[i]->getCharacter()->getGroupId() == actions[player]->getCharacter()->getGroupId()) {
+				if (actions[i]->getCharacter()->getName() != "複製のハート") {
+					followers.push_back(i);
+				}
+			}
 		}
 	}
 	// プレイヤーは手前に描画
@@ -239,6 +250,15 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 		if (drawSkillBar) {
 			m_characterDrawer->drawPlayerSkillBar(x, y + height + 10, wide, 30, playerCharacter, m_skillBarGraph);
 		}
+	}
+
+	// 仲間の情報
+	const int fX = 30;
+	const int fY = 800;
+	const int fWide = 300;
+	const int fHeight = 80;
+	for (unsigned int i = 0; i < followers.size(); i++) {
+		m_characterDrawer->drawFollowHpBar(fX + (fWide + 20) * i, fY, fWide, fHeight, actions[followers[i]]->getCharacter(), m_followHpBarGraph, m_followerNameFont);
 	}
 
 	// ボスの情報

--- a/WorldDrawer.h
+++ b/WorldDrawer.h
@@ -66,6 +66,9 @@ private:
 	// skillバー
 	int m_skillBarGraph;
 
+	// 仲間のHPバー
+	int m_followHpBarGraph;
+
 	// ボスのHPバー
 	int m_bossHpBarGraph;
 
@@ -77,6 +80,8 @@ private:
 	double m_exX, m_exY;
 
 	int m_font;
+
+	int m_followerNameFont;
 
 public:
 	WorldDrawer(const World* world);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

ひとまず、やられた仲間はArea移動時に半分のＨＰで復活する仕様にした。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [ ] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
仲間のＨＰ表示が少し邪魔になるかも。
