### PR TITLE
story.csvの読み込み方法を修正

### DIFF
--- a/CsvReader.h
+++ b/CsvReader.h
@@ -40,6 +40,10 @@ public:
 };
 
 
+/*
+* DOMAIN対応版
+* TODO: CsvReaderを使いまわしてリファクタリング
+*/
 class CsvReader2 {
 private:
 	/*

--- a/Story.cpp
+++ b/Story.cpp
@@ -13,8 +13,9 @@ using namespace std;
 
 string getChapterName(int storyNum) {
 	// story○○.csvをロード
+	CsvReader csvReader("data/story/storyMap.csv");
 	ostringstream oss;
-	oss << "data/story/story" << storyNum << ".csv";
+	oss << "data/story/" << csvReader.findOne("num", to_string(storyNum).c_str())["fileName"] << ".csv";
 	CsvReader2 csvReader2(oss.str().c_str());
 	string s = csvReader2.getDomainData("NAME:")[0]["name"];
 	return s;
@@ -36,8 +37,9 @@ Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer, EventData* ev
 	m_initDark = false;
 
 	// story○○.csvをロード
+	CsvReader csvReader("data/story/storyMap.csv");
 	ostringstream oss;
-	oss << "data/story/story" << storyNum << ".csv";
+	oss << "data/story/" << csvReader.findOne("num", to_string(storyNum).c_str())["fileName"] << ".csv";
 	loadCsvData(oss.str().c_str(), world, soundPlayer);
 
 	// イベントの発火確認


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
ストーリーのcsvファイルは今まで番号を振りstory〇〇.csvという名前にしていた。

しかしこの方法はストーリーの修正でcsvを追加・削除するとき番号を振り直す必要があった。

そのため、csvファイルの名前を任意にし、storyMap.csvでそのファイル名と番号のマッピングを指定するよう変更する。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認

# 懸念点
記入欄
