### PR TITLE
standSlashとstandBulletのアニメーション追加

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -495,9 +495,24 @@ void Heart::switchPreJump(int cnt) {
 	m_graphHandle->switchPreJump(index);
 }
 
-// ŽËŒ‚UŒ‚‚ð‚·‚é
-Object* Heart::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
+// —§‚¿ŽaŒ‚‰æ‘œ‚ðƒZƒbƒg
+void Heart::switchSlash(int cnt) {
+	if (m_graphHandle->getSlashHandle() == nullptr) { return; }
+	int index = (getSlashCountSum() + getSlashInterval() - cnt) / 3;
+	m_graphHandle->switchSlash(index);
+}
 
+// —§‚¿ŽËŒ‚‰æ‘œ‚ðƒZƒbƒg
+void Heart::switchBullet(int cnt) {
+	if (m_graphHandle->getBulletHandle() == nullptr) { return; }
+	int flame = getBulletRapid() / m_graphHandle->getStandBulletHandle()->getGraphHandles()->getSize();
+	int index = (getBulletRapid() - cnt) / flame;
+	m_graphHandle->switchBullet(index);
+}
+
+// ŽËŒ‚UŒ‚‚ð‚·‚é
+Object* Heart::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+	if (cnt != getBulletRapid()) { return nullptr; }
 	// ’e‚Ìì¬
 	BulletObject* attackObject;
 	if (m_graphHandle->getBulletHandle() != nullptr) {
@@ -598,7 +613,8 @@ Character* Siesta::createCopy() {
 }
 
 // ŽËŒ‚UŒ‚‚ð‚·‚é
-Object* Siesta::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
+Object* Siesta::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+	if (cnt != getBulletRapid() / 2) { return nullptr; }
 	ParabolaBullet *attackObject = new ParabolaBullet(getCenterX(), getCenterY(), m_graphHandle->getBulletHandle()->getGraphHandles()->getGraphHandle(), gx, gy, m_attackInfo);
 	// Ž©–Å–hŽ~
 	attackObject->setCharacterId(m_id);
@@ -690,7 +706,8 @@ Character* Hierarchy::createCopy() {
 }
 
 // ŽËŒ‚UŒ‚‚ð‚·‚é
-Object* Hierarchy::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
+Object* Hierarchy::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+	if (cnt != getBulletRapid()) { return nullptr; }
 	//gx = GetRand(600) - 300 + getCenterX();
 	//gy = getCenterY() - GetRand(300);
 	BulletObject* attackObject = new BulletObject(getCenterX(), getCenterY(), m_graphHandle->getBulletHandle()->getGraphHandles()->getGraphHandle(), gx, gy, m_attackInfo);
@@ -842,7 +859,8 @@ Character* Koharu::createCopy() {
 }
 
 // ŽËŒ‚UŒ‚‚ð‚·‚é
-Object* Koharu::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
+Object* Koharu::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+	if (cnt != getBulletRapid()) { return nullptr; }
 	// ƒoƒY[ƒJ‚ÌeŒû‚©‚ço‚é‚æ‚¤‚ÉŒ©‚¹‚é
 	gy = getY() + getHeight() - 160;
 	BulletObject* attackObject = new BulletObject(getCenterX(), gy, m_graphHandle->getBulletHandle()->getGraphHandles()->getGraphHandle(), gx, gy, m_attackInfo);
@@ -922,7 +940,8 @@ Character* ParabolaOnly::createCopy() {
 }
 
 // ŽËŒ‚UŒ‚‚ð‚·‚é
-Object* ParabolaOnly::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
+Object* ParabolaOnly::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+	if (cnt != getBulletRapid()) { return nullptr; }
 	ParabolaBullet* attackObject = new ParabolaBullet(getCenterX(), getCenterY(), m_bulletColor, gx, gy, m_attackInfo);
 	// Ž©–Å–hŽ~
 	attackObject->setCharacterId(m_id);
@@ -969,7 +988,8 @@ void Sun::switchInit(int cnt) {
 	m_graphHandle->switchInit(index);
 }
 
-Object* Sun::bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) {
+Object* Sun::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+	if (cnt != getBulletRapid()) { return nullptr; }
 	int x = getCenterX() + GetRand(400) - 200;
 	int y = getCenterY() + GetRand(400) - 200;
 	ParabolaBullet* attackObject = new ParabolaBullet(x, y, m_graphHandle->getBulletHandle()->getGraphHandles()->getGraphHandle(), gx, gy, m_attackInfo);

--- a/Character.h
+++ b/Character.h
@@ -383,7 +383,7 @@ public:
 	void moveDown(int d);
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é(ƒLƒƒƒ‰‚²‚Æ‚Éˆá‚¤)
-	virtual Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) { return nullptr; }
+	virtual Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) { return nullptr; }
 
 	// aŒ‚UŒ‚‚ğ‚·‚é(ƒLƒƒƒ‰‚²‚Æ‚Éˆá‚¤) ¶‚ğŒü‚¢‚Ä‚¢‚é‚©A¡‰½ƒJƒEƒ“ƒg‚©
 	virtual Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
@@ -443,8 +443,14 @@ public:
 	// ƒWƒƒƒ“ƒv‘O‰æ‘œ‚ğƒZƒbƒg
 	void switchPreJump(int cnt = 0);
 
