### PR TITLE
チャプター28まで完成

### DIFF
--- a/Brain.cpp
+++ b/Brain.cpp
@@ -566,8 +566,10 @@ const Character* FollowNormalAI::getFollow() const {
 // ’ÇÕ‘ÎÛ‚ðƒZƒbƒg
 void FollowNormalAI::setFollow(const Character* character) {
 	m_follow_p = character;
-	m_gx = m_characterAction_p->getCharacter()->getX();
-	m_gy = m_characterAction_p->getCharacter()->getY();
+	if (m_characterAction_p != nullptr) {
+		m_gx = m_characterAction_p->getCharacter()->getX();
+		m_gy = m_characterAction_p->getCharacter()->getY();
+	}
 }
 
 bool FollowNormalAI::checkAlreadyFollow() {

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -563,6 +563,13 @@ const Character* FollowNormalAI::getFollow() const {
 	return m_follow_p;
 }
 
+// ’ÇÕ‘ÎÛ‚ğƒZƒbƒg
+void FollowNormalAI::setFollow(const Character* character) {
+	m_follow_p = character;
+	m_gx = m_characterAction_p->getCharacter()->getX();
+	m_gy = m_characterAction_p->getCharacter()->getY();
+}
+
 bool FollowNormalAI::checkAlreadyFollow() {
 	// ’ÇÕ‘ÎÛ‚ª‚¢‚È‚¢
 	if (m_follow_p == nullptr) { return true; }

--- a/Brain.h
+++ b/Brain.h
@@ -286,7 +286,7 @@ public:
 	const Character* getFollow() const;
 
 	// 追跡対象をセット
-	void setFollow(const Character* character) { m_follow_p = character; }
+	void setFollow(const Character* character);
 
 	// 移動の目標地点設定
 	void moveOrder(int& right, int& left, int& up, int& down);

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -367,7 +367,10 @@ bool CharacterAction::ableWalk() const {
 }
 
 bool CharacterAction::ableChangeDirection() const {
-	if (m_bulletCnt > 0 || m_slashCnt > 0 || m_moveLeft || m_moveRight || m_moveUp || m_moveDown || m_damageCnt > 0) {
+	if (m_character_p->getHp() == 0
+		|| m_bulletCnt > 0 || m_slashCnt > 0
+		|| m_moveLeft || m_moveRight || m_moveUp || m_moveDown
+		|| m_damageCnt > 0) {
 		return false;
 	}
 	return true;

--- a/CharacterLoader.cpp
+++ b/CharacterLoader.cpp
@@ -48,6 +48,13 @@ pair<vector<Character*>, vector<CharacterController*> > CharacterLoader::getChar
 		// キャラを作成
 		Character* character = createCharacter(name.c_str(), 100, x, y, groupId);
 
+		// HP設定（指定されている場合のみ）
+		if (m_characters[areaNum][i].find("hp") != m_characters[areaNum][i].end()) {
+			string s = m_characters[areaNum][i]["hp"];
+			if (s == "0") { character->setHp(0); }
+			else if (s == "max") { character->setHp(character->getMaxHp()); }
+		}
+
 		// カメラをセット
 		if (cameraFlag && character != nullptr) {
 			camera_p->setPoint(character->getCenterX(), character->getCenterY());
@@ -98,6 +105,11 @@ void CharacterLoader::saveCharacterData(CharacterData* characterData) {
 				characterData->setActionName(characters[i]["action"].c_str());
 				characterData->setBrainName(characters[i]["brain"].c_str());
 				characterData->setControllerName(characters[i]["controller"].c_str());
+				if (characters[i].find("hp") != characters[i].end()) {
+					string s = characters[i]["hp"];
+					if (s == "0") { characterData->setHp(0); }
+					else if (s == "max") { characterData->setHp(-1); }
+				}
 				return;
 			}
 		}

--- a/Define.h
+++ b/Define.h
@@ -4,7 +4,7 @@
 #include "DxLib.h"
 
 // フルスクリーンならFALSE
-static int WINDOW = FALSE;
+static int WINDOW = TRUE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = TRUE;
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -682,6 +682,7 @@ EVENT_RESULT PlayerDeadEvent::play() {
 	m_world_p->battle();
 	// 対象のキャラのHPをチェックする
 	if (m_world_p->getAreaNum() == m_areaNum && m_world_p->playerDead() && m_world_p->getBrightValue() == 0) {
+		m_world_p->changePlayer(m_world_p->getCharacterWithId(m_world_p->getPlayerId()));
 		return EVENT_RESULT::SUCCESS;
 	}
 	return EVENT_RESULT::NOW;

--- a/Game.cpp
+++ b/Game.cpp
@@ -21,7 +21,7 @@ using namespace std;
 
 
 // どこまで
-const int FINISH_STORY = 24;
+const int FINISH_STORY = 29;
 // エリア0でデバッグするときはtrueにする
 const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号

--- a/Text.h
+++ b/Text.h
@@ -36,6 +36,10 @@ private:
 
 	bool m_finishFlag;
 
+	bool m_heavyFlag;
+	bool m_lightFlag;
+	int m_alpha;
+
 public:
 
 	EventAnime(const char* filePath, int sum, int speed = -1);
@@ -46,11 +50,14 @@ public:
 	inline const bool getToDark() const { return m_toDark; }
 	inline const int getBright() const { return m_bright; }
 	inline const Animation* getAnime() const { return m_animation; }
+	inline const int getAlpha() const { return m_alpha; }
 
 	// セッタ
 	inline void setToDark(bool toDark) { m_toDark = toDark; }
 	inline void setBright(int bright) { m_bright = bright; }
 	inline void setFinishFlag(bool flag) { m_finishFlag = flag; }
+	inline void setHeavyTrue() { m_heavyFlag = true; m_alpha = 0; }
+	inline void setLightTrue() { m_lightFlag = true; m_alpha = 255; }
 
 	// アニメイベントが終わったか
 	bool getFinishAnimeEvent() const;
@@ -220,6 +227,7 @@ public:
 		return m_eventAnime->getAnime();
 	}
 	inline int getAnimeBright() const { return m_eventAnime->getBright(); }
+	inline int getAnimeAlpha() const { return m_eventAnime->getAlpha(); }
 	inline const std::vector<Animation*> getAnimations() const { return m_animations; }
 	inline const GraphHandle* getTextFinishGraph() const { return m_textFinishGraph; }
 	inline const EventAnime* getEventAnime() const { return m_eventAnime; }

--- a/TextDrawer.cpp
+++ b/TextDrawer.cpp
@@ -62,11 +62,14 @@ void ConversationDrawer::draw() {
 	// アニメ
 	const Animation* anime = m_conversation->getAnime();
 	if (anime != nullptr) {
-		DrawBox(0, 0, GAME_WIDE, GAME_HEIGHT, BLACK, TRUE);
 		int bright = m_conversation->getAnimeBright();
 		SetDrawBright(bright, bright, bright);
+		int alpha = m_conversation->getAnimeAlpha();
+		SetDrawBlendMode(DX_BLENDMODE_ALPHA, alpha);
+		if(alpha == 255){ DrawBox(0, 0, GAME_WIDE, GAME_HEIGHT, BLACK, TRUE); }
 		m_animationDrawer->setAnimation(anime);
 		m_animationDrawer->drawAnimation();
+		SetDrawBlendMode(DX_BLENDMODE_NOBLEND, 0 );
 		SetDrawBright(255, 255, 255);
 		if (m_conversation->animePlayNow() && m_conversation->getFinishCnt() == 0) { animeOnly = true; }
 	}
@@ -123,7 +126,7 @@ void ConversationDrawer::draw() {
 	drawSkip(m_conversation->getSkipCnt(), m_exX, m_exY, m_textHandle);
 	
 	// 画面右下のクリック要求アイコン
-	bool textFinish = m_conversation->finishText() && m_conversation->getFinishCnt() == 0 && m_conversation->getStartCnt() == 0 && m_conversation->nextTextAble();
+	bool textFinish = m_conversation->finishText() && m_conversation->getFinishCnt() == 0 && m_conversation->nextTextAble();
 	bool eventFinish = !(m_conversation->animePlayNow()) || (m_conversation->getEventAnime()->getAnime()->getFinishFlag());
 	if (textFinish && eventFinish) {
 		int dy = (int)(((m_conversation->getCnt() / 3) % 20 - 10) * m_exY);

--- a/World.cpp
+++ b/World.cpp
@@ -714,6 +714,8 @@ void World::setPlayerFollowerPoint() {
 					m_characters[j]->setY(m_player_p->getY() + m_player_p->getHeight() - m_characters[j]->getHeight());
 					// HP=0‚È‚ç”¼•ª‰ñ•œ‚µ‚Ä•œŠˆ
 					if (m_characters[j]->getHp() == 0) { m_characters[j]->setHp(m_characters[j]->getMaxHp() / 2); }
+					// gx, gy‚ðXV‚·‚é‚½‚ß
+					m_characterControllers[i]->setBrainFollow(m_player_p);
 					break;
 				}
 			}
@@ -780,6 +782,9 @@ void World::asignedCharacter(Character* character, CharacterData* data, bool cha
 	if (data->id() != -1) {
 		// ‚±‚ÌƒQ[ƒ€‚Å‰“oê‚¶‚á‚È‚¢
 		character->setHp(data->hp());
+		if (data->hp() == -1) { // -1‚ÍÅ‘åHP‚ð•\‚·
+			character->setHp(character->getMaxHp());
+		}
 		character->setSkillGage(data->skillGage());
 	}
 	character->setInvincible(data->invincible());


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
記入欄

# やったこと
- HP0のキャラはFreezeのとき方向転換しない
- やられイベント後、ハートが復活した際に仲間の目標座標を現在地にリセットする(&setFollowの修正)
- story.csvでキャラのHPを0, maxで指定できるように
- テキストイベントで、挿絵の透明描画を可能にした
- テキストイベントで、クリック要求アイコンの表示仕様を変更（フキダシの状態を無視）
- #208 の解消

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [ ] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
