### PR TITLE
ステップとスライディングを追加&FlightActionのバグ修正

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -205,10 +205,11 @@ void AttackInfo::setParam(map<string, string>& data) {
 */
 int Character::characterId;
 
+
 Character::Character() :
 	Character(100, 0, 0, 0)
 {
-
+	
 }
 
 Character::Character(int hp, int x, int y, int groupId) {
@@ -376,6 +377,25 @@ void Character::moveDown(int d) {
 	m_y += d;
 }
 
+vector<Object*>* Character::slidingAttack(int sound, SoundPlayer* soundPlayer) {
+	int x1, y1, x2, y2;
+	getAtariArea(&x1, &y1, &x2, &y2);
+	SlashObject* attackObject = new SlashObject(x1, y1, x2, y2, nullptr, 1, m_slidingInfo);
+	// 効果音
+	if (sound && soundPlayer != nullptr) {
+		soundPlayer->pushSoundQueue(m_slidingInfo->slashStartSoundHandle(),
+			adjustPanSound(getCenterX(),
+				soundPlayer->getCameraX()));
+	}
+	return new std::vector<Object*>{ attackObject };
+}
+
+bool Character::haveStepGraph() const {
+	return !(m_graphHandle->getStepHandle() == nullptr);
+}
+bool Character::haveSlidingGraph() const {
+	return !(m_graphHandle->getSlidingHandle() == nullptr);
+}
 bool Character::haveDeadGraph() const {
 	return !(m_graphHandle->getDeadHandle() == nullptr);
 }
@@ -406,6 +426,10 @@ void Character::switchPreJump(int cnt) { m_graphHandle->switchPreJump(); }
 void Character::switchDamage(int cnt) { m_graphHandle->switchDamage(); }
 // ブースト画像をセット
 void Character::switchBoost(int cnt) { m_graphHandle->switchBoost(); }
+// ステップ画像をセット
+void Character::switchStep(int cnt) { m_graphHandle->switchStep(); }
+// スライディング画像をセット
+void Character::switchSliding(int cnt) { m_graphHandle->switchSliding(); }
 // 空中射撃画像をセット
 void Character::switchAirBullet(int cnt) { m_graphHandle->switchAirBullet(); }
 // 空中斬撃画像をセット
@@ -439,6 +463,8 @@ Heart::Heart(const char* name, int hp, int x, int y, int groupId) :
 
 	m_bulletColor = WHITE;
 
+	if (haveSlidingGraph()) { m_slidingInfo = new AttackInfo("スライディング", m_characterInfo->handleEx()); }
+
 	// とりあえず立ち画像でスタート
 	switchStand();
 	m_y -= getHeight();
@@ -460,11 +486,13 @@ Heart::Heart(const char* name, int hp, int x, int y, int groupId, AttackInfo* at
 
 	m_bulletColor = WHITE;
 
+	if(haveSlidingGraph()){ m_slidingInfo = new AttackInfo("スライディング", m_characterInfo->handleEx()); }
+
 }
 
 // デストラクタ
 Heart::~Heart() {
-
+	delete m_slidingInfo;
 }
 
 Character* Heart::createCopy() {

--- a/Character.h
+++ b/Character.h
@@ -200,6 +200,8 @@ public:
 protected:
 	static int characterId;
 
+	AttackInfo* m_slidingInfo;
+
 	bool m_duplicationFlag;
 
 	// ID
@@ -371,6 +373,10 @@ public:
 	virtual void switchDamage(int cnt = 0);
 	// ブースト画像をセット
 	virtual void switchBoost(int cnt = 0);
+	// ステップ画像をセット
+	virtual void switchStep(int cnt = 0);
+	// スライディング画像をセット
+	virtual void switchSliding(int cnt = 0);
 	// 空中射撃画像をセット
 	virtual void switchAirBullet(int cnt = 0);
 	// 空中斬撃画像をセット
@@ -397,12 +403,17 @@ public:
 	// 斬撃攻撃をする(キャラごとに違う) 左を向いているか、今何カウントか
 	virtual std::vector<Object*>* slashAttack(bool leftDirection, int cnt, bool grand, SoundPlayer* soundPlayer) { return nullptr; }
 
+	// スライディング攻撃
+	std::vector<Object*>* slidingAttack(int sound, SoundPlayer* soundPlayer);
+
 	// 射撃攻撃を持っているか
 	bool haveBulletAttack() const { return m_attackInfo->bulletDamage() != 0; }
 	// 斬撃攻撃を持っているか
 	bool haveSlashAttack() const { return m_attackInfo->slashDamage() != 0; }
 
-	// やられ画像があるか
+	// 特定の画像があるか
+	bool haveStepGraph() const;
+	bool haveSlidingGraph() const;
 	bool haveDeadGraph() const;
 
 	// HPが0でやられ画像がなく、画面から消えるべきか

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -93,6 +93,10 @@ CharacterAction::CharacterAction(Character* character, SoundPlayer* soundPlayer_
 	m_landCnt = 0;
 	m_boostCnt = 0;
 	m_boostDone = 0;
+	m_stepCnt = 0;
+	m_stepDone = 0;
+	m_slidingCnt = 0;
+	m_slidingDone = 0;
 	m_damageCnt = 0;
 	m_heavy = false;
 }
@@ -130,6 +134,10 @@ void CharacterAction::setParam(CharacterAction* action) {
 	action->setLandCnt(m_landCnt);
 	action->setBoostCnt(m_boostCnt);
 	action->setBoostDone(m_boostDone);
+	action->setStepCnt(m_stepCnt);
+	action->setStepDone(m_stepDone);
+	action->setSlidingCnt(m_slidingCnt);
+	action->setSlidingDone(m_slidingDone);
 	action->setDamageCnt(m_damageCnt);
 	action->setHeavy(m_heavy);
 }
@@ -182,7 +190,63 @@ void CharacterAction::finishBoost() {
 	else if (m_boostDone == 2) {
 		m_vx += BOOST_SPEED;
 	}
-	m_boostDone = false;
+	m_boostDone = 0;
+}
+
+void CharacterAction::setStep(bool leftDirection) {
+	if (!m_character_p->haveSlidingGraph()) { return; }
+	if (m_state != CHARACTER_STATE::SQUAT || m_stepDone != 0 || m_slidingCnt > 0) { return; }
+	m_stepCnt = STEP_TIME;
+	if (leftDirection && !m_leftLock) {
+		m_vx -= STEP_SPEED;
+		m_stepDone = 2;
+		m_character_p->setLeftDirection(false);
+	}
+	else if(!m_rightLock) {
+		m_vx += STEP_SPEED;
+		m_stepDone = 1;
+		m_character_p->setLeftDirection(true);
+	}
+	finishBullet();
+}
+void CharacterAction::finishStep() {
+	if (m_stepCnt > STEP_STOP_TIME) {
+		if (m_stepDone == 1) {
+			m_vx -= STEP_SPEED;
+		}
+		else if (m_stepDone == 2) {
+			m_vx += STEP_SPEED;
+		}
+	}
+	m_stepCnt = 0;
+	m_stepDone = 0;
+}
+
+void CharacterAction::setSliding(bool leftDirection) {
+	if (!m_character_p->haveStepGraph()) { return; }
+	if (m_state != CHARACTER_STATE::SQUAT || m_slidingDone != 0 || m_stepCnt > 0) { return; }
+	m_slidingCnt = SLIDING_SPEED;
+	if (leftDirection) {
+		m_vx -= SLIDING_SPEED;
+		m_slidingDone = 2;
+		m_character_p->setLeftDirection(true);
+	}
+	else {
+		m_vx += SLIDING_SPEED;
+		m_slidingDone = 1;
+		m_character_p->setLeftDirection(false);
+	}
+	finishBullet();
+}
+void CharacterAction::finishSliding() {
+	m_slidingCnt = 0;
+	if (m_slidingDone == 1) {
+		m_vx -= m_slidingCnt;
+	}
+	else if (m_slidingDone == 2) {
+		m_vx += m_slidingCnt;
+	}
+	m_slidingDone = 0;
 }
 
 // キャラクターのセッタ
@@ -262,6 +326,28 @@ void CharacterAction::otherAction() {
 	// アニメーション用のカウント
 	if (m_landCnt > 0) { m_landCnt--; }
 	if (m_boostCnt > 0) { m_boostCnt--; }
+	if (m_stepCnt > 0) { 
+		m_stepCnt--;
+		if (m_stepCnt == STEP_STOP_TIME) {
+			if (m_stepDone == 1) {
+				m_vx -= STEP_SPEED;
+			}
+			else if (m_stepDone == 2) {
+				m_vx += STEP_SPEED;
+			}
+		}
+		if (m_stepCnt == 0) {
+			finishStep();
+		}
+	}
+	if (m_slidingCnt > 0) {
+		m_slidingCnt--;
+		if (m_slidingDone == 1) { m_vx--; }
+		if (m_slidingDone == 2) { m_vx++; }
+		if (m_slidingCnt == 0) {
+			finishSliding();
+		}
+	}
 }
 
 void CharacterAction::moveAction() {
@@ -338,6 +424,7 @@ void CharacterAction::damage(int vx, int vy, int damageValue) {
 	// HP減少
 	m_character_p->damageHp(damageValue);
 	m_boostCnt = 0;
+	finishSliding();
 }
 
 void CharacterAction::startBullet() {
@@ -357,11 +444,11 @@ void CharacterAction::finishSlash() {
 }
 
 bool CharacterAction::ableDamage() const {
-	return !(m_state == CHARACTER_STATE::DAMAGE || m_damageCnt > 0 || m_boostCnt > max(0, BOOST_TIME - 10));
+	return !(m_state == CHARACTER_STATE::DAMAGE || m_damageCnt > 0 || m_boostCnt > max(0, BOOST_TIME - 10) || m_stepCnt > STEP_STOP_TIME);
 }
 
 bool CharacterAction::ableAttack() const {
-	return !(m_bulletCnt > 0 || m_slashCnt > 0);
+	return !(m_bulletCnt > 0 || m_slashCnt > 0 || m_slidingCnt > 0 || m_stepCnt > STEP_STOP_TIME);
 }
 
 bool CharacterAction::ableWalk() const {
@@ -401,7 +488,7 @@ void CharacterAction::setGrand(bool grand) {
 
 void CharacterAction::setSquat(bool squat) {
 	if (m_state != CHARACTER_STATE::DAMAGE && m_state != CHARACTER_STATE::PREJUMP && m_state != CHARACTER_STATE::INIT) {
-		if (squat && m_grand && m_slashCnt == 0) {
+		if ((squat && m_grand && m_slashCnt == 0) || (m_stepCnt > 0 || m_slidingCnt > 0)) {
 			// しゃがめる状態なのでしゃがむ
 			m_state = CHARACTER_STATE::SQUAT;
 		}
@@ -439,6 +526,14 @@ void CharacterAction::stopMoveLeft() {
 	if (m_boostDone == 2) {
 		finishBoost();
 	}
+	if (m_leftLock) {
+		if (m_stepDone == 2) {
+			finishStep();
+		}
+		if (m_slidingDone == 2) {
+			finishSliding();
+		}
+	}
 }
 void CharacterAction::stopMoveRight() {
 	// 右へ歩くのをやめる
@@ -448,6 +543,14 @@ void CharacterAction::stopMoveRight() {
 	}
 	if (m_boostDone == 1) {
 		finishBoost();
+	}
+	if (m_rightLock) {
+		if (m_stepDone == 1) {
+			finishStep();
+		}
+		if (m_slidingDone == 1) {
+			finishSliding();
+		}
 	}
 }
 void CharacterAction::stopMoveUp() {
@@ -600,6 +703,12 @@ void StickAction::switchHandle() {
 			if (m_bulletCnt > 0) {
 				m_character_p->switchSquatBullet(m_bulletCnt);
 			}
+			else if (m_stepCnt > 0) {
+				m_character_p->switchStep(m_stepCnt);
+			}
+			else if (m_slidingCnt > 0) {
+				m_character_p->switchSliding(m_slidingCnt);
+			}
 			else {
 				m_character_p->switchSquat();
 			}
@@ -608,7 +717,7 @@ void StickAction::switchHandle() {
 			m_character_p->switchPreJump(m_preJumpCnt);
 			break;
 		case CHARACTER_STATE::DAMAGE:
-			if (m_boostCnt > 0) {
+			if (m_boostCnt > 0) { 
 				if (m_slashCnt > 0) {
 					m_character_p->switchSlash(m_slashCnt);
 				}
@@ -723,10 +832,10 @@ void StickAction::walk(bool right, bool left) {
 void StickAction::move(bool right, bool left, bool up, bool down) {
 	if ((m_state == CHARACTER_STATE::STAND || m_state == CHARACTER_STATE::SQUAT) && m_grand && m_slashCnt == 0 && m_bulletCnt == 0) {
 		// 移動方向へ向く
-		if(left && !right){
+		if(left && !right && m_stepCnt == 0 && m_slidingCnt == 0){
 			m_character_p->setLeftDirection(true);
 		}
-		if (right && !left) {
+		if (right && !left && m_stepCnt == 0 && m_slidingCnt == 0) {
 			m_character_p->setLeftDirection(false);
 		}
 	}
@@ -838,6 +947,15 @@ vector<Object*>* StickAction::slashAttack(int gx, int gy) {
 	}
 	// 攻撃のタイミングじゃないならnullptrが返る
 	return m_character_p->slashAttack(m_attackLeftDirection, m_slashCnt, m_grand, m_soundPlayer_p);
+}
+
+// スライディング攻撃
+vector<Object*>* StickAction::slidingAttack() {
+	if (m_slidingCnt == 0) {
+		return nullptr;
+	}
+	// 攻撃のタイミングじゃないならnullptrが返る
+	return m_character_p->slidingAttack(m_slidingCnt == SLIDING_SPEED, m_soundPlayer_p);
 }
 
 
@@ -1035,6 +1153,12 @@ void FlightAction::otherAction() {
 		if (m_boostCnt == 0) {
 			finishBoost();
 		}
+	}
+	if (m_stepCnt > 0) { m_stepCnt--; }
+	if (m_slidingCnt > 0) {
+		m_slidingCnt--;
+		if (m_slidingDone == 1) { m_vx--; }
+		if (m_slidingDone == 2) { m_vx++; }
 	}
 }
 void FlightAction::moveAction() {

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -73,9 +73,21 @@ protected:
 
 	// ブーストアニメの残り時間 または受け身状態
 	int m_boostCnt;
+	int m_boostDone;// 0:none 1:right 2:left
 	const int BOOST_TIME = 30;
 	const int BOOST_SPEED = 6;
-	int m_boostDone;// 0:none 1:right 2:left
+
+	// ステップ
+	int m_stepCnt;
+	int m_stepDone;// 0:none 1:right 2:left
+	const int STEP_STOP_TIME = 10;
+	const int STEP_TIME = 20;
+	const int STEP_SPEED = 30;
+
+	// スライディング
+	int m_slidingCnt;
+	int m_slidingDone;// 0:none 1:right 2:left
+	const int SLIDING_SPEED = 30;
 
 	// やられ状態の時間
 	const int DAMAGE_TIME = 10;
@@ -160,6 +172,7 @@ public:
 	inline int getDx() const { return m_dx; }
 	inline int getSlashCnt() const { return m_slashCnt; }
 	inline int getBulletCnt() const { return m_bulletCnt; }
+	inline int getSlidingDone() const { return m_slidingDone; }
 	bool getRightLock() const { return m_rightLock; }
 	bool getLeftLock() const { return m_leftLock; }
 	bool getUpLock() const { return m_upLock; }
@@ -181,6 +194,10 @@ public:
 	void setDownLock(bool lock);
 	virtual void setBoost(bool leftDirection);
 	void finishBoost();
+	void setStep(bool leftDirection);
+	void finishStep();
+	void setSliding(bool leftDirection);
+	void finishSliding();
 	inline void setGrandRightSlope(bool grand) { m_grandRightSlope = grand; }
 	inline void setGrandLeftSlope(bool grand) { m_grandLeftSlope = grand; }
 	inline void setRunCnt(int runCnt) { m_runCnt = runCnt; }
@@ -199,6 +216,10 @@ public:
 	inline void setLandCnt(int landCnt) { m_landCnt = landCnt; }
 	inline void setBoostCnt(int boostCnt) { m_boostCnt = boostCnt; }
 	inline void setBoostDone(int boostDone) { m_boostDone = boostDone; }
+	inline void setStepCnt(int stepCnt) { m_stepCnt = stepCnt; }
+	inline void setStepDone(int stepDone) { m_stepDone = stepDone; }
+	inline void setSlidingCnt(int slidingCnt) { m_slidingCnt = slidingCnt; }
+	inline void setSlidingDone(int slidingDone) { m_slidingDone = slidingDone; }
 	inline void setDamageCnt(int damageCnt) { m_damageCnt = damageCnt; }
 	inline void setHeavy(bool heavy) { m_heavy = heavy; }
 	inline void setSoundPlayer(SoundPlayer* soundPlayer) { m_soundPlayer_p = soundPlayer; }
@@ -232,6 +253,9 @@ public:
 
 	// 斬撃攻撃
 	virtual std::vector<Object*>* slashAttack(int gx, int gy) = 0;
+
+	// スライディング攻撃
+	virtual std::vector<Object*>* slidingAttack() { return nullptr; }
 
 	// ダメージ 必要に応じてオーバーライド
 	virtual void damage(int vx, int vy, int damageValue);
@@ -320,6 +344,9 @@ public:
 
 	// 斬撃攻撃
 	std::vector<Object*>* slashAttack(int gx, int gy);
+
+	// スライディング攻撃
+	std::vector<Object*>* slidingAttack();
 };
 
 

--- a/CharacterAction.h
+++ b/CharacterAction.h
@@ -105,6 +105,7 @@ protected:
 	int m_vx; // キャラの横移動の速度（トータル）
 	int m_vy; // キャラの縦移動の速度（トータル）
 	int m_runVx; // Controllerによる横移動の速度（走りなど。ダメージによる吹っ飛びは除く）
+	int m_runVy;
 
 	// 他のキャラと重なっているため次のフレームで位置をずらす
 	int m_dx;
@@ -168,7 +169,7 @@ public:
 	inline bool getGrandLeftSlope() const { return m_grandLeftSlope; }
 	inline bool getHeavy() const { return m_heavy; }
 	inline int getVx() const { return m_vx + m_runVx; }
-	inline int getVy() const { return m_vy; }
+	inline int getVy() const { return m_vy + m_runVy; }
 	inline int getDx() const { return m_dx; }
 	inline int getSlashCnt() const { return m_slashCnt; }
 	inline int getBulletCnt() const { return m_bulletCnt; }
@@ -209,6 +210,7 @@ public:
 	inline void setVx(int vx) { m_vx = vx; }
 	inline void setVy(int vy) { m_vy = vy; }
 	inline void setRunVx(int run_vx) { m_runVx = run_vx; }
+	inline void setRunVy(int run_vy) { m_runVy = run_vy; }
 	inline void setDx(int dx) { m_dx = dx; }
 	inline void setBulletCnt(int bulletCnt) { m_bulletCnt = bulletCnt; }
 	inline void setSlashCnt(int slashCnt) { m_slashCnt = slashCnt; }
@@ -228,7 +230,7 @@ public:
 	inline bool damageFlag() const { return m_state == CHARACTER_STATE::DAMAGE; }
 
 	// squat==trueならしゃがむ、falseなら立つ
-	void setSquat(bool squat);
+	virtual void setSquat(bool squat);
 
 	// キャラクターのセッタ
 	void setCharacterX(int x);
@@ -401,7 +403,6 @@ protected:
 
 	void damageAction();
 	void otherAction();
-	void moveAction();
 
 	// キャラの画像を状態(state)に応じて変更
 	void switchHandle();
@@ -417,6 +418,10 @@ public:
 	CharacterAction* createCopy(std::vector<Character*> characters);
 
 	void debug(int x, int y, int color) const;
+
+	void setSquat(bool squat) {}
+
+	void action();
 
 	// 移動 引数は４方向分
 	void move(bool right, bool left, bool up, bool down);

--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -374,6 +374,11 @@ void NormalController::control() {
 		squat = m_brain->squatOrder();
 	}
 	m_characterAction->setSquat(squat);
+
+	// ステップ
+	if (downStick > 0 && (leftStick == 1 || rightStick == 1)) {
+		m_characterAction->setStep(leftStick == 1);
+	}
 }
 
 vector<Object*>* NormalController::bulletAttack() {
@@ -452,6 +457,14 @@ vector<Object*>* NormalController::slashAttack() {
 	}
 	else {
 		order = m_brain->slashOrder();
+	}
+
+	// スライディング
+	if (order == 1) {
+		m_characterAction->setSliding(m_characterAction->getCharacter()->getCenterX() > targetX);
+	}
+	if (m_characterAction->getSlidingDone() != 0) {
+		return m_characterAction->slidingAttack();
 	}
 
 	// 近距離攻撃の命令がされたか、した後で今が攻撃タイミングなら

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -102,7 +102,7 @@ void FollowNormalAI::debug(int x, int y, int color) const {
 // Actionクラスのデバッグ
 void CharacterAction::debugAction(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**CharacterAction**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "state=%d, grand=%d(%d%d), (vx,vy)=(%d + %d,%d), slope=(%d,%d)", (int)m_state, m_grand, m_grandLeftSlope, m_grandRightSlope, m_vx, m_runVx, m_vy, m_grandLeftSlope, m_grandRightSlope);
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "state=%d, grand=%d(%d%d), (vx,vy)=(%d + %d,%d + %d), slope=(%d,%d)", (int)m_state, m_grand, m_grandLeftSlope, m_grandRightSlope, m_vx, m_runVx, m_vy, m_runVy, m_grandLeftSlope, m_grandRightSlope);
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "制限中：(←, →, ↑, ↓)=(%d,%d,%d,%d)", m_leftLock, m_rightLock, m_upLock, m_downLock);
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "移動中：(←, →, ↑, ↓)=(%d,%d,%d,%d)", m_moveLeft, m_moveRight, m_moveUp, m_moveDown);
 	m_character_p->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 4, color);

--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 31;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = false;
+const bool TEST_MODE = true;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 

--- a/GraphHandle.cpp
+++ b/GraphHandle.cpp
@@ -395,6 +395,8 @@ CharacterGraphHandle::CharacterGraphHandle(const char* characterName, double dra
 	loadCharacterGraph(dir, characterName, m_boostHandles, "boost", data, m_ex, &atariReader);
 	loadCharacterGraph(dir, characterName, m_airBulletHandles, "airBullet", data, m_ex, &atariReader);
 	loadCharacterGraph(dir, characterName, m_airSlashHandles, "airSlash", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_stepHandles, "step", data, m_ex, &atariReader);
+	loadCharacterGraph(dir, characterName, m_slidingHandles, "sliding", data, m_ex, &atariReader);
 	loadCharacterGraph(dir, characterName, m_closeHandles, "close", data, m_ex, &atariReader);
 	loadCharacterGraph(dir, characterName, m_deadHandles, "dead", data, m_ex, &atariReader);
 	loadCharacterGraph(dir, characterName, m_initHandles, "init", data, m_ex, &atariReader);
@@ -422,6 +424,8 @@ CharacterGraphHandle::~CharacterGraphHandle() {
 	if (m_boostHandles != nullptr) { delete m_boostHandles; }
 	if (m_airBulletHandles != nullptr) { delete m_airBulletHandles; }
 	if (m_airSlashHandles != nullptr) { delete m_airSlashHandles; }
+	if (m_stepHandles != nullptr) { delete m_stepHandles; }
+	if (m_slidingHandles != nullptr) { delete m_slidingHandles; }
 	if (m_closeHandles != nullptr) { delete m_closeHandles; }
 	if (m_deadHandles != nullptr) { delete m_deadHandles; }
 	if (m_initHandles != nullptr) { delete m_initHandles; }
@@ -538,6 +542,14 @@ void CharacterGraphHandle::switchAirBullet(int index){
 // 空中斬撃画像をセット
 void CharacterGraphHandle::switchAirSlash(int index){
 	setGraph(m_airSlashHandles, index);
+}
+// ステップ画像をセット
+void CharacterGraphHandle::switchStep(int index) {
+	setGraph(m_stepHandles, index);
+}
+// スライディング画像をセット
+void CharacterGraphHandle::switchSliding(int index) {
+	setGraph(m_slidingHandles, index);
 }
 // 瞬き画像をセット
 void CharacterGraphHandle::switchClose(int index) {

--- a/GraphHandle.h
+++ b/GraphHandle.h
@@ -244,6 +244,12 @@ private:
 	// 空中斬撃画像
 	GraphHandlesWithAtari* m_airSlashHandles;
 
+	// ステップ
+	GraphHandlesWithAtari* m_stepHandles;
+
+	// スライディング
+	GraphHandlesWithAtari* m_slidingHandles;
+
 	// 瞬き画像
 	GraphHandlesWithAtari* m_closeHandles;
 
@@ -292,6 +298,8 @@ public:
 	inline GraphHandlesWithAtari* getBoostHandle() { return m_boostHandles; }
 	inline GraphHandlesWithAtari* getAirBulletHandle() { return m_airBulletHandles; }
 	inline GraphHandlesWithAtari* getAirSlashHandle() { return m_airSlashHandles; }
+	inline GraphHandlesWithAtari* getStepHandle() { return m_stepHandles; }
+	inline GraphHandlesWithAtari* getSlidingHandle() { return m_slidingHandles; }
 	inline GraphHandlesWithAtari* getCloseHandle() { return m_closeHandles; }
 	inline GraphHandlesWithAtari* getDeadHandle() { return m_deadHandles; }
 	inline GraphHandlesWithAtari* getInitHandle() { return m_initHandles; }
@@ -336,6 +344,10 @@ public:
 	void switchAirBullet(int index = 0);
 	// 空中斬撃画像をセット
 	void switchAirSlash(int index = 0);
+	// ステップ画像をセット
+	void switchStep(int index = 0);
+	// スライディング画像をセット
+	void switchSliding(int index = 0);
 	// 瞬き画像をセット
 	void switchClose(int index = 0);
 	// やられ画像をセット

--- a/Object.cpp
+++ b/Object.cpp
@@ -760,7 +760,7 @@ GraphHandle* ParabolaBullet::getHandle() const {
 }
 
 
-SlashObject::SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo) :
+SlashObject::SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum, const AttackInfo* attackInfo) :
 	Object(x1, y1, x2, y2, attackInfo->slashHp())
 {
 	// 必要なら後からセッタで設定

--- a/Object.h
+++ b/Object.h
@@ -390,7 +390,7 @@ private:
 
 public:
 	// 座標、画像、生存時間、AttackInfo
-	SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum, AttackInfo* attackInfo);
+	SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum, const AttackInfo* attackInfo);
 
 	SlashObject(int x1, int y1, int x2, int y2, GraphHandle* handle, int slashCountSum);
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
ステップ：しゃがみ状態で左右キーを押すと無敵状態で少し横移動する。（等速）

スライディング：しゃがみ状態で斬撃キーを押すとスライディングする。無敵はないが低い姿勢で横移動し攻撃判定もある。（等速ではない）

FlightActionのバグ： #220 が原因。上下左右に動けなくなっていたので修正。また、上下移動も横移動と同じで少しずつスピードが変化する仕様に変更。

# やったこと
ステップとスライディングを追加。また、FlightActionの修正

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [x] デバッグモードで確認

# 懸念点
記入欄
