### PR TITLE
キャラのアニメーション修正＋Y座標調整

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -37,7 +37,7 @@ Character* createCharacter(const char* characterName, int hp, int x, int y, int 
 	else if (name == "コハル") {
 		character = new Koharu(name.c_str(), hp, x, y, groupId);
 	}
-	else if (name == "棒人間" || name == "クロ人間") {
+	else if (name == "棒人間" || name == "クロ人間" || name == "ソッリーソ") {
 		character = new SlashOnly(name.c_str(), hp, x, y, groupId);
 	}
 	else if (name == "緑人間" || name == "フェーレース") {
@@ -230,6 +230,8 @@ Character::Character(int hp, int x, int y, int groupId) {
 	m_leftDirection = true;
 	m_freeze = false;
 	m_bossFlag = false;
+	
+	m_drawCnt = 0;
 
 	m_characterInfo = nullptr;
 	m_attackInfo = nullptr;
@@ -471,6 +473,18 @@ Character* Heart::createCopy() {
 	return res;
 }
 
+// 立ち画像をセット
+void Heart::switchStand(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchStand(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+
+// しゃがみ画像をセット
+void Heart::switchSquat(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchSquat(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+
 // 走り画像をセット
 void Heart::switchRun(int cnt) { 
 	if (m_graphHandle->getRunHandle() == nullptr) { return; }
@@ -508,9 +522,8 @@ void Heart::switchSlash(int cnt) {
 // 立ち射撃画像をセット
 void Heart::switchBullet(int cnt) {
 	if (m_graphHandle->getStandBulletHandle() == nullptr) { return; }
-	int flame = getBulletRapid() / m_graphHandle->getStandBulletHandle()->getGraphHandles()->getSize();
-	int index = (getBulletRapid() - cnt) / flame;
-	m_graphHandle->switchBullet(index);
+	m_drawCnt++;
+	m_graphHandle->switchBullet(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
 // 空中斬撃画像をセット
@@ -533,10 +546,18 @@ void Heart::switchAirBullet(int cnt) {
 
 // しゃがみ射撃画像をセット
 void Heart::switchSquatBullet(int cnt) {
-	if (m_graphHandle->getSquatBulletHandle() == nullptr) { return; }
-	int flame = getBulletRapid() / m_graphHandle->getSquatBulletHandle()->getGraphHandles()->getSize();
-	int index = (getBulletRapid() - cnt) / flame;
-	m_graphHandle->switchSquatBullet(index);
+	if (m_graphHandle->getSquatBulletHandle() == nullptr) {
+		switchBullet(cnt);
+		return;
+	}
+	m_drawCnt++;
+	m_graphHandle->switchSquatBullet(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+
+// やられ画像をセット
+void Heart::switchDead(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchDead(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
 // 射撃攻撃をする
@@ -639,6 +660,22 @@ Character* Siesta::createCopy() {
 	Character* res = new Siesta(m_characterInfo->name().c_str(), m_hp, m_x, m_y, m_groupId, m_attackInfo);
 	setParam(res);
 	return res;
+}
+
+// 立ち射撃画像をセット
+void Siesta::switchBullet(int cnt) {
+	if (m_graphHandle->getStandBulletHandle() == nullptr) { return; }
+	int flame = getBulletRapid() / m_graphHandle->getStandBulletHandle()->getGraphHandles()->getSize();
+	int index = (getBulletRapid() - cnt) / flame;
+	m_graphHandle->switchBullet(index);
+}
+
+// しゃがみ射撃画像をセット
+void Siesta::switchSquatBullet(int cnt) {
+	if (m_graphHandle->getSquatBulletHandle() == nullptr) { return; }
+	int flame = getBulletRapid() / m_graphHandle->getSquatBulletHandle()->getGraphHandles()->getSize();
+	int index = (getBulletRapid() - cnt) / flame;
+	m_graphHandle->switchSquatBullet(index);
 }
 
 // 射撃攻撃をする
@@ -779,6 +816,12 @@ Character* Valkyria::createCopy() {
 	return res;
 }
 
+// 立ち斬撃画像をセット
+void Valkyria::switchSlash(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchSlash(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+
 // ジャンプ前画像をセット
 void Valkyria::switchPreJump(int cnt) {
 	if (m_graphHandle->getPreJumpHandle() == nullptr) { return; }
@@ -861,6 +904,32 @@ Character* Troy::createCopy() {
 	return res;
 }
 
+// 走り画像をセット
+void Troy::switchRun(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchRun(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+// 走り射撃画像をセット
+void Troy::switchRunBullet(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchRunBullet(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+// 上昇画像をセット
+void Troy::switchJump(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchJump(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+// 降下画像をセット
+void Troy::switchDown(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchDown(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+// 空中射撃画像をセット
+void Troy::switchAirBullet(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchAirBullet(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+
 // 斬撃攻撃をする
 Object* Troy::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
 	return nullptr;
@@ -927,6 +996,12 @@ Character* BulletOnly::createCopy() {
 	return res;
 }
 
+// 上昇画像をセット
+void BulletOnly::switchJump(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchJump(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+
 /*
 * 普通の斬撃のみをするキャラ
 */
@@ -945,6 +1020,18 @@ Character* SlashOnly::createCopy() {
 	Character* res = new SlashOnly(m_characterInfo->name().c_str(), m_hp, m_x, m_y, m_groupId, m_attackInfo);
 	setParam(res);
 	return res;
+}
+
+// 上昇画像をセット
+void SlashOnly::switchJump(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchJump(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
+}
+
+// 降下画像をセット
+void SlashOnly::switchDown(int cnt) {
+	m_drawCnt++;
+	m_graphHandle->switchDown(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
 

--- a/Character.h
+++ b/Character.h
@@ -191,6 +191,8 @@ public:
 
 	const int SKILL_MAX = 100;
 
+	const int DEFAULT_ANIME_SPEED = 3;
+
 protected:
 	static int characterId;
 
@@ -231,6 +233,9 @@ protected:
 
 	// ボスならtrue
 	bool m_bossFlag;
+
+	// 描画用
+	int m_drawCnt;
 
 	// キャラの情報
 	CharacterInfo* m_characterInfo;
@@ -434,6 +439,12 @@ public:
 	void debug(int x, int y, int color) const;
 
 	// 画像変更関数のオーバーライド
+	// 立ち画像をセット
+	void switchStand(int cnt = 0);
+
+	// しゃがみ画像をセット
+	void switchSquat(int cnt = 0);
+
 	// 走り画像をセット
 	void switchRun(int cnt = 0);
 
@@ -458,6 +469,9 @@ public:
 	// しゃがみ射撃画像をセット
 	void switchSquatBullet(int cnt = 0);
 
+	// やられ画像をセット
+	void switchDead(int cnt = 0);
+
 	// 射撃攻撃をする
 	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
@@ -479,6 +493,12 @@ public:
 	Siesta(const char* name, int hp, int x, int y, int groupId, AttackInfo* attackInfo);
 
 	Character* createCopy();
+
+	// 立ち射撃画像をセット
+	void switchBullet(int cnt = 0);
+
+	// しゃがみ射撃画像をセット
+	void switchSquatBullet(int cnt = 0);
 
 	// 射撃攻撃をする
 	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
@@ -522,6 +542,8 @@ public:
 
 	Character* createCopy();
 
+	// 立ち斬撃画像をセット
+	void switchSlash(int cnt = 0);
 	// ジャンプ前画像をセット
 	void switchPreJump(int cnt = 0);
 
@@ -545,6 +567,17 @@ public:
 	Troy(const char* name, int hp, int x, int y, int groupId, AttackInfo* attackInfo);
 
 	Character* createCopy();
+
+	// 走り画像をセット
+	void switchRun(int cnt = 0);
+	// 走り射撃画像をセット
+	void switchRunBullet(int cnt = 0);
+	// 上昇画像をセット
+	void switchJump(int cnt = 0);
+	// 降下画像をセット
+	void switchDown(int cnt = 0);
+	// 空中射撃画像をセット
+	void switchAirBullet(int cnt = 0);
 
 	// 斬撃攻撃をする
 	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
@@ -583,6 +616,9 @@ public:
 
 	Character* createCopy();
 
+	// 上昇画像をセット
+	void switchJump(int cnt = 0);
+
 	// 斬撃攻撃をする(キャラごとに違う)
 	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
 };
@@ -600,6 +636,11 @@ public:
 	SlashOnly(const char* name, int hp, int x, int y, int groupId, AttackInfo* attackInfo);
 
 	Character* createCopy();
+
+	// 上昇画像をセット
+	void switchJump(int cnt = 0);
+	// 降下画像をセット
+	void switchDown(int cnt = 0);
 
 	// 射撃攻撃をする
 	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) { return nullptr; }

--- a/CharacterDrawer.cpp
+++ b/CharacterDrawer.cpp
@@ -84,15 +84,15 @@ void CharacterDrawer::drawCharacter(const Camera* const camera, int enemyNoticeH
 		return;
 	}
 
-	// 描画 ダメージ状態なら点滅
+	// 描画 ダメージ状態なら点滅 y+1して宙に浮いて見えないようにする
 	if (!m_characterAction->ableDamage() && ++m_cnt / 2 % 2 == 1) {
 		int dark = max(0, bright - 100);
 		SetDrawBright(dark, dark, dark);
-		graphHandle->draw(x, y, ex);
+		graphHandle->draw(x, y + 1, ex);
 		SetDrawBright(bright, bright, bright);
 	}
 	else {
-		graphHandle->draw(x, y, ex);
+		graphHandle->draw(x, y + 1, ex);
 	}
 
 	if (character->getDispHpCnt() > 0 && character->getName() != "ハート" && !character->getBossFlag()) {


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#215 の続き

加えて、キャラの描画時に計算誤差が生じると宙に浮いて見えることがあるのを修正。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
