### PR TITLE
resetWorld時のバグ修正

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -21,7 +21,7 @@ using namespace std;
 
 
 // どこまで
-const int FINISH_STORY = 29;
+const int FINISH_STORY = 31;
 // エリア0でデバッグするときはtrueにする
 const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
@@ -635,6 +635,7 @@ bool Game::play() {
 		// 世界のやり直しが起きる場合ドアやキャラのデータを初期化
 		if (m_story->getResetWorld()) {
 			m_gameData->resetWorld();
+			m_world->clearCharacter();
 			m_gameData->asignWorld(m_world, true);
 			m_soundPlayer->stopBGM();
 		}

--- a/World.cpp
+++ b/World.cpp
@@ -444,6 +444,22 @@ void World::addCharacter(CharacterLoader* characterLoader) {
 	m_characterControllers.insert(m_characterControllers.end(), p.second.begin(), p.second.end());
 }
 
+// ループによるキャラclear
+void World::clearCharacter() {
+	for (int i = (int)m_characterControllers.size() - 1; i >= 0; i--) {
+		if (m_characterControllers[i]->getAction()->getCharacter()->getName() != "ハート") {
+			delete m_characterControllers[i];
+			m_characterControllers.pop_back();
+		}
+	}
+	for (int i = (int)m_characters.size() - 1; i >= 0; i--) {
+		if (m_characters[i]->getName() != "ハート") {
+			delete m_characters[i];
+			m_characters.pop_back();
+		}
+	}
+}
+
 // ストーリーによるキャラの性能変化
 void World::changeCharacterVersion(int version) {
 	for (unsigned int i = 0; i < m_characters.size(); i++) {

--- a/World.h
+++ b/World.h
@@ -261,6 +261,9 @@ public:
 	// ストーリーによるキャラ追加
 	void addCharacter(CharacterLoader* characterLoader);
 
+	// ループによるキャラclear
+	void clearCharacter();
+
 	// ストーリーによるキャラの性能変化
 	void changeCharacterVersion(int version);
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
世界がループしたとき、シエスタが２人になってしまうバグが発覚。

原因：
- ループ直前に行われたエリア移動イベントで、ハートに追従して移動するシエスタ
- story.csvから読み込まれるシエスタ
の二人が存在する？

# やったこと
`ループ直前に行われたエリア移動イベントで、ハートに追従して移動するシエスタ`
を削除する。

具体的には、ループ後のWorldにstory.csvが反映される前にworldのキャラをハート以外リセットする。

流れとしては
1. MoveAreaEvent開始
2. 画面が暗転し、World::m_areaNumが変わるまでEvent継続
3. Gameクラスがエリア移動を察知しエリア1のWorldを作り直す
4. MoveAreaEventが終了し、m_story->play()がtrue時の処理が開始
5. 新しいStoryクラスが作成される（story.csvの読み込み）
6. ループ時の処理（resetWorld）が実行される
7. `ここで、worldインスタンスからキャラを削除`
8. reset後のGameDataをworldにasign
9. story.csvをGameDataに反映
10. GameDataをWorldに反映
11. story.play()の実行ループに戻る

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認

# 懸念点
記入欄
