### PR TITLE
斬撃攻撃の仕様変更

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // どこまで
 const int FINISH_STORY = 31;
 // エリア0でデバッグするときはtrueにする
-const bool TEST_MODE = true;
+const bool TEST_MODE = false;
 // スキルが発動可能になるストーリー番号
 const int SKILL_USEABLE_STORY = 14;
 

--- a/Object.cpp
+++ b/Object.cpp
@@ -273,8 +273,6 @@ void BoxObject::penetration(CharacterController* characterController) {
 
 // 攻撃オブジェクトとの当たり判定
 bool BoxObject::atariFromObject(Object* object) {
-	// 破壊不能オブジェクト
-	// if (!object->getAbleDelete()) { return false; }
 	// 当たっているなら
 	if (m_x2 > object->getX1() && m_x1 < object->getX2() && m_y2 > object->getY1() && m_y1 < object->getY2()) {
 		if (object->getAbleDelete()) {
@@ -577,8 +575,6 @@ void TriangleObject::penetration(CharacterController* characterController) {
 
 // 他オブジェクトとの当たり判定
 bool TriangleObject::atariFromObject(Object* object) {
-	// 破壊不能オブジェクト
-	// if (!object->getAbleDelete()) { return false; }
 	// 斜辺を考慮して当たり判定を計算
 	int y = object->getY1();
 	if (m_leftDown) {

--- a/Object.cpp
+++ b/Object.cpp
@@ -16,6 +16,8 @@ using namespace std;
 const double OBJECT_DEFAULT_SIZE = 0.3;
 
 
+int Object::objectId;
+
 Object::Object() :
 	Object(0, 0, 0, 0, -1)
 {
@@ -23,6 +25,9 @@ Object::Object() :
 }
 
 Object::Object(int x1, int y1, int x2, int y2, int hp) {
+	objectId++;
+	m_id = objectId;
+
 	m_x1 = x1;
 	m_y1 = y1;
 	m_x2 = x2;
@@ -44,6 +49,8 @@ Object::Object(int x1, int y1, int x2, int y2, int hp) {
 }
 
 void Object::setParam(Object* object) {
+	object->setId(m_id);
+	object->setAtariIdList(m_atariIdList);
 	object->setX1(m_x1);
 	object->setY1(m_y1);
 	object->setX2(m_x2);
@@ -56,10 +63,18 @@ void Object::setParam(Object* object) {
 }
 
 // HPを減らす
-void Object::decreaseHp(int damageValue) {
+bool Object::decreaseHp(int damageValue, int id) {
+	if (!getAbleDelete()) { return false; }
+	for (unsigned int i = 0; i < m_atariIdList.size(); i++) {
+		if (m_atariIdList[i] == id) { 
+			return false;
+		}
+	}
+	m_atariIdList.push_back(id);
 	m_hp = max(0, m_hp - damageValue);
 	if (m_hp == 0) { setDeleteFlag(true); }
 	m_damageCnt = DAMAGE_CNT_SUM;
+	return true;
 }
 
 // 単純に四角の落下物と衝突しているか
@@ -257,17 +272,16 @@ void BoxObject::penetration(CharacterController* characterController) {
 }
 
 // 攻撃オブジェクトとの当たり判定
-bool BoxObject::atariObject(Object* object) {
+bool BoxObject::atariFromObject(Object* object) {
 	// 破壊不能オブジェクト
-	if (!object->getAbleDelete()) { return false; }
+	// if (!object->getAbleDelete()) { return false; }
 	// 当たっているなら
 	if (m_x2 > object->getX1() && m_x1 < object->getX2() && m_y2 > object->getY1() && m_y1 < object->getY2()) {
-		object->setDeleteFlag(true);
-		// 自分の体力を減らす
-		if (getAbleDelete()) {
-			decreaseHp(object->getDamage());
-			return true;
+		if (object->getAbleDelete()) {
+			object->setDeleteFlag(true);
 		}
+		// 自分の体力を減らす
+		return decreaseHp(object->getDamage(), object->getId());
 	}
 	return false;
 }
@@ -562,9 +576,9 @@ void TriangleObject::penetration(CharacterController* characterController) {
 }
 
 // 他オブジェクトとの当たり判定
-bool TriangleObject::atariObject(Object* object) {
+bool TriangleObject::atariFromObject(Object* object) {
 	// 破壊不能オブジェクト
-	if (!object->getAbleDelete()) { return false; }
+	// if (!object->getAbleDelete()) { return false; }
 	// 斜辺を考慮して当たり判定を計算
 	int y = object->getY1();
 	if (m_leftDown) {
@@ -575,12 +589,11 @@ bool TriangleObject::atariObject(Object* object) {
 	}
 	// 当たっているなら
 	if (m_x2 > object->getX1() && m_x1 < object->getX2() && m_y2 > object->getY1() && y < object->getY2()) {
-		object->setDeleteFlag(true);
-		// 自分の体力を減らす
-		if (getAbleDelete()) {
-			decreaseHp(object->getDamage());
-			return true;
+		if (object->getAbleDelete()) {
+			object->setDeleteFlag(true);
 		}
+		// 自分の体力を減らす
+		return decreaseHp(object->getDamage(), object->getId());
 	}
 	return false;
 }
@@ -683,17 +696,15 @@ bool BulletObject::atari(CharacterController* characterController) {
 	return false;
 }
 
-// 他攻撃オブジェクトとの当たり判定
-bool BulletObject::atariObject(Object* object) {
+// 他オブジェクトに対する当たり判定
+bool BulletObject::atariToObject(Object* object) {
 	// どちらかが破壊不能オブジェクト
-	if (!object->getAbleDelete() || !getAbleDelete() || m_groupId == object->getGroupId()) { 
+	if (m_groupId == object->getGroupId()) { 
 		return false;
 	}
 	// 当たっているなら
 	if (m_x2 > object->getX1() && m_x1 < object->getX2() && m_y2 > object->getY1() && m_y1 < object->getY2()) {
-		object->decreaseHp(m_damage);
-		decreaseHp(object->getDamage());
-		return true;
+		return object->decreaseHp(m_damage, m_id);
 	}
 	return false;
 }
@@ -854,17 +865,15 @@ bool SlashObject::atari(CharacterController* characterController) {
 	return false;
 }
 
-// 他攻撃オブジェクトとの当たり判定
-bool SlashObject::atariObject(Object* object) {
-	// どちらかが破壊不能オブジェクト
-	if (!object->getAbleDelete() || !getAbleDelete() || m_groupId == object->getGroupId()) {
+// 他オブジェクトに対する当たり判定
+bool SlashObject::atariToObject(Object* object) {
+	// どちらかが破壊不能オブジェクトもしくは味方の攻撃
+	if (m_groupId == object->getGroupId()) {
 		return false;
 	}
 	// 当たっているなら
 	if (m_x2 > object->getX1() && m_x1 < object->getX2() && m_y2 > object->getY1() && m_y1 < object->getY2()) {
-		object->decreaseHp(m_damage);
-		decreaseHp(object->getDamage());
-		return true;
+		return object->decreaseHp(m_damage, m_id);
 	}
 	return false;
 }
@@ -948,20 +957,18 @@ bool BombObject::atari(CharacterController* characterController) {
 	return false;
 }
 
-// 他攻撃オブジェクトとの当たり判定
-bool BombObject::atariObject(Object* object) {
+// 他オブジェクトに対する当たり判定
+bool BombObject::atariToObject(Object* object) {
 	// まだ判定なし
 	if (!ableDamage()) { return false; }
 	// どちらかが破壊不能オブジェクト
-	if (!object->getAbleDelete() || !getAbleDelete() || m_groupId == object->getGroupId()) {
+	if (m_groupId == object->getGroupId()) {
 		return false;
 	}
 	// 当たっているなら
 	if (m_x2 > object->getX1() && m_x1 < object->getX2() && m_y2 > object->getY1() && m_y1 < object->getY2()) {
 		int damage = (int)(m_damage * calcDamageRate(min(abs(m_x - object->getX1()), abs(m_x - object->getX2())), min(abs(m_y - object->getY1()), abs(m_y - object->getY2()))));
-		object->decreaseHp(damage);
-		decreaseHp(object->getDamage());
-		return true;
+		return object->decreaseHp(damage, m_id);
 	}
 	return false;
 }

--- a/Object.cpp
+++ b/Object.cpp
@@ -72,7 +72,9 @@ bool Object::decreaseHp(int damageValue, int id) {
 	}
 	m_atariIdList.push_back(id);
 	m_hp = max(0, m_hp - damageValue);
-	if (m_hp == 0) { setDeleteFlag(true); }
+	if (m_hp == 0) { 
+		setDeleteFlag(true);
+	}
 	m_damageCnt = DAMAGE_CNT_SUM;
 	return true;
 }
@@ -863,7 +865,7 @@ bool SlashObject::atari(CharacterController* characterController) {
 
 // 他オブジェクトに対する当たり判定
 bool SlashObject::atariToObject(Object* object) {
-	// どちらかが破壊不能オブジェクトもしくは味方の攻撃
+	// 味方の攻撃
 	if (m_groupId == object->getGroupId()) {
 		return false;
 	}

--- a/Object.h
+++ b/Object.h
@@ -2,6 +2,7 @@
 #define OBJECT_H_INCLUDED
 
 #include <string>
+#include <vector>
 
 class Character;
 class CharacterController;
@@ -16,6 +17,13 @@ class Animation;
 */
 class Object {
 protected:
+	// id
+	static int objectId;
+
+	int m_id;
+
+	std::vector<int> m_atariIdList;
+
 	// 左上の座標
 	int m_x1, m_y1;
 
@@ -56,6 +64,7 @@ public:
 	virtual void debug(int x, int y, int color) const = 0;
 
 	// ゲッタ
+	inline int getId() const { return m_id; }
 	inline bool getDeleteFlag() const { return m_deleteFlag; }
 	inline bool getAbleDelete() const { return m_hp != -1 ? true : false; }
 	inline int getX1() const { return m_x1; }
@@ -73,6 +82,8 @@ public:
 
 
 	// セッタ
+	inline void setId(int id) { m_id = id; }
+	inline void setAtariIdList(std::vector<int>& list) { for (unsigned int i = 0; i < list.size(); i++) { m_atariIdList.push_back(list[i]); } }
 	inline void setDeleteFlag(bool deleteFlag) { m_deleteFlag = deleteFlag; }
 	void setX1(int x1) { m_x1 = x1; }
 	void setY1(int y1) { m_y1 = y1; }
@@ -92,7 +103,7 @@ public:
 	virtual int getY(int x) const { return m_y1; }
 
 	// HPを減らす
-	void decreaseHp(int damageValue);
+	bool decreaseHp(int damageValue, int id);
 
 	// IDのゲッタ
 	virtual inline int getCharacterId() const { return -1; }
@@ -132,8 +143,11 @@ public:
 	// キャラがオブジェクトに入り込んでいるときの処理
 	virtual void penetration(CharacterController* characterController) {};
 
-	// 攻撃オブジェクトとの当たり判定
-	virtual bool atariObject(Object* object) { return false; }
+	// 他オブジェクトからの当たり判定
+	virtual bool atariFromObject(Object* object) { return false; }
+
+	// 他オブジェクトに対する当たり判定
+	virtual bool atariToObject(Object* object) { return false; }
 
 	// 動くオブジェクト用 毎フレーム行う
 	virtual void action() {};
@@ -182,7 +196,7 @@ public:
 	void penetration(CharacterController* characterController);
 
 	// 攻撃オブジェクトとの当たり判定
-	bool atariObject(Object* object);
+	bool atariFromObject(Object* object);
 
 	// 動くオブジェクト用 毎フレーム行う
 	void action();
@@ -234,7 +248,7 @@ public:
 	void penetration(CharacterController* characterController);
 
 	// 攻撃オブジェクトとの当たり判定
-	bool atariObject(Object* object);
+	bool atariFromObject(Object* object);
 
 	// 動くオブジェクト用 毎フレーム行う
 	void action();
@@ -321,7 +335,7 @@ public:
 	bool atari(CharacterController* characterController);
 
 	// 攻撃オブジェクトとの当たり判定
-	bool atariObject(Object* object);
+	bool atariToObject(Object* object);
 
 	// 動くオブジェクト用 毎フレーム行う
 	void action();
@@ -423,7 +437,7 @@ public:
 	bool atari(CharacterController* characterController);
 
 	// 攻撃オブジェクトとの当たり判定
-	bool atariObject(Object* object);
+	bool atariToObject(Object* object);
 
 	// 動くオブジェクト用 毎フレーム行う
 	void action();
@@ -485,7 +499,7 @@ public:
 	bool atari(CharacterController* characterController);
 
 	// 攻撃オブジェクトとの当たり判定
-	bool atariObject(Object* object);
+	bool atariToObject(Object* object);
 
 	// 動くオブジェクト用 毎フレーム行う
 	void action();

--- a/World.cpp
+++ b/World.cpp
@@ -1303,14 +1303,14 @@ void World::atariAttackAndAttack() {
 		for (unsigned int j = 0; j < m_attackObjects.size(); j++) {
 			if (i == j) { continue; }
 			// 攻撃が他の攻撃に当たっているか判定
-			if (m_attackObjects[j]->atariToObject(m_attackObjects[i])) {
+			if (m_attackObjects[j]->atariToObject(m_attackObjects[i]) && (m_attackObjects[i]->getDeleteFlag() || !m_attackObjects[i]->getAbleDelete())) {
 				// エフェクト作成
 				Animation* atariAnimation = m_attackObjects[i]->createAnimation(x, y, 3);
 				if (atariAnimation != nullptr) {
 					m_animations.push_back(atariAnimation);
 				}
-				createBomb(x, y, m_attackObjects[i]);
-				int soundHandle = m_attackObjects[i]->getSoundHandle();
+				createBomb(x, y, m_attackObjects[j]);
+				int soundHandle = m_attackObjects[j]->getSoundHandle();
 				int panPal = adjustPanSound(x, m_camera->getX());
 				m_soundPlayer_p->pushSoundQueue(soundHandle, panPal);
 			}

--- a/World.cpp
+++ b/World.cpp
@@ -1265,7 +1265,7 @@ void World::atariStageAndAttack() {
 		int y = m_attackObjects[i]->getCenterY();
 		for (unsigned int j = 0; j < m_stageObjects.size(); j++) {
 			// 攻撃が壁床に当たっているか判定
-			if (m_stageObjects[j]->atariObject(m_attackObjects[i])) {
+			if (m_stageObjects[j]->atariFromObject(m_attackObjects[i])) {
 				// エフェクト作成
 				Animation* atariAnimation = m_attackObjects[i]->createAnimation(x, y, 3);
 				if (atariAnimation != nullptr) {
@@ -1297,14 +1297,15 @@ void World::atariStageAndAttack() {
 //  Battle：攻撃<->攻撃の当たり判定
 void World::atariAttackAndAttack() {
 	if (m_attackObjects.size() == 0) { return; }
-	for (unsigned int i = 0; i < m_attackObjects.size() - 1; i++) {
+	for (unsigned int i = 0; i < m_attackObjects.size(); i++) {
 		int x = m_attackObjects[i]->getCenterX();
 		int y = m_attackObjects[i]->getCenterY();
-		for (unsigned int j = i + 1; j < m_attackObjects.size(); j++) {
-			// 攻撃が壁床に当たっているか判定
-			if (m_attackObjects[j]->atariObject(m_attackObjects[i])) {
+		for (unsigned int j = 0; j < m_attackObjects.size(); j++) {
+			if (i == j) { continue; }
+			// 攻撃が他の攻撃に当たっているか判定
+			if (m_attackObjects[j]->atariToObject(m_attackObjects[i])) {
 				// エフェクト作成
-				Animation* atariAnimation = m_attackObjects[j]->createAnimation(x, y, 3);
+				Animation* atariAnimation = m_attackObjects[i]->createAnimation(x, y, 3);
 				if (atariAnimation != nullptr) {
 					m_animations.push_back(atariAnimation);
 				}


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
斬撃攻撃で壁床や弾を壊せるようにする。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [ ] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
