### PR TITLE
bulletAttack, slashAttackで同時に複数の攻撃を発生させられるよう変更

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -475,13 +475,13 @@ Character* Heart::createCopy() {
 
 // —§‚¿‰æ‘œ‚ğƒZƒbƒg
 void Heart::switchStand(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchStand(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
 // ‚µ‚á‚ª‚İ‰æ‘œ‚ğƒZƒbƒg
 void Heart::switchSquat(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchSquat(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
@@ -522,7 +522,7 @@ void Heart::switchSlash(int cnt) {
 // —§‚¿ËŒ‚‰æ‘œ‚ğƒZƒbƒg
 void Heart::switchBullet(int cnt) {
 	if (m_graphHandle->getStandBulletHandle() == nullptr) { return; }
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchBullet(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
@@ -550,18 +550,18 @@ void Heart::switchSquatBullet(int cnt) {
 		switchBullet(cnt);
 		return;
 	}
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchSquatBullet(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
 // ‚â‚ç‚ê‰æ‘œ‚ğƒZƒbƒg
 void Heart::switchDead(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchDead(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
 // ËŒ‚UŒ‚‚ğ‚·‚é
-Object* Heart::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+vector<Object*>* Heart::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
 	if (cnt != getBulletRapid()) { return nullptr; }
 	// ’e‚Ìì¬
 	BulletObject* attackObject;
@@ -581,11 +581,11 @@ Object* Heart::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
 			adjustPanSound(getCenterX(),
 				soundPlayer->getCameraX()));
 	}
-	return attackObject;
+	return new std::vector<Object*>{ attackObject };
 }
 
 // aŒ‚UŒ‚‚ğ‚·‚é
-Object* Heart::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
+vector<Object*>* Heart::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
 	// UŒ‚”ÍˆÍ‚ğŒˆ’è
 	int centerX = getCenterX();
 	int height = m_attackInfo->slashLenY() / 2;
@@ -638,7 +638,10 @@ Object* Heart::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer*
 		// ƒ`[ƒ€ƒLƒ‹–h~
 		attackObject->setGroupId(m_groupId);
 	}
-	return attackObject;
+	else {
+		return nullptr;
+	}
+	return new std::vector<Object*>{ attackObject };
 }
 
 
@@ -679,7 +682,7 @@ void Siesta::switchSquatBullet(int cnt) {
 }
 
 // ËŒ‚UŒ‚‚ğ‚·‚é
-Object* Siesta::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+vector<Object*>* Siesta::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
 	if (cnt != getBulletRapid() / 2) { return nullptr; }
 	ParabolaBullet *attackObject = new ParabolaBullet(getCenterX(), getCenterY(), m_graphHandle->getBulletHandle()->getGraphHandles()->getGraphHandle(), gx, gy, m_attackInfo);
 	// ©–Å–h~
@@ -692,11 +695,11 @@ Object* Siesta::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) 
 			adjustPanSound(getCenterX(),
 				soundPlayer->getCameraX()));
 	}
-	return attackObject;
+	return new std::vector<Object*>{ attackObject };
 }
 
 // aŒ‚UŒ‚‚ğ‚·‚é
-Object* Siesta::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
+vector<Object*>* Siesta::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
 	// UŒ‚”ÍˆÍ‚ğŒˆ’è
 	int centerX = getCenterX();
 	int height = getHeight();
@@ -747,7 +750,10 @@ Object* Siesta::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer
 		// ƒ`[ƒ€ƒLƒ‹–h~
 		attackObject->setGroupId(m_groupId);
 	}
-	return attackObject;
+	else {
+		return nullptr;
+	}
+	return new std::vector<Object*>{ attackObject };
 }
 
 
@@ -772,7 +778,7 @@ Character* Hierarchy::createCopy() {
 }
 
 // ËŒ‚UŒ‚‚ğ‚·‚é
-Object* Hierarchy::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+vector<Object*>* Hierarchy::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
 	if (cnt != getBulletRapid()) { return nullptr; }
 	//gx = GetRand(600) - 300 + getCenterX();
 	//gy = getCenterY() - GetRand(300);
@@ -787,11 +793,11 @@ Object* Hierarchy::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlaye
 			adjustPanSound(getCenterX(),
 				soundPlayer->getCameraX()));
 	}
-	return attackObject;
+	return new std::vector<Object*>{ attackObject };
 }
 
 // aŒ‚UŒ‚‚ğ‚·‚é
-Object* Hierarchy::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
+vector<Object*>* Hierarchy::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
 	return nullptr;
 }
 
