### PR TITLE
テキストイベント中の見栄えを改善する

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -171,6 +171,7 @@ NormalAI::NormalAI() {
 	m_jumpCnt = 0;
 	m_squatCnt = 0;
 	m_moveCnt = 0;
+	m_prevX = 0;
 }
 
 
@@ -195,6 +196,7 @@ void NormalAI::setParam(NormalAI* brain) {
 	brain->setGx(m_gx);
 	brain->setGy(m_gy);
 	brain->setMoveCnt(m_moveCnt);
+	brain->setPrevX(m_prevX);
 }
 
 void NormalAI::setCharacterAction(const CharacterAction* characterAction) {
@@ -237,10 +239,10 @@ void NormalAI::moveOrder(int& right, int& left, int& up, int& down) {
 	int x = m_characterAction_p->getCharacter()->getCenterX();
 	int y = m_characterAction_p->getCharacter()->getCenterY();
 
-	// (壁につっかえるなどで)移動できてないから諦める
+		// (壁につっかえるなどで)移動できてないから諦める
 	if (m_moveCnt >= GIVE_UP_MOVE_CNT) {
-		m_gx = x;
-		m_gy = y;
+			m_gx = x;
+			m_gy = y;
 	}
 
 	// 目標地点設定
@@ -266,11 +268,11 @@ void NormalAI::moveOrder(int& right, int& left, int& up, int& down) {
 
 // 上下移動するAIが使う
 void NormalAI::moveUpDownOrder(int x, int y, bool& tryFlag) {
-	// (壁につっかえるなどで)移動できてないから諦める
+		// (壁につっかえるなどで)移動できてないから諦める
 	if (m_moveCnt >= GIVE_UP_MOVE_CNT || (m_gy > y && m_characterAction_p->getGrand())) {
-		m_gx = x;
-		m_gy = y;
-		tryFlag = false;
+			m_gx = x;
+			m_gy = y;
+			tryFlag = false;
 	}
 
 	// 壁にぶつかったから上下移動
@@ -491,6 +493,15 @@ bool NormalAI::moveGoalOrder(int& right, int& left, int& up, int& down, int& jum
 	// 現在地
 	int x = m_characterAction_p->getCharacter()->getCenterX();
 	int y = m_characterAction_p->getCharacter()->getY() + m_characterAction_p->getCharacter()->getHeight();
+	// 60フレームごとに座標を確認
+	if (m_moveCnt % 60 == 59) {
+		// (壁につっかえるなどで)移動できてないから諦める
+		if (m_moveCnt >= 60 && abs(m_prevX - x) < 20) {
+			m_gx = x;
+			m_gy = y;
+		}
+		m_prevX = x;
+	}
 	// 目標に到達しているか
 	if (m_gx > x - GX_ERROR && m_gx < x + GX_ERROR && m_gy > y - GY_ERROR && m_gy < y + GY_ERROR) {
 		return true;
@@ -571,10 +582,10 @@ void FollowNormalAI::moveOrder(int& right, int& left, int& up, int& down) {
 	int x = m_characterAction_p->getCharacter()->getCenterX();
 	int y = m_characterAction_p->getCharacter()->getCenterY();
 
-	// (壁につっかえるなどで)移動できてないから諦める
+		// (壁につっかえるなどで)移動できてないから諦める
 	if (m_moveCnt >= GIVE_UP_MOVE_CNT) {
-		m_gx = x;
-		m_gy = y;
+			m_gx = x;
+			m_gy = y;
 	}
 
 	// 目標地点設定用パラメータ

--- a/Brain.h
+++ b/Brain.h
@@ -197,6 +197,9 @@ protected:
 	// 移動時間
 	int m_moveCnt;
 
+	// 10フレーム前でのX座標
+	int m_prevX;
+
 	// 移動を諦めるまでの時間
 	const int GIVE_UP_MOVE_CNT = 180;
 
@@ -221,6 +224,7 @@ public:
 	void setGx(int gx) { m_gx = gx; }
 	void setGy(int gy) { m_gy = gy; }
 	void setMoveCnt(int cnt) { m_moveCnt = cnt; }
+	void setPrevX(int prevX) { m_prevX = prevX; }
 	void setTarget(const Character* character) { m_target_p = character; }
 	void setCharacterAction(const CharacterAction* characterAction);
 

--- a/Character.h
+++ b/Character.h
@@ -395,6 +395,9 @@ public:
 
 	// ‚â‚ç‚ê‰æ‘œ‚ª‚ ‚é‚©
 	bool haveDeadGraph() const;
+
+	// HP‚ª0‚Å‚â‚ç‚ê‰æ‘œ‚ª‚È‚­A‰æ–Ê‚©‚çÁ‚¦‚é‚×‚«‚©
+	inline bool noDispForDead() const { return m_hp == 0 && !haveDeadGraph(); }
 };
 
 

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -81,6 +81,7 @@ CharacterAction::CharacterAction(Character* character, SoundPlayer* soundPlayer_
 	m_grandRightSlope = false;
 	m_vx = 0;
 	m_vy = 0;
+	m_dx = 0;
 	m_rightLock = false;
 	m_leftLock = false;
 	m_upLock = false;
@@ -201,6 +202,8 @@ void CharacterAction::init() {
 
 	m_cnt++;
 
+	m_dx = 0;
+
 	// スキルゲージの回復
 	if (m_cnt % 30 == 29) {
 		m_character_p->setSkillGage(m_character_p->getSkillGage() + 1);
@@ -263,6 +266,9 @@ void CharacterAction::otherAction() {
 
 void CharacterAction::moveAction() {
 	// 移動
+	if (!m_heavy && ((m_dx < 0 && !m_leftLock) || (m_dx > 0 && !m_rightLock))) {
+		m_character_p->moveRight(m_dx);
+	}
 	if (m_vx > 0) {// 右
 		if (m_rightLock) {
 			stopMoveLeft(); // 左に移動したいのに吹っ飛び等で右へ移動しているとき、いったん左移動への入力をキャンセルさせないとバグる
@@ -1021,43 +1027,20 @@ void FlightAction::otherAction() {
 	}
 }
 void FlightAction::moveAction() {
-	// 移動
-	if (m_vx > 0) {// 右
-		if (m_rightLock) {
-			stopMoveLeft(); // 左に移動したいのに吹っ飛び等で右へ移動しているとき、いったん左移動への入力をキャンセルさせないとバグる
-			m_vx = 0;
-		}
-		else {
-			m_character_p->moveRight(m_vx);
-		}
-	}
-	else if (m_vx < 0) { // 左
-		if (m_leftLock) {
-			stopMoveRight();// 右に移動したいのに吹っ飛び等で左へ移動しているとき、いったん右移動への入力をキャンセルさせないとバグる
-			m_vx = 0;
-		}
-		else {
-			m_character_p->moveLeft(-m_vx);
-		}
-	}
+
+	CharacterAction::moveAction();
+
 	if (m_vy < 0) { // 上
 		if (m_upLock) {
 			stopMoveDown();
-			m_vy = 0;
-		}
-		else {
-			m_character_p->moveUp(-m_vy);
 		}
 	}
 	else if (m_vy > 0) { // 下
 		if (m_downLock) {
 			stopMoveUp();
-			m_vy = 0;
-		}
-		else {
-			m_character_p->moveDown(m_vy);
 		}
 	}
+
 }
 
 void FlightAction::walk(bool right, bool left, bool up, bool down) {

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -78,7 +78,7 @@ protected:
 	int m_boostDone;// 0:none 1:right 2:left
 
 	// やられ状態の時間
-	const int DAMAGE_TIME = 20;
+	const int DAMAGE_TIME = 10;
 
 	// ノックバックなしのキャラならtrue
 	bool m_heavy = false;

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -93,6 +93,9 @@ protected:
 	int m_vx;
 	int m_vy;
 
+	// 他のキャラと重なっているため次のフレームで位置をずらす
+	int m_dx;
+
 	// 移動のロック（オブジェクト等で動けない方向はtrue）
 	bool m_rightLock;
 	bool m_leftLock;
@@ -152,6 +155,7 @@ public:
 	inline bool getGrandLeftSlope() const { return m_grandLeftSlope; }
 	inline int getVx() const { return m_vx; }
 	inline int getVy() const { return m_vy; }
+	inline int getDx() const { return m_dx; }
 	inline int getSlashCnt() const { return m_slashCnt; }
 	inline int getBulletCnt() const { return m_bulletCnt; }
 	bool getRightLock() const { return m_rightLock; }
@@ -185,6 +189,7 @@ public:
 	inline void setMoveDown(bool moveDown) { m_moveDown = moveDown; }
 	inline void setVx(int vx) { m_vx = vx; }
 	inline void setVy(int vy) { m_vy = vy; }
+	inline void setDx(int dx) { m_dx = dx; }
 	inline void setBulletCnt(int bulletCnt) { m_bulletCnt = bulletCnt; }
 	inline void setSlashCnt(int slashCnt) { m_slashCnt = slashCnt; }
 	inline void setAttackLeftDirection(bool attackLeftDirection) { m_attackLeftDirection = attackLeftDirection; }

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -235,6 +235,7 @@ void CharacterController::setGoal(int gx, int gy) {
 
 // 目標地点へ移動するだけ
 bool CharacterController::moveGoal() {
+	if (m_characterAction->getCharacter()->getHp() == 0) { return true; }
 	// 移動 stickなどの入力状態を更新する
 	int rightStick = 0, leftStick = 0, upStick = 0, downStick = 0, jump = 0;
 	bool alreadyGoal = m_brain->moveGoalOrder(rightStick, leftStick, upStick, downStick, jump);

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -174,6 +174,9 @@ void CharacterController::setActionDownLock(bool lock) {
 void CharacterController::setActionSound(SoundPlayer* soundPlayer) {
 	m_characterAction->setSoundPlayer(soundPlayer);
 }
+void CharacterController::addActionDx(int value) {
+	m_characterAction->setDx(m_characterAction->getDx() + value);
+}
 
 // キャラクターのセッタ
 void CharacterController::setCharacterX(int x) {

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -92,6 +92,7 @@ public:
 	void setActionUpLock(bool lock);
 	void setActionDownLock(bool lock);
 	void setActionSound(SoundPlayer* soundPlayer);
+	void addActionDx(int value);
 
 	// キャラクターのセッタ
 	void setCharacterX(int x);

--- a/World.cpp
+++ b/World.cpp
@@ -1361,6 +1361,7 @@ bool World::dealBrightValue() {
 
 // ‰ï˜b‚³‚¹‚é
 void World::talk() {
+	moveGoalCharacter();
 	if (m_conversation_p != nullptr) {
 		updateCamera();
 		m_conversation_p->play();

--- a/World.cpp
+++ b/World.cpp
@@ -131,6 +131,8 @@ void penetrationCharacterAndObject(CharacterController* controller, vector<Objec
 World::World() {
 	m_duplicationFlag = false;
 
+	m_dispHpInfoFlag = false;
+
 	m_brightValue = 255;
 
 	m_resetBgmFlag = false;
@@ -814,6 +816,9 @@ CharacterController* World::createControllerWithData(const Character* character,
 *  戦わせる
 */
 void World::battle() {
+
+	m_dispHpInfoFlag = true;
+
 	if (!m_soundPlayer_p->checkBGMplay()) {
 		m_soundPlayer_p->playBGM();
 	}
@@ -1344,6 +1349,9 @@ void World::createBossDeadEffect() {
 
 // 各キャラが目標地点へ移動するだけ 全員到達したらtrueを返す
 bool World::moveGoalCharacter() {
+
+	m_dispHpInfoFlag = false;
+
 	// deleteFlagがtrueのオブジェクトを削除する。
 	deleteObject(m_stageObjects);
 	deleteObject(m_attackObjects);
@@ -1431,7 +1439,6 @@ bool World::dealBrightValue() {
 void World::talk() {
 	moveGoalCharacter();
 	if (m_conversation_p != nullptr) {
-		updateCamera();
 		m_conversation_p->play();
 		// 会話終了
 		if (m_conversation_p->getFinishFlag()) {

--- a/World.cpp
+++ b/World.cpp
@@ -1362,7 +1362,7 @@ bool World::moveGoalCharacter() {
 
 	// キャラクターの動き
 	bool allCharacterAlreadyGoal = true;
-	size_t size = m_characterControllers.size();
+	const size_t size = m_characterControllers.size();
 	for (unsigned int i = 0; i < size; i++) {
 		CharacterController* controller = m_characterControllers[i];
 

--- a/World.h
+++ b/World.h
@@ -58,6 +58,9 @@ public:
 class World {
 private:
 
+	// (Drawer—p) ‚g‚o‚È‚Ç‚Ìî•ñ‚ğ•\¦‚·‚é‚©
+	bool m_dispHpInfoFlag;
+
 	// ‰ğ‘œ“x‚Ì”{—¦
 	double m_exX, m_exY;
 
@@ -186,6 +189,7 @@ public:
 	void debug(int x, int y, int color) const;
 
 	// ƒQƒbƒ^
+	inline bool getDispHpInfoFlag() const { return m_dispHpInfoFlag; }
 	inline int getFocusId() const { return m_focusId; }
 	inline int getPlayerId() const { return m_playerId; }
 	inline int getBrightValue() const { return m_brightValue; }

--- a/World.h
+++ b/World.h
@@ -361,6 +361,9 @@ private:
 	// Battle：アイテムの動き
 	void controlItem();
 
+	// Battle：キャラクター<->キャラクターの当たり判定
+	void atariCharacterAndCharacter();
+
 	// Battle：キャラクターとオブジェクトの当たり判定 slope=trueならslopeが対象falseならそれ以外
 	void atariCharacterAndObject(CharacterController* controller, std::vector<Object*>& objects, bool slope);
 

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -196,7 +196,7 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 			m_characterDrawer->setCharacterAction(actions[i]);
 			int enemyNotice = -1, groupId = actions[i]->getCharacter()->getGroupId();
 			// 中立と味方なら通知しない
-			if (groupId != -1 && player != -1 && groupId != actions[player]->getCharacter()->getGroupId()) {
+			if (groupId != -1 && groupId != 0) {
 				enemyNotice = m_enemyNotice;
 			}
 			// カメラを使ってキャラを描画
@@ -204,7 +204,7 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 			// ボスがいるなら保持しておく
 			if (actions[i]->getCharacter()->getBossFlag()) { bossCharacterAction = actions[i]; }
 			// 仲間も保持
-			if (player != -1 && actions[i]->getCharacter()->getGroupId() == actions[player]->getCharacter()->getGroupId()) {
+			if (groupId == 0) {
 				if (actions[i]->getCharacter()->getName() != "複製のハート") {
 					followers.push_back(i);
 				}
@@ -239,42 +239,44 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 		m_animationDrawer->drawAnimation(camera);
 	}
 
-	// ハートの情報
-	if (player != -1) {
-		const int x = 30;
-		const int y = 30;
-		const int wide = 700;
-		const int height = 70;
-		const Character* playerCharacter = actions[player]->getCharacter();
-		m_characterDrawer->drawPlayerHpBar(x, y, wide, height, playerCharacter, m_hpBarGraph);
-		if (drawSkillBar) {
-			m_characterDrawer->drawPlayerSkillBar(x, y + height + 10, wide, 30, playerCharacter, m_skillBarGraph);
+	if (m_world->getDispHpInfoFlag()) {
+		// ハートの情報
+		if (player != -1) {
+			const int x = 30;
+			const int y = 30;
+			const int wide = 700;
+			const int height = 70;
+			const Character* playerCharacter = actions[player]->getCharacter();
+			m_characterDrawer->drawPlayerHpBar(x, y, wide, height, playerCharacter, m_hpBarGraph);
+			if (drawSkillBar) {
+				m_characterDrawer->drawPlayerSkillBar(x, y + height + 10, wide, 30, playerCharacter, m_skillBarGraph);
+			}
 		}
-	}
 
-	// 仲間の情報
-	const int fX = 30;
-	const int fY = 800;
-	const int fWide = 300;
-	const int fHeight = 80;
-	for (unsigned int i = 0; i < followers.size(); i++) {
-		m_characterDrawer->drawFollowHpBar(fX + (fWide + 20) * i, fY, fWide, fHeight, actions[followers[i]]->getCharacter(), m_followHpBarGraph, m_followerNameFont);
-	}
+		// 仲間の情報
+		const int fX = 30;
+		const int fY = 800;
+		const int fWide = 300;
+		const int fHeight = 80;
+		for (unsigned int i = 0; i < followers.size(); i++) {
+			m_characterDrawer->drawFollowHpBar(fX + (fWide + 20) * i, fY, fWide, fHeight, actions[followers[i]]->getCharacter(), m_followHpBarGraph, m_followerNameFont);
+		}
 
-	// ボスの情報
-	const int bX = 30;
-	const int bY = 950;
-	const int bWide = 1500;
-	const int bHeight = 80;
-	if (bossCharacterAction != nullptr) {
-		m_characterDrawer->drawBossHpBar(bX, bY, bWide, bHeight, bossCharacterAction->getCharacter(), m_bossHpBarGraph);
-	}
+		// ボスの情報
+		const int bX = 30;
+		const int bY = 950;
+		const int bWide = 1500;
+		const int bHeight = 80;
+		if (bossCharacterAction != nullptr) {
+			m_characterDrawer->drawBossHpBar(bX, bY, bWide, bHeight, bossCharacterAction->getCharacter(), m_bossHpBarGraph);
+		}
 
-	// お金
-	DrawExtendGraph((int)(1600 * m_exX), (int)(10 * m_exY), (int)(1900 * m_exX), (int)(80 * m_exY), m_moneyBoxGraph, TRUE);
-	int money = m_world->getMoney();
-	ostringstream oss;
-	oss << "＄：" << money;
-	DrawStringToHandle((int)(1650 * m_exX), (int)(20 * m_exY), oss.str().c_str(), BLACK, m_font);
+		// お金
+		DrawExtendGraph((int)(1600 * m_exX), (int)(10 * m_exY), (int)(1900 * m_exX), (int)(80 * m_exY), m_moneyBoxGraph, TRUE);
+		int money = m_world->getMoney();
+		ostringstream oss;
+		oss << "＄：" << money;
+		DrawStringToHandle((int)(1650 * m_exX), (int)(20 * m_exY), oss.str().c_str(), BLACK, m_font);
+	}
 
 }


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
テキストイベント中にキャラがフリーズしているのは違和感がある。
また、フリーズしなくてもキャラが重なっている状態で会話するのも違和感がある。

# やったこと
- テキストイベント中も戦闘画面はフリーズせずキャラは瞬きを行ったり目標地点への移動を続行する。
- キャラクター間の当たり判定を実装
  - キャラが重なっているときはお互いに距離を話す方向（横のみ）にずれていく。
  - 次のフレームでずれる幅はCharacterAction::m_dxで管理
  - ただしheavyのキャラは動かない。
  - また、例外としてボスは他キャラとの当たり判定を一切持たない。
- テキストイベントやWaiイベント中はＨＰの表示等が不要なため非表示にする。
  - オブジェクトを調べた際の会話では表示のまま
  - 具体的には、World::battle()を実行したフレームでは表示し、World::moveGoalCharacter()を実行したフレームでは非表示にする。

加えて、上記の修正をするとテキストイベント中にCPUが壁につっかえ永遠にジャンプし続けることがあったので、1秒以上経過かつ1秒間Ｘ座標が変わらなかった場合に移動をやめるようにした。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認

# 懸念点
記入欄
