### PR TITLE
しゃがみ射撃と空中斬撃のアニメーション追加・修正

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -499,6 +499,9 @@ void Heart::switchPreJump(int cnt) {
 void Heart::switchSlash(int cnt) {
 	if (m_graphHandle->getStandSlashHandle() == nullptr) { return; }
 	int index = (getSlashCountSum() + getSlashInterval() - cnt) / 3;
+	if (cnt > 6) {
+		index = min(m_graphHandle->getStandSlashHandle()->getGraphHandles()->getSize() - 2, index);
+	}
 	m_graphHandle->switchSlash(index);
 }
 
@@ -514,6 +517,9 @@ void Heart::switchBullet(int cnt) {
 void Heart::switchAirSlash(int cnt) {
 	if (m_graphHandle->getAirSlashHandle() == nullptr) { return; }
 	int index = (getSlashCountSum() + getSlashInterval() - cnt) / 3;
+	if (cnt > 6) {
+		index = min(m_graphHandle->getAirSlashHandle()->getGraphHandles()->getSize() - 2, index);
+	}
 	m_graphHandle->switchAirSlash(index);
 }
 
@@ -523,6 +529,14 @@ void Heart::switchAirBullet(int cnt) {
 	int flame = getBulletRapid() / m_graphHandle->getAirBulletHandle()->getGraphHandles()->getSize();
 	int index = (getBulletRapid() - cnt) / flame;
 	m_graphHandle->switchAirBullet(index);
+}
+
+// ‚µ‚á‚ª‚İËŒ‚‰æ‘œ‚ğƒZƒbƒg
+void Heart::switchSquatBullet(int cnt) {
+	if (m_graphHandle->getSquatBulletHandle() == nullptr) { return; }
+	int flame = getBulletRapid() / m_graphHandle->getSquatBulletHandle()->getGraphHandles()->getSize();
+	int index = (getBulletRapid() - cnt) / flame;
+	m_graphHandle->switchSquatBullet(index);
 }
 
 // ËŒ‚UŒ‚‚ğ‚·‚é

--- a/Character.h
+++ b/Character.h
@@ -455,11 +455,15 @@ public:
 	// 空中斬撃画像をセット
 	void switchAirSlash(int cnt = 0);
 
+	// しゃがみ射撃画像をセット
+	void switchSquatBullet(int cnt = 0);
+
 	// 射撃攻撃をする
 	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 	// 斬撃攻撃をする
 	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
+
 };
 
 

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -589,7 +589,7 @@ void StickAction::switchHandle() {
 			break;
 		case CHARACTER_STATE::SQUAT:
 			if (m_bulletCnt > 0) {
-				m_character_p->switchSquatBullet();
+				m_character_p->switchSquatBullet(m_bulletCnt);
 			}
 			else {
 				m_character_p->switchSquat();
@@ -625,7 +625,7 @@ void StickAction::switchHandle() {
 		switch (m_state) {
 		case CHARACTER_STATE::STAND: //—§‚¿ó‘Ô(‚È‚É‚à‚È‚µ‚Ìó‘Ô)
 			if (m_slashCnt > 0) {
-				m_character_p->switchAirSlash();
+				m_character_p->switchAirSlash(m_slashCnt);
 			}
 			else if (m_bulletCnt > 0) {
 				m_character_p->switchAirBullet(m_bulletCnt);

--- a/Story.cpp
+++ b/Story.cpp
@@ -15,7 +15,7 @@ string getChapterName(int storyNum) {
 	// story○○.csvをロード
 	CsvReader csvReader("data/story/storyMap.csv");
 	ostringstream oss;
-	oss << "data/story/" << csvReader.findOne("num", to_string(storyNum).c_str())["fileName"] << ".csv";
+	oss << "data/story/main/" << csvReader.findOne("num", to_string(storyNum).c_str())["fileName"] << ".csv";
 	CsvReader2 csvReader2(oss.str().c_str());
 	string s = csvReader2.getDomainData("NAME:")[0]["name"];
 	return s;
@@ -39,7 +39,7 @@ Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer, EventData* ev
 	// story○○.csvをロード
 	CsvReader csvReader("data/story/storyMap.csv");
 	ostringstream oss;
-	oss << "data/story/" << csvReader.findOne("num", to_string(storyNum).c_str())["fileName"] << ".csv";
+	oss << "data/story/main/" << csvReader.findOne("num", to_string(storyNum).c_str())["fileName"] << ".csv";
 	loadCsvData(oss.str().c_str(), world, soundPlayer);
 
 	// イベントの発火確認
@@ -117,7 +117,7 @@ void Story::loadCsvData(const char* fileName, World* world, SoundPlayer* soundPl
 		m_version = stoi(versionData[0]["num"]);
 		if (m_version > 0 && (bool)stoi(versionData[0]["update"])) {
 			ostringstream oss;
-			oss << "data/story/version" << m_version << ".csv";
+			oss << "data/story/template/version" << m_version << ".csv";
 			loadCsvData(oss.str().c_str(), world, soundPlayer);
 		}
 		m_loop = stoi(versionData[0]["loop"]);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り

#214 解決

# やったこと
Action側でslashCntやbulletCntを渡してやらないとアニメーションは動かないので修正。

また、しゃがみ射撃について、立ち射撃と同様にアニメーションを追加。

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