@@ -818,7 +824,7 @@ Character* Valkyria::createCopy() {
 
 // —§‚¿aŒ‚‰æ‘œ‚ğƒZƒbƒg
 void Valkyria::switchSlash(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchSlash(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
@@ -833,7 +839,7 @@ void Valkyria::switchPreJump(int cnt) {
 }
 
 // aŒ‚UŒ‚‚ğ‚·‚é
-Object* Valkyria::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
+vector<Object*>* Valkyria::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
 	// UŒ‚”ÍˆÍ‚ğŒˆ’è
 	int attackWide, attackHeight;
 	GetGraphSize(m_graphHandle->getStandSlashHandle()->getGraphHandles()->getHandle(0), &attackWide, &attackHeight);
@@ -880,7 +886,10 @@ Object* Valkyria::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlay
 		// ƒ`[ƒ€ƒLƒ‹–h~
 		attackObject->setGroupId(m_groupId);
 	}
-	return attackObject;
+	else {
+		return nullptr;
+	}
+	return new std::vector<Object*>{ attackObject };
 }
 
 
@@ -906,32 +915,32 @@ Character* Troy::createCopy() {
 
 // ‘–‚è‰æ‘œ‚ğƒZƒbƒg
 void Troy::switchRun(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchRun(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 // ‘–‚èËŒ‚‰æ‘œ‚ğƒZƒbƒg
 void Troy::switchRunBullet(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchRunBullet(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 // ã¸‰æ‘œ‚ğƒZƒbƒg
 void Troy::switchJump(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchJump(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 // ~‰º‰æ‘œ‚ğƒZƒbƒg
 void Troy::switchDown(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchDown(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 // ‹ó’†ËŒ‚‰æ‘œ‚ğƒZƒbƒg
 void Troy::switchAirBullet(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchAirBullet(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
 // aŒ‚UŒ‚‚ğ‚·‚é
-Object* Troy::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
+vector<Object*>* Troy::slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) {
 	return nullptr;
 }
 
@@ -957,7 +966,7 @@ Character* Koharu::createCopy() {
 }
 
 // ËŒ‚UŒ‚‚ğ‚·‚é
-Object* Koharu::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+vector<Object*>* Koharu::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
 	if (cnt != getBulletRapid()) { return nullptr; }
 	// ƒoƒY[ƒJ‚ÌeŒû‚©‚ço‚é‚æ‚¤‚ÉŒ©‚¹‚é
 	gy = getY() + getHeight() - 160;
@@ -972,7 +981,7 @@ Object* Koharu::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) 
 			adjustPanSound(getCenterX(),
 				soundPlayer->getCameraX()));
 	}
-	return attackObject;
+	return new std::vector<Object*>{ attackObject };
 }
 
 
@@ -998,7 +1007,7 @@ Character* BulletOnly::createCopy() {
 
 // ã¸‰æ‘œ‚ğƒZƒbƒg
 void BulletOnly::switchJump(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchJump(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
@@ -1024,13 +1033,13 @@ Character* SlashOnly::createCopy() {
 
 // ã¸‰æ‘œ‚ğƒZƒbƒg
 void SlashOnly::switchJump(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchJump(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
 // ~‰º‰æ‘œ‚ğƒZƒbƒg
 void SlashOnly::switchDown(int cnt) {
-	m_drawCnt++;
+	countDrawCnt();
 	m_graphHandle->switchDown(m_drawCnt / DEFAULT_ANIME_SPEED % 2);
 }
 
@@ -1056,7 +1065,7 @@ Character* ParabolaOnly::createCopy() {
 }
 
 // ËŒ‚UŒ‚‚ğ‚·‚é
-Object* ParabolaOnly::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+vector<Object*>* ParabolaOnly::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
 	if (cnt != getBulletRapid()) { return nullptr; }
 	ParabolaBullet* attackObject = new ParabolaBullet(getCenterX(), getCenterY(), m_bulletColor, gx, gy, m_attackInfo);
 	// ©–Å–h~
@@ -1069,7 +1078,7 @@ Object* ParabolaOnly::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPl
 			adjustPanSound(getCenterX(),
 				soundPlayer->getCameraX()));
 	}
-	return attackObject;
+	return new std::vector<Object*>{ attackObject };
 }
 
 
@@ -1104,7 +1113,7 @@ void Sun::switchInit(int cnt) {
 	m_graphHandle->switchInit(index);
 }
 
-Object* Sun::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
+vector<Object*>* Sun::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
 	if (cnt != getBulletRapid()) { return nullptr; }
 	int x = getCenterX() + GetRand(400) - 200;
 	int y = getCenterY() + GetRand(400) - 200;
@@ -1119,5 +1128,5 @@ Object* Sun::bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) {
 			adjustPanSound(getCenterX(),
 				soundPlayer->getCameraX()));
 	}
-	return attackObject;
+	return new std::vector<Object*>{ attackObject };
 }

--- a/Character.h
+++ b/Character.h
@@ -4,6 +4,7 @@
 
 #include<string>
 #include<map>
+#include<vector>
 
 class Object;
 class GraphHandle;
@@ -188,6 +189,9 @@ private:
 */
 class Character {
 public:
+
+	// ƒLƒƒƒ‰‚ğ—h‚ç‚µ‚Ä•`‰æ‚·‚é‚È‚çtrue
+	const bool SHAKING_FLAG = false;
 
 	const int SKILL_MAX = 100;
 
@@ -388,10 +392,10 @@ public:
 	void moveDown(int d);
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é(ƒLƒƒƒ‰‚²‚Æ‚Éˆá‚¤)
-	virtual Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) { return nullptr; }
+	virtual std::vector<Object*>* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) { return nullptr; }
 
 	// aŒ‚UŒ‚‚ğ‚·‚é(ƒLƒƒƒ‰‚²‚Æ‚Éˆá‚¤) ¶‚ğŒü‚¢‚Ä‚¢‚é‚©A¡‰½ƒJƒEƒ“ƒg‚©
-	virtual Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
+	virtual std::vector<Object*>* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
 
 	// ËŒ‚UŒ‚‚ğ‚Á‚Ä‚¢‚é‚©
 	bool haveBulletAttack() const { return m_attackInfo->bulletDamage() != 0; }
@@ -403,6 +407,9 @@ public:
 
 	// HP‚ª0‚Å‚â‚ç‚ê‰æ‘œ‚ª‚È‚­A‰æ–Ê‚©‚çÁ‚¦‚é‚×‚«‚©
 	inline bool noDispForDead() const { return m_hp == 0 && !haveDeadGraph(); }
+
+protected:
+	void countDrawCnt(){ if (SHAKING_FLAG) { m_drawCnt++; } }
 };
 
 
@@ -473,10 +480,10 @@ public:
 	void switchDead(int cnt = 0);
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
+	std::vector<Object*>* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
-	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
+	std::vector<Object*>* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
 
 };
 
@@ -501,10 +508,10 @@ public:
 	void switchSquatBullet(int cnt = 0);
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
+	std::vector<Object*>* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
-	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
+	std::vector<Object*>* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
 };
 
 
@@ -522,10 +529,10 @@ public:
 	Character* createCopy();
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
+	std::vector<Object*>* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
-	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
+	std::vector<Object*>* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
 };
 
 
@@ -548,10 +555,10 @@ public:
 	void switchPreJump(int cnt = 0);
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer){ return nullptr; }
+	std::vector<Object*>* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer){ return nullptr; }
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
-	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
+	std::vector<Object*>* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
 };
 
 
