### PR TITLE
カメラの改善（Y方向）

### DIFF
--- a/Camera.cpp
+++ b/Camera.cpp
@@ -42,16 +42,16 @@ Camera::Camera(const Camera* original) {
 // カメラの移動 目標地点が近いほど鈍感になる
 void Camera::move() {
 	if (m_x < m_gx) {
-		m_x += (m_gx - m_x) / 2 + 1;
+		m_x += (m_gx - m_x) / 8 + 1;
 	}
 	if (m_x > m_gx) {
-		m_x -= (m_x - m_gx) / 2 + 1;
+		m_x -= (m_x - m_gx) / 8 + 1;
 	}
 	if (m_y < m_gy) {
-		m_y += (m_gy - m_y) / 2 + 1;
+		m_y += (m_gy - m_y) * (m_gy - m_y) / 5000 + 1;
 	}
 	if (m_y > m_gy) {
-		m_y -= (m_y - m_gy) / 2 + 1;
+		m_y -= (m_y - m_gy) * (m_y - m_gy) / 30000 + 1;
 	}
 }
 

--- a/World.cpp
+++ b/World.cpp
@@ -790,7 +790,7 @@ void World::changePlayer(const Character* nextPlayer) {
 void World::cameraPointInit() {
 	for (unsigned int i = 0; i < m_characters.size(); i++) {
 		if (m_characters[i]->getId() == m_focusId) {
-			m_camera->setPoint(m_characters[i]->getCenterX(), m_characters[i]->getCenterY());
+			m_camera->setPoint(m_characters[i]->getCenterX(), m_characters[i]->getAtariCenterY() - m_characters[i]->getHeight() / 3);
 			break;
 		}
 	}
@@ -916,7 +916,10 @@ void World::updateCamera() {
 	for (unsigned int i = 0; i < size; i++) {
 		// 今フォーカスしているキャラの座標に合わせる
 		if (m_focusId == m_characters[i]->getId()) {
-			m_camera->setGPoint(m_characters[i]->getAtariCenterX(), m_characters[i]->getAtariCenterY());
+			int gy = m_characters[i]->getAtariCenterY() - m_characters[i]->getHeight() / 3;
+			m_camera->setGPoint(m_characters[i]->getAtariCenterX(), gy);
+			int dy = abs(m_camera->getY() - gy);
+			max_dy = max(max_dy, dy * dy / 100);
 		}
 		// フォーカスしているキャラ以外なら距離を調べる
 		else if (m_characters[i]->getHp() > 0) {


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
- ジャンプした感を得られるよう、Y方向のカメラ追従を弱める。
- ただし、下方向には追従しやすい。（床が見えないと困るため）
- また、デフォルトのカメラ位置を少し上にする。（床の下より空の方が見たい場面が多いため）
- カメラの追従が弱くなることでプレイヤーが画面外に取り残されないよう、カメラの拡大率調整にプレイヤーも加味する。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [ ] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
