### PR TITLE
CharacterActionの_xが保存されないバグ修正

### DIFF
--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -153,6 +153,7 @@ public:
 	inline bool getGrand() const { return m_grand; }
 	inline bool getGrandRightSlope() const { return m_grandRightSlope; }
 	inline bool getGrandLeftSlope() const { return m_grandLeftSlope; }
+	inline bool getHeavy() const { return m_heavy; }
 	inline int getVx() const { return m_vx; }
 	inline int getVy() const { return m_vy; }
 	inline int getDx() const { return m_dx; }

--- a/Define.h
+++ b/Define.h
@@ -4,7 +4,7 @@
 #include "DxLib.h"
 
 // フルスクリーンならFALSE
-static int WINDOW = TRUE;
+static int WINDOW = FALSE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = TRUE;
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -58,9 +58,10 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	//SetMousePoint(320, 240);//マウスカーソルの初期位置
 	
 	// 画像の拡大処理方式
-	SetDrawMode(DX_DRAWMODE_BILINEAR);
-	//SetDrawMode(DX_DRAWMODE_NEAREST);
-	SetFullScreenScalingMode(DX_DRAWMODE_NEAREST);
+	const int DRAW_MODE = DX_DRAWMODE_BILINEAR;
+	//const int DRAW_MODE = DX_DRAWMODE_NEAREST;
+	SetDrawMode(DRAW_MODE);
+	SetFullScreenScalingMode(DRAW_MODE);
 
 	// ゲーム本体
 	Game* game = nullptr;

--- a/World.cpp
+++ b/World.cpp
@@ -612,7 +612,11 @@ void World::asignCharacterData(const char* name, CharacterData* data, int fromAr
 			if (m_characterControllers[i]->getBrain()->getFollow() != nullptr) {
 				data->setFollowName(m_characterControllers[i]->getBrain()->getFollow()->getName().c_str());
 			}
-			data->setActionName(m_characterControllers[i]->getAction()->getActionName());
+			string actionName = m_characterControllers[i]->getAction()->getActionName();
+			if (m_characterControllers[i]->getAction()->getHeavy()) {
+				actionName += "_x";
+			}
+			data->setActionName(actionName.c_str());
 			data->setSoundFlag(m_characterControllers[i]->getAction()->getSoundPlayer() != nullptr);
 			data->setControllerName(m_characterControllers[i]->getControllerName());
 			break;


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
エリア移動時にheavyを考慮したキャラデータ保存を行っていない。そのため、エリア移動して戻ると、さっきheavy=trueだったキャラがheavy=falseに変わってしまう。

# やったこと
heavy=trueならCharacterActionのクラス名の保存において末尾に_xを付与する。

また、フルスクリーン時とウィンドウ時で描画方式が統一されていなかったのでそれもついでに修正した。

全画像にスムージング処理を行ったので画質も改善された。（コードに修正はない。）

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [ ] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