@@ -580,7 +587,7 @@ public:
 	void switchAirBullet(int cnt = 0);
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
-	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
+	std::vector<Object*>* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer);
 };
 
 
@@ -598,7 +605,7 @@ public:
 	Character* createCopy();
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
+	std::vector<Object*>* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 };
 
@@ -620,7 +627,7 @@ public:
 	void switchJump(int cnt = 0);
 
 	// aŒ‚UŒ‚‚ğ‚·‚é(ƒLƒƒƒ‰‚²‚Æ‚Éˆá‚¤)
-	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
+	std::vector<Object*>* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
 };
 
 
@@ -643,7 +650,7 @@ public:
 	void switchDown(int cnt = 0);
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) { return nullptr; }
+	std::vector<Object*>* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer) { return nullptr; }
 };
 
 
@@ -661,7 +668,7 @@ public:
 	Character* createCopy();
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
+	std::vector<Object*>* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 };
 
 
@@ -682,12 +689,33 @@ public:
 	void switchInit(int cnt);
 
 	// ËŒ‚UŒ‚‚ğ‚·‚é
-	Object* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
+	std::vector<Object*>* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
 
 	// aŒ‚UŒ‚‚ğ‚·‚é
-	Object* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
+	std::vector<Object*>* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
 
 };
+
+
+/*
+* Boss2: ƒA[ƒJƒCƒu
+*/
+//class Archive :
+//	public Heart
+//{
+//public:
+//	// ƒRƒ“ƒXƒgƒ‰ƒNƒ^
+//	Archive(const char* name, int hp, int x, int y, int groupId);
+//	Archive(const char* name, int hp, int x, int y, int groupId, AttackInfo* attackInfo);
+//
+//	Character* createCopy();
+//
+//	// ËŒ‚UŒ‚‚ğ‚·‚é
+//	std::vector<Object*>* bulletAttack(int cnt, int gx, int gy, SoundPlayer* soundPlayer);
+//
+//	// aŒ‚UŒ‚‚ğ‚·‚é
+//	std::vector<Object*>* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
+//};
 
 
 #endif

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -788,7 +788,7 @@ void StickAction::jump(int cnt) {
 }
 
 // éÀåÇçUåÇ