+	// —§‚¿aŒ‚‰æ‘œ‚ğƒZƒbƒg
+	void switchSlash(int cnt = 0);
+
+	// —§‚¿ËŒ‚‰æ‘œ‚ğƒZƒbƒg
+	void switchBullet(int cnt = 0);
+
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer);
+	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
 	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
@@ -465,7 +471,7 @@ public:
 	Character* createCopy();
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer);
+	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
 	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
@@ -486,7 +492,7 @@ public:
 	Character* createCopy();
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer);
+	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
 	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
@@ -510,7 +516,7 @@ public:
 	void switchPreJump(int cnt = 0);
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer){ return nullptr; }
+	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer){ return nullptr; }
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
 	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
@@ -549,7 +555,7 @@ public:
 	Character* createCopy();
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer);
+	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 };
 
@@ -586,7 +592,7 @@ public:
 	Character* createCopy();
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer) { return nullptr; }
+	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) { return nullptr; }
 };
 
 
@@ -604,7 +610,7 @@ public:
 	Character* createCopy();
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer);
+	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 };
 
 
@@ -625,7 +631,7 @@ public:
 	void switchInit(int cnt);
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int gx, int gy, SoundPlayer* soundPlayer);
+	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
 	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -567,7 +567,7 @@ void StickAction::switchHandle() {
 		switch (m_state) {
 		case CHARACTER_STATE::STAND: //—§‚¿ó‘Ô
 			if (m_slashCnt > 0) {
-				m_character_p->switchSlash();
+				m_character_p->switchSlash(m_slashCnt);
 			}
 			else if (m_landCnt > 0) {
 				m_character_p->switchLand();
@@ -577,7 +577,7 @@ void StickAction::switchHandle() {
 					m_character_p->switchRunBullet(m_runCnt);
 				}
 				else {
-					m_character_p->switchBullet();
+					m_character_p->switchBullet(m_bulletCnt);
 				}
 			}
 			else if (m_runCnt != -1) {
@@ -601,14 +601,14 @@ void StickAction::switchHandle() {
 		case CHARACTER_STATE::DAMAGE:
 			if (m_boostCnt > 0) {
 				if (m_slashCnt > 0) {
-					m_character_p->switchSlash();
+					m_character_p->switchSlash(m_slashCnt);
 				}
 				else if (m_bulletCnt > 0) {
 					if (m_runCnt != -1) {
 						m_character_p->switchRunBullet(m_runCnt);
 					}
 					else {
-						m_character_p->switchBullet();
+						m_character_p->switchBullet(m_bulletCnt);
 					}
 				}
 				else {
@@ -802,10 +802,9 @@ Object* StickAction::bulletAttack(int gx, int gy) {
 			m_character_p->setLeftDirection(m_character_p->getCenterX() > gx);
 		}
 		startBullet();
-		// UŒ‚‚ð•Ô‚·
-		return m_character_p->bulletAttack(gx, gy, m_soundPlayer_p);
 	}
-	return nullptr;
+	// UŒ‚‚ð•Ô‚·
+	return m_character_p->bulletAttack(m_bulletCnt, gx, gy, m_soundPlayer_p);
 }
 
 // ŽaŒ‚UŒ‚
@@ -1149,10 +1148,9 @@ Object* FlightAction::bulletAttack(int gx, int gy) {
 			m_character_p->setLeftDirection(m_character_p->getCenterX() > gx);
 		}
 		startBullet();
-		// UŒ‚‚ð•Ô‚·
-		return m_character_p->bulletAttack(gx, gy, m_soundPlayer_p);
 	}
-	return nullptr;
+	// UŒ‚‚ð•Ô‚·
+	return m_character_p->bulletAttack(m_bulletCnt, gx, gy, m_soundPlayer_p);
 }
 
 // ŽaŒ‚UŒ‚
@@ -1221,10 +1219,9 @@ Object* KoharuAction::bulletAttack(int gx, int gy) {
 			m_character_p->setLeftDirection(m_character_p->getCenterX() > gx);
 		}
 		startBullet();
-		// UŒ‚‚ð•Ô‚·
-		return m_character_p->bulletAttack(gx, gy, m_soundPlayer_p);
 	}
-	return nullptr;
+	// UŒ‚‚ð•Ô‚·
+	return m_character_p->bulletAttack(m_bulletCnt, gx, gy, m_soundPlayer_p);
 }
 
 void KoharuAction::startBullet() {

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -412,7 +412,7 @@ Object* NormalController::bulletAttack() {
 	}
 
 	// ‰“‹——£UŒ‚‚Ì–½—ß‚ª‚³‚ê‚Ä‚¢‚é‚È‚ç
-	if (order > 0) {
+	if (order > 0 || m_characterAction->getBulletCnt() > 0) {
 		// –Ú•W‚ÉŒü‚©‚Á‚ÄŽËŒ‚
 		return m_characterAction->bulletAttack(targetX, targetY);
 	}


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
斬撃、射撃攻撃時のアニメーションを追加する。

それに伴い、射撃時の弾が発射されるタイミングはCharacterクラスのコードで設定できるようにした。(アニメーションと発射タイミングを合わせ自然な見た目にするため）

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [ ] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