-Object* StickAction::bulletAttack(int gx, int gy) {
+vector<Object*>* StickAction::bulletAttack(int gx, int gy) {
 	if (damageFlag() && m_boostCnt == 0) {
 		finishBullet();
 		return nullptr;
@@ -808,7 +808,7 @@ Object* StickAction::bulletAttack(int gx, int gy) {
 }
 
 // éaåÇçUåÇ
-Object* StickAction::slashAttack(int gx, int gy) {
+vector<Object*>* StickAction::slashAttack(int gx, int gy) {
 	if (damageFlag() && m_boostCnt == 0) {
 		if (m_slashCnt > 0) { finishSlash(); }
 		return nullptr;
@@ -1134,7 +1134,7 @@ void FlightAction::setBoost(bool leftDirection) {
 }
 
 // éÀåÇçUåÇ
-Object* FlightAction::bulletAttack(int gx, int gy) {
+vector<Object*>* FlightAction::bulletAttack(int gx, int gy) {
 	if (damageFlag() && m_boostCnt == 0) {
 		finishBullet();
 		return nullptr;
@@ -1154,7 +1154,7 @@ Object* FlightAction::bulletAttack(int gx, int gy) {
 }
 
 // éaåÇçUåÇ
-Object* FlightAction::slashAttack(int gx, int gy) {
+vector<Object*>* FlightAction::slashAttack(int gx, int gy) {
 	if (damageFlag() && m_boostCnt == 0) {
 		if (m_slashCnt > 0) { finishSlash(); }
 		return nullptr;
@@ -1195,7 +1195,7 @@ CharacterAction* KoharuAction::createCopy(vector<Character*> characters) {
 }
 
 // éÀåÇçUåÇ
-Object* KoharuAction::bulletAttack(int gx, int gy) {
+vector<Object*>* KoharuAction::bulletAttack(int gx, int gy) {
 	if (damageFlag() && m_boostCnt == 0) {
 		finishBullet();
 		return nullptr;

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -226,10 +226,10 @@ public:
 	virtual void jump(int rate) = 0;
 
 	// 射撃攻撃
-	virtual Object* bulletAttack(int gx, int gy) = 0;
+	virtual std::vector<Object*>* bulletAttack(int gx, int gy) = 0;
 
 	// 斬撃攻撃
-	virtual Object* slashAttack(int gx, int gy) = 0;
+	virtual std::vector<Object*>* slashAttack(int gx, int gy) = 0;
 
 	// ダメージ 必要に応じてオーバーライド
 	virtual void damage(int vx, int vy, int damageValue);
@@ -314,10 +314,10 @@ public:
 	void jump(int cnt);
 
 	// 射撃攻撃
-	Object* bulletAttack(int gx, int gy);
+	std::vector<Object*>* bulletAttack(int gx, int gy);
 
 	// 斬撃攻撃
-	Object* slashAttack(int gx, int gy);
+	std::vector<Object*>* slashAttack(int gx, int gy);
 };
 
 
@@ -398,10 +398,10 @@ public:
 	void setBoost(bool leftDirection);
 
 	// 射撃攻撃
-	Object* bulletAttack(int gx, int gy);
+	std::vector<Object*>* bulletAttack(int gx, int gy);
 
 	// 斬撃攻撃
-	Object* slashAttack(int gx, int gy);
+	std::vector<Object*>* slashAttack(int gx, int gy);
 
 };
 
@@ -429,7 +429,7 @@ public:
 	void debug(int x, int y, int color) const;
 
 	// 射撃攻撃
-	Object* bulletAttack(int gx, int gy);
+	std::vector<Object*>* bulletAttack(int gx, int gy);
 
 	void startBullet();
 
@@ -475,10 +475,10 @@ public:
 	void jump(int rate) { }
 
 	// 射撃攻撃
-	Object* bulletAttack(int gx, int gy) { return nullptr; }
+	std::vector<Object*>* bulletAttack(int gx, int gy) { return nullptr; }
 
 	// 斬撃攻撃
-	Object* slashAttack(int gx, int gy) { return nullptr; }
+	std::vector<Object*>* slashAttack(int gx, int gy) { return nullptr; }
 
 	// ダメージ 必要に応じてオーバーライド
 	void damage(int vx, int vy, int damageValue) { }

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -376,7 +376,7 @@ void NormalController::control() {
 	m_characterAction->setSquat(squat);
 }
 
-Object* NormalController::bulletAttack() {
+vector<Object*>* NormalController::bulletAttack() {
 
 	if (m_characterAction->getCharacter()->getHp() == 0) {
 		return nullptr;
@@ -419,7 +419,7 @@ Object* NormalController::bulletAttack() {
 	return nullptr;
 }
 
-Object* NormalController::slashAttack() {
+vector<Object*>* NormalController::slashAttack() {
 
 	if (m_characterAction->getCharacter()->getHp() == 0) {
 		return nullptr;

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -121,10 +121,10 @@ public:
 	virtual void control() = 0;
 
 	// ËŒ‚UŒ‚
-	virtual Object* bulletAttack() = 0;
+	virtual std::vector<Object*>* bulletAttack() = 0;
 
 	// aŒ‚UŒ‚
-	virtual Object* slashAttack() = 0;
+	virtual std::vector<Object*>* slashAttack() = 0;
 
 	// ƒ_ƒ[ƒW
 	virtual void damage(int vx, int vy, int damageValue) = 0;
@@ -166,10 +166,10 @@ public:
 	void control();
 
 	// ËŒ‚UŒ‚
-	Object* bulletAttack();
+	std::vector<Object*>* bulletAttack();
 
 	// aŒ‚UŒ‚
-	Object* slashAttack();
+	std::vector<Object*>* slashAttack();
 
 	// ƒ_ƒ\ƒW
 	void damage(int vx, int vy, int damageValue);

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -44,7 +44,7 @@ void debugObjects(int x, int y, int color, std::vector<Object*> objects) {
 void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "areaNum=%d, CharacterSum=%d, ControllerSum=%d, cameraEx=%f", m_areaNum, m_characters.size(), m_characterControllers.size(), m_camera->getEx());
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "itemSum=%d, animeSum=%d", m_itemVector.size(), m_animations.size());
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "itemSum=%d, animeSum=%d, attackObjects=%d", m_itemVector.size(), m_animations.size(), m_attackObjects.size());
 	if (m_itemVector.size() > 0) {
 		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "itemY=%d", m_itemVector[0]->getY());
 	}

--- a/World.cpp
+++ b/World.cpp
@@ -1025,12 +1025,12 @@ void World::controlCharacter() {
 		}
 
 		// ŽËŒ‚UŒ‚
-		Object* bulletAttack = controller->bulletAttack();
-		if (bulletAttack != nullptr) { m_attackObjects.push_back(bulletAttack); }
+		vector<Object*>* bulletAttack = controller->bulletAttack();
+		if (bulletAttack != nullptr) { m_attackObjects.insert(m_attackObjects.end(), bulletAttack->begin(), bulletAttack->end()); }
 
 		// ŽaŒ‚UŒ‚
-		Object* slashAttack = controller->slashAttack();
-		if (slashAttack != nullptr) { m_attackObjects.push_back(slashAttack); }
+		vector<Object*>* slashAttack = controller->slashAttack();
+		if (slashAttack != nullptr) { m_attackObjects.insert(m_attackObjects.end(), slashAttack->begin(), slashAttack->end()); }
 	}
 
 	// ƒLƒƒƒ‰ŠÔ‚Ì“–‚½‚è”»’è


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
今後の敵実装のため。例えばアーカイブは斬撃と射撃を同時に行う。

前段階として、本PRでbulletAttack(), slashAttack()が複数のAttackObjectを返すように仕様変更する。具体的には、`Object*`ではなく、`vector<Object*>*`を戻り値の型とする。vectorをポインタにしたのは、計算量削減のため。nullを返す時に空のvectorを作成して返すよりnullを返す方が効率が良いと思われる。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [x] デバッグモードで確認

# 懸念点
記入欄
