### PR TITLE
ストーリー進行の仕組みを刷新

### DIFF
--- a/Animation.cpp
+++ b/Animation.cpp
@@ -129,7 +129,7 @@ void Movie::play() {
 
 	// ZƒL[’·‰Ÿ‚µ‚ÅI—¹
 	if (controlZ() > 0) {
-		if (m_skipCnt++ == 60) {
+		if (m_skipCnt++ == FPS_N) {
 			m_finishFlag = true;
 		}
 	}

--- a/Brain.cpp
+++ b/Brain.cpp
@@ -4,6 +4,7 @@
 #include "Camera.h"
 #include "Control.h"
 #include "Object.h"
+#include "Define.h"
 #include "DxLib.h"
 #include <cmath>
 
@@ -493,10 +494,10 @@ bool NormalAI::moveGoalOrder(int& right, int& left, int& up, int& down, int& jum
 	// 現在地
 	int x = m_characterAction_p->getCharacter()->getCenterX();
 	int y = m_characterAction_p->getCharacter()->getY() + m_characterAction_p->getCharacter()->getHeight();
-	// 60フレームごとに座標を確認
-	if (m_moveCnt % 60 == 59) {
+	// 1秒ごとに座標を確認
+	if (m_moveCnt % FPS_N == FPS_N - 1) {
 		// (壁につっかえるなどで)移動できてないから諦める
-		if (m_moveCnt >= 60 && abs(m_prevX - x) < 20) {
+		if (m_moveCnt >= FPS_N && abs(m_prevX - x) < 20) {
 			m_gx = x;
 			m_gy = y;
 		}

--- a/Character.cpp
+++ b/Character.cpp
@@ -363,7 +363,7 @@ void Character::damageHp(int value) {
 	
 	// –³“G‚¶‚á‚È‚¢‚È‚çHPŒ»Û
 	m_hp = max(0, m_hp - value);
-	m_dispHpCnt = 60;
+	m_dispHpCnt = FPS_N;
 }
 
 // ˆÚ“®‚·‚éiÀ•W‚ğ“®‚©‚·j

--- a/CharacterAction.cpp
+++ b/CharacterAction.cpp
@@ -1448,7 +1448,7 @@ SunAction::SunAction(Character* character, SoundPlayer* soundPlayer_p, bool dupl
 	FlightAction(character, soundPlayer_p)
 {
 	m_state = CHARACTER_STATE::INIT;
-	m_initCnt = -60;
+	m_initCnt = -FPS_N;
 	m_initHp = m_character_p->getHp();
 	if (!duplicationFlag) {
 		m_character_p->setHp(min(1, m_initHp));

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -9,6 +9,7 @@
 #include "Animation.h"
 #include "Define.h"
 #include "Text.h"
+#include "Timer.h"
 #include "Event.h"
 #include "Story.h"
 #include "Brain.h"
@@ -22,7 +23,7 @@
 // Gameクラスのデバッグ
 void Game::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**GAME**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "StoryNum=%d, doorSum=%d", m_gameData->getStoryNum(), m_gameData->getDoorSum());
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "timer=%d, Loop=%d, doorSum=%d, version=%d", m_story->getTimer()->getTime(), m_gameData->getLoop(), m_gameData->getDoorSum(), m_story->getVersion());
 	//for (int i = 0; i < m_gameData->getDoorSum(); i++) {
 	//	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE + ((i + 1) * DRAW_FORMAT_STRING_SIZE), color, "from=%d, to=%d", m_gameData->getFrom(i), m_gameData->getTo(i));
 	//}
@@ -43,7 +44,7 @@ void debugObjects(int x, int y, int color, std::vector<Object*> objects) {
 // Worldクラスのデバッグ
 void World::debug(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**World**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "areaNum=%d, CharacterSum=%d, ControllerSum=%d, cameraEx=%f", m_areaNum, m_characters.size(), m_characterControllers.size(), m_camera->getEx());
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "date=%d, areaNum=%d, CharacterSum=%d, ControllerSum=%d, cameraEx=%f", m_date, m_areaNum, m_characters.size(), m_characterControllers.size(), m_camera->getEx());
 	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 2, color, "itemSum=%d, animeSum=%d, attackObjects=%d", m_itemVector.size(), m_animations.size(), m_attackObjects.size());
 	if (m_itemVector.size() > 0) {
 		DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE * 3, color, "itemY=%d", m_itemVector[0]->getY());
@@ -61,7 +62,7 @@ void World::debug(int x, int y, int color) const {
 */
 void Story::debug(int x, int y, int color) {
 	DrawFormatString(x, y, color, "**Story**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "MustEventSum=%d", m_mustEvent.size());
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "MustEventSum=%d", m_eventList.size());
 }
 
 

--- a/Define.h
+++ b/Define.h
@@ -8,6 +8,9 @@ static int WINDOW = TRUE;
 // マウスを表示するならFALSE
 static int MOUSE_DISP = TRUE;
 
+// FPS
+#define FPS_N 60
+
 //画面の大きさ
 #define GAME_WIDE_MAX 3840
 #define GAME_HEIGHT_MAX 2160

--- a/DuplicationHeart.vcxproj
+++ b/DuplicationHeart.vcxproj
@@ -180,6 +180,7 @@
     <ClCompile Include="Story.cpp" />
     <ClCompile Include="Text.cpp" />
     <ClCompile Include="TextDrawer.cpp" />
+    <ClCompile Include="Timer.cpp" />
     <ClCompile Include="Title.cpp" />
     <ClCompile Include="DrawTool.cpp" />
     <ClCompile Include="World.cpp" />
@@ -214,6 +215,7 @@
     <ClInclude Include="Story.h" />
     <ClInclude Include="Text.h" />
     <ClInclude Include="TextDrawer.h" />
+    <ClInclude Include="Timer.h" />
     <ClInclude Include="Title.h" />
     <ClInclude Include="World.h" />
     <ClInclude Include="WorldDrawer.h" />

--- a/DuplicationHeart.vcxproj.filters
+++ b/DuplicationHeart.vcxproj.filters
@@ -144,6 +144,9 @@
     <ClCompile Include="DrawTool.cpp">
       <Filter>ソース ファイル\ui</Filter>
     </ClCompile>
+    <ClCompile Include="Timer.cpp">
+      <Filter>ソース ファイル\api</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Define.h">
@@ -238,6 +241,9 @@
     </ClInclude>
     <ClInclude Include="DrawTool.h">
       <Filter>ヘッダー ファイル\ui</Filter>
+    </ClInclude>
+    <ClInclude Include="Timer.h">
+      <Filter>ヘッダー ファイル\api</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Event.cpp
+++ b/Event.cpp
@@ -35,9 +35,11 @@ vector<string> mapParam2vector(map<string, string> paramMap) {
 /*
 * ƒCƒxƒ“ƒg
 */
-Event::Event(int eventNum, World* world, SoundPlayer* soundPlayer, int version) {
+Event::Event(int eventNum, int startTime, int endTime, World* world, SoundPlayer* soundPlayer, int version) {
 
 	m_eventNum = eventNum;
+	m_startTime = startTime;
+	m_endTime = endTime;
 	m_nowElement = 0;
 	m_eventElement = nullptr;
 

--- a/Event.cpp
+++ b/Event.cpp
@@ -35,11 +35,12 @@ vector<string> mapParam2vector(map<string, string> paramMap) {
 /*
 * ƒCƒxƒ“ƒg
 */
-Event::Event(int eventNum, int startTime, int endTime, World* world, SoundPlayer* soundPlayer, int version) {
+Event::Event(int eventNum, int startTime, int endTime, vector<int> requireEventNum, World* world, SoundPlayer* soundPlayer, int version) {
 
 	m_eventNum = eventNum;
 	m_startTime = startTime;
 	m_endTime = endTime;
+	m_requireEventNum = requireEventNum;
 	m_nowElement = 0;
 	m_eventElement = nullptr;
 

--- a/Event.h
+++ b/Event.h
@@ -87,6 +87,9 @@ private:
 	int m_startTime;
 	int m_endTime;
 
+	// 前提としてクリアが必要なイベントの番号
+	std::vector<int> m_requireEventNum;
+
 	// イベントの発火条件
 	std::vector<EventFire*> m_eventFire;
 
@@ -106,13 +109,14 @@ private:
 	int m_version;
 
 public:
-	Event(int eventNum, int startTime, int endTime, World* world, SoundPlayer* soundPlayer, int version);
+	Event(int eventNum, int startTime, int endTime, std::vector<int> requireEventNum, World* world, SoundPlayer* soundPlayer, int version);
 	~Event();
 
 	// ゲッタ
 	inline int getEventNum() const { return m_eventNum; }
 	inline int getStartTime() const { return m_startTime; }
 	inline int getEndTime() const { return m_endTime; }
+	inline const std::vector<int> getRequireEventNum() const { return m_requireEventNum; }
 	inline void setVersion(int version) { m_version = version; }
 
 	// 発火

--- a/Event.h
+++ b/Event.h
@@ -84,6 +84,9 @@ private:
 	// イベント番号
 	int m_eventNum;
 
+	int m_startTime;
+	int m_endTime;
+
 	// イベントの発火条件
 	std::vector<EventFire*> m_eventFire;
 
@@ -103,11 +106,14 @@ private:
 	int m_version;
 
 public:
-	Event(int eventNum, World* world, SoundPlayer* soundPlayer, int version);
+	Event(int eventNum, int startTime, int endTime, World* world, SoundPlayer* soundPlayer, int version);
 	~Event();
 
 	// ゲッタ
-	inline int getEventNum() { return m_eventNum; }
+	inline int getEventNum() const { return m_eventNum; }
+	inline int getStartTime() const { return m_startTime; }
+	inline int getEndTime() const { return m_endTime; }
+	inline void setVersion(int version) { m_version = version; }
 
 	// 発火
 	bool fire();

--- a/Game.cpp
+++ b/Game.cpp
@@ -361,7 +361,6 @@ bool GameData::load() {
 	// Read
 	fread(&m_areaNum, sizeof(m_areaNum), 1, intFp);
 	fread(&m_time, sizeof(m_time), 1, intFp);
-	//m_time = 35800;
 	fread(&m_loop, sizeof(m_loop), 1, intFp);
 	fread(&m_latestLoop, sizeof(m_latestLoop), 1, intFp);
 	fread(&m_money, sizeof(m_money), 1, intFp);

--- a/Game.h
+++ b/Game.h
@@ -165,7 +165,10 @@ public:
 	void load(FILE* eventFp);
 
 	// 初期化
-	void init() { m_clearEvent.clear(); }
+	void init() { 
+		m_clearEvent.clear();
+		m_clearLoop.clear();
+	}
 
 	// 特定のイベントをクリアしてるか (0 ~ loopまでの周回が対象)
 	bool checkClearEvent(int eventNum, int loop = 100);

--- a/Game.h
+++ b/Game.h
@@ -176,6 +176,10 @@ public:
 // セーブデータ
 class GameData {
 private:
+	const char* INT_DATA_PATH = "intDataNew.dat";
+	const char* STR_DATA_PATH = "strDataNew.dat";
+	const char* EVENT_DATA_PATH = "eventDataNew.dat";
+
 	// セーブする場所
 	std::string m_saveFilePath;
 
@@ -195,10 +199,12 @@ private:
 	int m_areaNum;
 
 	// 今やっているストーリー
-	int m_storyNum;
+	int m_time;
 
-	// 最新の未クリアストーリー
-	int m_latestStoryNum;
+	int m_loop;
+
+	// 最新の未ループ
+	int m_latestLoop;
 
 	// 音量
 	int m_soundVolume;
@@ -212,7 +218,7 @@ private:
 public:
 	GameData();
 	GameData(const char* saveFilePath);
-	GameData(const char* saveFilePath, int storyNum);
+	GameData(const char* saveFilePath, int loop);
 	~GameData();
 
 	// セーブ完了の通知を表示する時間
@@ -221,8 +227,8 @@ public:
 	// セーブとロード
 	bool save(bool force = false);
 	bool load();
-	bool saveChapter();
-	bool loadChapter(int storyNum);
+	bool saveLoop();
+	bool loadLoop(int loop);
 	// 全セーブデータ共通
 	bool saveCommon(int soundVolume, int gameWide, int gameHeight);
 	bool loadCommon(int* soundVolume, int* gameWide, int* gameHeight);
@@ -230,21 +236,23 @@ public:
 	// ゲッタ
 	inline bool getExist() const { return m_exist; }
 	inline int getAreaNum() const { return m_areaNum; }
-	inline int getStoryNum() const { return m_storyNum; }
+	inline int getTime() const { return m_time; }
+	inline int getLoop() const { return m_loop; }
 	inline int getSoundVolume() const { return m_soundVolume; }
 	inline int getMoney() const { return m_money; }
 	inline const char* getSaveFilePath() const { return m_saveFilePath.c_str(); }
 	inline int getDoorSum() const { return (int)m_doorData.size(); }
 	inline int getFrom(int i) const { return m_doorData[i]->from(); }
 	inline int getTo(int i) const { return m_doorData[i]->to(); }
-	inline int getLatestStoryNum() const { return m_latestStoryNum; }
+	inline int getLatestLoop() const { return m_latestLoop; }
 	inline EventData* getEventData() { return m_eventData; }
 	inline int getNoticeSaveDone() const { return m_noticeSaveDone; }
 	CharacterData* getCharacterData(std::string characterName);
 
 	// セッタ
 	inline void setAreaNum(int areaNum) { m_areaNum = areaNum; }
-	inline void setStoryNum(int storyNum) { m_storyNum = storyNum; }
+	inline void setTime(int time) { m_time = time; }
+	inline void setLoop(int loop) { m_loop = loop; }
 	inline void setSoundVolume(int soundVolume) { m_soundVolume = soundVolume; }
 	inline void setNoticeSaveDone(int noticeSaveDone) { m_noticeSaveDone = noticeSaveDone; }
 
@@ -259,6 +267,8 @@ public:
 
 	// ストーリーが進んだ時にセーブデータを更新する
 	void updateStory(Story* story);
+
+	void updateWorldVersion(Story* story);
 
 	// 世界のやり直し
 	void resetWorld();
@@ -330,6 +340,15 @@ private:
 
 
 class Game {
+public:
+	// 世界が終わるまでの時間 X分 * 60 * FPS 36000だと10min debug時1200とか
+	const int WORLD_LIFESPAN = 36000;
+
+	const int MAX_VERSION = 6;
+
+	// 複製の最大数
+	const int MAX_SKILL = 6;
+
 private:
 
 	GameData* m_gameData;
@@ -359,10 +378,11 @@ private:
 	bool m_rebootFlag;
 
 public:
-	Game(const char* saveFilePath = "savedata/test/", int storyNum = -1);
+	Game(const char* saveFilePath = "savedata/test/", int loop = -1);
 	~Game();
 
 	// ゲッタ
+	Story* const getStory() const { return m_story; }
 	World* getWorld() const { return m_world; }
 	HeartSkill* getSkill() const { return m_skill; }
 	BattleOption* getGamePause() const { return m_battleOption; }
@@ -377,13 +397,13 @@ public:
 	bool play();
 
 	// セーブデータをロード（前のセーブポイントへ戻る）
-	void backPrevSave(int prevStoryNum);
+	void backPrevSave();
 
 	// 描画していいならtrue
 	bool ableDraw();
 
 	// スキル発動できるところまでストーリーが進んでいるか
-	bool afterSkillUsableStoryNum() const;
+	bool afterSkillUsableLoop() const;
 
 private:
 

--- a/Game.h
+++ b/Game.h
@@ -153,6 +153,9 @@ private:
 	// クリアしたイベント番号
 	std::vector<int> m_clearEvent;
 
+	// クリアした周
+	std::vector<int> m_clearLoop;
+
 public:
 
 	EventData();
@@ -164,11 +167,11 @@ public:
 	// 初期化
 	void init() { m_clearEvent.clear(); }
 
-	// 特定のイベントをクリアしてるか
-	bool checkClearEvent(int eventNum);
+	// 特定のイベントをクリアしてるか (0 ~ loopまでの周回が対象)
+	bool checkClearEvent(int eventNum, int loop = 100);
 
 	//特定のイベントをクリアした
-	void setClearEvent(int eventNum);
+	void setClearEvent(int eventNum, int loop);
 
 };
 

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -89,13 +89,15 @@ void GameDrawer::draw() {
 		}
 	}
 	// 経過時間 TODO: 画像にする
-	if (m_worldDrawer->getWorld()->getBrightValue() == 255 && !m_game->getStory()->eventNow()) {
+	else if (m_worldDrawer->getWorld()->getBrightValue() == 255 && !m_game->getStory()->eventNow()) {
 		int time = m_game->getStory()->getTimer()->getTime();
 		int lifespan = m_game->WORLD_LIFESPAN;
 		int wide = GAME_WIDE / 4;
-		DrawBox(800, 50, 800 + wide, 80, BLACK, TRUE);
-		int p = 800 + (time * wide / lifespan);
-		DrawBox(p - 10, 20, p + 10, 110, WHITE, TRUE);
+		int barWide = (int)(10 * m_exX);
+		int leftX = (int)(850 * m_exX);
+		DrawBox(leftX, (int)(50 * m_exY), leftX + wide, (int)(80 * m_exY), BLACK, TRUE);
+		int p = leftX + (time * wide / lifespan);
+		DrawBox(p - barWide, (int)(20 * m_exY), p + barWide, (int)(110 * m_exY), WHITE, TRUE);
 	}
 
 	// セーブ完了通知

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -49,7 +49,7 @@ void GameDrawer::draw() {
 	// ゲームオーバー
 	int gameoverCnt = m_game->getGameoverCnt();
 	if (gameoverCnt > 0) {
-		if ((gameoverCnt < 60 && gameoverCnt / 2 % 2 == 0) || gameoverCnt > 60) {
+		if ((gameoverCnt < FPS_N && gameoverCnt / 2 % 2 == 0) || gameoverCnt > FPS_N) {
 			DrawRotaGraph(GAME_WIDE / 2, GAME_HEIGHT / 2, min(m_exX, m_exY) * 0.7, 0.0, m_gameoverHandle, TRUE);
 		}
 

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -68,34 +68,6 @@ void GameDrawer::draw() {
 	}
 	m_worldDrawer->draw(m_game->afterSkillUsableLoop());
 
-	// 経過時間 TODO: 画像にする
-	if (m_worldDrawer->getWorld()->getBrightValue() == 255 && !m_game->getStory()->eventNow()) {
-		int time = m_game->getStory()->getTimer()->getTime();
-		int lifespan = m_game->WORLD_LIFESPAN;
-		int wide = GAME_WIDE / 4;
-		DrawBox(800, 50, 800 + wide, 80, BLACK, TRUE);
-		int p = 800 + (time * wide / lifespan);
-		DrawBox(p - 10, 20, p + 10, 110, WHITE, TRUE);
-	}
-
-	// セーブ完了通知
-	int noticeSaveDone = m_game->getGameData()->getNoticeSaveDone();
-	int alpha = 0;
-	if (noticeSaveDone > 0) {
-		if (noticeSaveDone * 3 > m_game->getGameData()->NOTICE_SAVE_DONE_TIME * 2) {
-			alpha = min(255, (m_game->getGameData()->NOTICE_SAVE_DONE_TIME - noticeSaveDone) * 3);
-		}
-		else if (noticeSaveDone * 3 > m_game->getGameData()->NOTICE_SAVE_DONE_TIME ) {
-			alpha = 255;
-		}
-		else {
-			alpha = max(0, noticeSaveDone * 3);
-		}
-		SetDrawBlendMode(DX_BLENDMODE_ALPHA, alpha);
-		DrawRotaGraph(m_noticeX, m_noticeY, min(m_exX, m_exY) * m_noticeEx, 0.0, m_noticeSaveDataHandle, TRUE);
-		SetDrawBlendMode(DX_BLENDMODE_ALPHA, 255);
-	}
-
 	// スキルの時間等を描画
 	if (skill != nullptr) {
 		int num = skill->getLoopNum();
@@ -115,6 +87,33 @@ void GameDrawer::draw() {
 			oss << now + 1 << "/" << num << "：" << cnt1 << "." << cnt2;
 			DrawStringToHandle((int)(900 * m_exX), (int)(30 * m_exY), oss.str().c_str(), BLACK, m_skillHandle);
 		}
+	}
+	// 経過時間 TODO: 画像にする
+	if (m_worldDrawer->getWorld()->getBrightValue() == 255 && !m_game->getStory()->eventNow()) {
+		int time = m_game->getStory()->getTimer()->getTime();
+		int lifespan = m_game->WORLD_LIFESPAN;
+		int wide = GAME_WIDE / 4;
+		DrawBox(800, 50, 800 + wide, 80, BLACK, TRUE);
+		int p = 800 + (time * wide / lifespan);
+		DrawBox(p - 10, 20, p + 10, 110, WHITE, TRUE);
+	}
+
+	// セーブ完了通知
+	int noticeSaveDone = m_game->getGameData()->getNoticeSaveDone();
+	int alpha = 0;
+	if (noticeSaveDone > 0) {
+		if (noticeSaveDone * 3 > m_game->getGameData()->NOTICE_SAVE_DONE_TIME * 2) {
+			alpha = min(255, (m_game->getGameData()->NOTICE_SAVE_DONE_TIME - noticeSaveDone) * 3);
+		}
+		else if (noticeSaveDone * 3 > m_game->getGameData()->NOTICE_SAVE_DONE_TIME) {
+			alpha = 255;
+		}
+		else {
+			alpha = max(0, noticeSaveDone * 3);
+		}
+		SetDrawBlendMode(DX_BLENDMODE_ALPHA, alpha);
+		DrawRotaGraph(m_noticeX, m_noticeY, min(m_exX, m_exY) * m_noticeEx, 0.0, m_noticeSaveDataHandle, TRUE);
+		SetDrawBlendMode(DX_BLENDMODE_ALPHA, 255);
 	}
 
 	// 一時停止画面

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -1,5 +1,7 @@
 #include "GameDrawer.h"
 #include "Game.h"
+#include "Story.h"
+#include "Timer.h"
 #include "World.h"
 #include "WorldDrawer.h"
 #include "PausePage.h"
@@ -64,7 +66,17 @@ void GameDrawer::draw() {
 	else {
 		m_worldDrawer->setWorld(m_game->getWorld());
 	}
-	m_worldDrawer->draw(m_game->afterSkillUsableStoryNum());
+	m_worldDrawer->draw(m_game->afterSkillUsableLoop());
+
+	// 経過時間 TODO: 画像にする
+	if (m_worldDrawer->getWorld()->getBrightValue() == 255 && !m_game->getStory()->eventNow()) {
+		int time = m_game->getStory()->getTimer()->getTime();
+		int lifespan = m_game->WORLD_LIFESPAN;
+		int wide = GAME_WIDE / 4;
+		DrawBox(800, 50, 800 + wide, 80, BLACK, TRUE);
+		int p = 800 + (time * wide / lifespan);
+		DrawBox(p - 10, 20, p + 10, 110, WHITE, TRUE);
+	}
 
 	// セーブ完了通知
 	int noticeSaveDone = m_game->getGameData()->getNoticeSaveDone();

--- a/Main.cpp
+++ b/Main.cpp
@@ -103,7 +103,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 			Title::TITLE_RESULT result = title->play();
 			title->draw();
 			if (result == Title::START) {
-				game = new Game(title->useSaveFile(), title->startStoryNum());
+				game = new Game(title->useSaveFile(), title->startLoop());
 				gameDrawer = new GameDrawer(game);
 				delete title;
 				gamePlay = true;

--- a/Main.cpp
+++ b/Main.cpp
@@ -11,8 +11,8 @@ static int mStartTime;
 static int mCount;
 static int debug = FALSE;
 static float mFps;
-static const int N = 60;
-static const int FPS = 60;
+static const int N = FPS_N;
+static const int FPS = FPS_N;
 
 bool Update() {
 	if (mCount == 0) {

--- a/Story.cpp
+++ b/Story.cpp
@@ -230,6 +230,12 @@ void Story::updateWorldVersion() {
 	m_world_p->addObject(getObjectLoader());
 }
 
+void Story::loopInit() {
+	m_version = 1;
+	m_timer->setTime(0);
+	m_date = 0;
+}
+
 // ƒZƒbƒ^
 void Story::setWorld(World* world) {
 	m_world_p = world;

--- a/Story.cpp
+++ b/Story.cpp
@@ -4,6 +4,7 @@
 #include "CsvReader.h"
 #include "World.h"
 #include "Sound.h"
+#include "Timer.h"
 #include "CharacterLoader.h"
 #include "ObjectLoader.h"
 #include <sstream>
@@ -11,48 +12,62 @@
 using namespace std;
 
 
-string getChapterName(int storyNum) {
-	// story○○.csvをロード
-	CsvReader csvReader("data/story/storyMap.csv");
-	ostringstream oss;
-	oss << "data/story/main/" << csvReader.findOne("num", to_string(storyNum).c_str())["fileName"] << ".csv";
-	CsvReader2 csvReader2(oss.str().c_str());
-	string s = csvReader2.getDomainData("NAME:")[0]["name"];
-	return s;
+vector<string> split(string str, char del) {
+	vector<string> result;
+	string subStr;
+
+	for (const char c : str) {
+		if (c == del) {
+			result.push_back(subStr);
+			subStr.clear();
+		}
+		else {
+			subStr += c;
+		}
+	}
+
+	result.push_back(subStr);
+	return result;
 }
 
 
-Story::Story(int storyNum, World* world, SoundPlayer* soundPlayer, EventData* eventData) {
+Story::Story(int loop, int time, World* world, SoundPlayer* soundPlayer, EventData* eventData, int worldLifespan, int maxVersion) {
+	m_worldEndFlag = false;
+	m_timer = new Timer();
+	m_timer->setTime(time);
 	m_world_p = world;
+	m_soundPlayer_p = soundPlayer;
 	m_nowEvent = nullptr;
-	m_storyNum = storyNum;
+	m_loop = loop;
 	m_eventData_p = eventData;
 
-	m_characterLoader = new CharacterLoader;
-	m_objectLoader = new ObjectLoader;
+	m_needWorldUpdate = false;
+	m_characterLoader = nullptr;
+	m_objectLoader = nullptr;
 
-	m_date = 0;
-	m_version = 0;
-	m_resetWorld = false;
 	m_initDark = false;
 
-	// story○○.csvをロード
-	CsvReader csvReader("data/story/storyMap.csv");
+	m_version = 1 + time / (worldLifespan / maxVersion);
+	m_date = time / (worldLifespan / 3);
+	if (time == 0) {
+		updateWorldVersion();
+	}
+	m_world_p->setDate(m_date);
+
+	// eventList.csvをロード
 	ostringstream oss;
-	oss << "data/story/main/" << csvReader.findOne("num", to_string(storyNum).c_str())["fileName"] << ".csv";
-	loadCsvData(oss.str().c_str(), world, soundPlayer);
+	oss << "data/newStory/" << "eventList.csv";
+	loadEventCsvData(oss.str().c_str(), world, m_soundPlayer_p);
 
 	// イベントの発火確認
 	checkFire();
-	soundPlayer->stopBGM();
+	m_soundPlayer_p->stopBGM();
 }
 
 Story::~Story() {
-	for (unsigned int i = 0; i < m_mustEvent.size(); i++) {
-		delete m_mustEvent[i];
-	}
-	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
-		delete m_subEvent[i];
+	delete m_timer;
+	for (unsigned int i = 0; i < m_eventList.size(); i++) {
+		delete m_eventList[i];
 	}
 	if (m_nowEvent != nullptr) {
 		delete m_nowEvent;
@@ -62,33 +77,34 @@ Story::~Story() {
 }
 
 // csvファイルを読み込む
-void Story::loadCsvData(const char* fileName, World* world, SoundPlayer* soundPlayer) {
-	CsvReader2 csvReader2(fileName);
-
-	// イベント生成
-	vector<map<string, string> > eventData = csvReader2.getDomainData("EVENT:");
-	for (unsigned int i = 0; i < eventData.size(); i++) {
-		int eventNum = stoi(eventData[i]["num"]);
-		bool mustFlag = (bool)stoi(eventData[i]["mustFlag"]);
-		string condition = eventData[i]["condition"];
-		string secondNum = eventData[i]["secondNum"];
-		// conditionがクリア済みならsecondNumのイベントを代わりにセット
-		if (condition != "" && m_eventData_p->checkClearEvent(stoi(eventData[i]["condition"]))) {
-			if (secondNum != "") {
-				// 代わりのイベントをセット
-				eventNum = stoi(eventData[i]["secondNum"]);
-			}
-			else {
-				// 代わりのイベントはない
-				eventNum = -1;
+void Story::loadEventCsvData(const char* fileName, World* world, SoundPlayer* soundPlayer) {
+	CsvReader csvReader(fileName);
+	vector<map<string, string> > data = csvReader.getData();
+	for (int i = 0; i < data.size(); i++) {
+		int eventNum = stoi(data[i].find("eventNum")->second);
+		bool repeat = (bool)stoi(data[i].find("repeat")->second);
+		string conditions_str = data[i].find("conditions")->second;
+		vector<string> conditions = split(conditions_str, '|');
+		int startTime = stoi(data[i].find("startTime")->second);
+		int endTime = stoi(data[i].find("endTime")->second);
+		bool checkConditions = true;
+		for (unsigned int j = 0; j < conditions.size(); j++) {
+			if (conditions[j] != "") {
+				m_eventData_p->checkClearEvent(stoi(conditions[j]));
 			}
 		}
-		if (eventNum != -1) {
-			Event* eventOne = new Event(eventNum, world, soundPlayer, m_version);
-			if (mustFlag) { m_mustEvent.push_back(eventOne); }
-			else { m_subEvent.push_back(eventOne); }
+		if (checkConditions && (repeat || !m_eventData_p->checkClearEvent(eventNum))) {
+			m_eventList.push_back(new Event(eventNum, startTime, endTime, world, soundPlayer, m_version));
 		}
 	}
+}
+
+void Story::loadVersionCsvData(const char* fileName, World* world, SoundPlayer* soundPlayer) {
+	delete m_characterLoader;
+	delete m_objectLoader;
+	m_characterLoader = new CharacterLoader;
+	m_objectLoader = new ObjectLoader;
+	CsvReader2 csvReader2(fileName);
 
 	// キャラクターを用意
 	vector<map<string, string> > characterData = csvReader2.getDomainData("CHARACTER:");
@@ -101,43 +117,31 @@ void Story::loadCsvData(const char* fileName, World* world, SoundPlayer* soundPl
 	for (unsigned int i = 0; i < objectData.size(); i++) {
 		m_objectLoader->addObject(objectData[i]);
 	}
-
-	// 時間帯を決定
-	vector<map<string, string> > dateData = csvReader2.getDomainData("DATE:");
-	if (dateData.size() > 0) {
-		m_date = stoi(dateData[0]["num"]);
-	}
-	if (m_date == 0) {
-		m_world_p->setDate(m_date);
-	}
-
-	// 世界のバージョンを取得しロードする 変化ない(updateが0)ならロードしない
-	vector<map<string, string> > versionData = csvReader2.getDomainData("VERSION:");
-	if (versionData.size() > 0) {
-		m_version = stoi(versionData[0]["num"]);
-		if (m_version > 0 && (bool)stoi(versionData[0]["update"])) {
-			ostringstream oss;
-			oss << "data/story/template/version" << m_version << ".csv";
-			loadCsvData(oss.str().c_str(), world, soundPlayer);
-		}
-		m_loop = stoi(versionData[0]["loop"]);
-	}
-
-	// Storyの初期状態
-	vector<map<string, string> > initData = csvReader2.getDomainData("INIT:");
-	if (initData.size() > 0) {
-		m_initDark = (bool)stoi(initData[0]["dark"]);
-		m_resetWorld = (bool)stoi(initData[0]["resetWorld"]);
-	}
 }
 
-bool Story::play() {
+bool Story::play(int worldLifespan, int maxVersion) {
 	m_initDark = false;
 	if (m_nowEvent == nullptr) {
-		// 普通に世界を動かす
+		if (m_timer->getTime() == worldLifespan) {
+			// 世界ループのイベントをセット
+			m_eventList.push_back(new Event(9999, 0, 99999999, m_world_p, m_soundPlayer_p, m_version));
+			m_worldEndFlag = true;
+			m_loop++;
+		}
+		m_timer->advanceTime();
 		m_world_p->battle();
-		// イベントの発火確認
 		checkFire();
+		if (m_timer->getTime() % (worldLifespan / maxVersion) == 0) {
+			// 新バージョンをロードし世界を更新
+			if (m_version < maxVersion) {
+				m_version++;
+				updateWorldVersion();
+			}
+		}
+		if (m_timer->getTime() % (worldLifespan / 3) == 0) {
+			m_date = min(2, m_date + 1);
+			m_world_p->setDate(m_date);
+		}
 	}
 	else {
 		// イベント進行中
@@ -155,31 +159,23 @@ bool Story::play() {
 		if (result != EVENT_RESULT::NOW) {
 			delete m_nowEvent;
 			m_nowEvent = nullptr;
+			return true;
 		}
 	}
 
-	// 必須イベント全て終わり
-	if (m_mustEvent.size() == 0 && m_nowEvent == nullptr) { 
-		return true;
-	}
 	return false;
 }
 
 // イベントの発火確認
 void Story::checkFire() {
-	for (unsigned int i = 0; i < m_mustEvent.size(); i++) {
-		if (m_mustEvent[i]->fire()) {
-			m_nowEvent = m_mustEvent[i];
-			m_mustEvent[i] = m_mustEvent.back();
-			m_mustEvent.pop_back();
-			i--;
+	for (unsigned int i = 0; i < m_eventList.size(); i++) {
+		if (!(m_timer->getTime() >= m_eventList[i]->getStartTime() && m_timer->getTime() < m_eventList[i]->getEndTime())) {
+			continue;
 		}
-	}
-	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
-		if (m_subEvent[i]->fire()) {
-			m_nowEvent = m_subEvent[i];
-			m_subEvent[i] = m_subEvent.back();
-			m_subEvent.pop_back();
+		if (m_eventList[i]->fire()) {
+			m_nowEvent = m_eventList[i];
+			m_eventList[i] = m_eventList.back();
+			m_eventList.pop_back();
 			i--;
 		}
 	}
@@ -193,6 +189,18 @@ bool Story::skillAble() {
 	return m_nowEvent->skillAble();
 }
 
+void Story::updateWorldVersion() {
+	m_needWorldUpdate = true;
+	ostringstream oss;
+	oss << "data/story/template/version" << m_version << ".csv";
+	loadVersionCsvData(oss.str().c_str(), m_world_p, m_soundPlayer_p);
+	for (unsigned int i = 0; i < m_eventList.size(); i++) {
+		m_eventList[i]->setVersion(m_version);
+	}
+	m_world_p->addCharacter(getCharacterLoader());
+	m_world_p->addObject(getObjectLoader());
+}
+
 // セッタ
 void Story::setWorld(World* world) {
 	m_world_p = world;
@@ -201,11 +209,8 @@ void Story::setWorld(World* world) {
 	if (m_nowEvent != nullptr) {
 		m_nowEvent->setWorld(m_world_p);
 	}
-	for (unsigned int i = 0; i < m_mustEvent.size(); i++) {
-		m_mustEvent[i]->setWorld(m_world_p);
-	}
-	for (unsigned int i = 0; i < m_subEvent.size(); i++) {
-		m_subEvent[i]->setWorld(m_world_p);
+	for (unsigned int i = 0; i < m_eventList.size(); i++) {
+		m_eventList[i]->setWorld(m_world_p);
 	}
 }
 

--- a/Story.h
+++ b/Story.h
@@ -63,7 +63,7 @@ public:
 	~Story();
 
 	// csvƒtƒ@ƒCƒ‹‚ğ“Ç‚İ‚Ş
-	void loadEventCsvData(const char* fileName, World* world, SoundPlayer* soundPlayer);
+	void loadEventCsvData(const char* fileName, World* world, SoundPlayer* soundPlayer, int versionTimeSpan);
 	void loadVersionCsvData(const char* fileName, World* world, SoundPlayer* soundPlayer);
 
 	void debug(int x, int y, int color);

--- a/Story.h
+++ b/Story.h
@@ -78,6 +78,9 @@ public:
 
 	void updateWorldVersion();
 
+	// ループ実行時の初期化（実行直後の1Fの描画のために使う。）
+	void loopInit();
+
 	// ゲッタ
 	inline const Timer* getTimer() const { return m_timer; }
 	inline int getDate() const { return m_date; }

--- a/Text.cpp
+++ b/Text.cpp
@@ -261,7 +261,7 @@ bool Conversation::play() {
 
 	// ZƒL[’·‰Ÿ‚µ‚ÅI—¹
 	if (controlZ() > 0) { 
-		if (m_skipCnt++ == 60) {
+		if (m_skipCnt++ == FPS_N) {
 			m_finishFlag = true;
 			return true;
 		}

--- a/Timer.cpp
+++ b/Timer.cpp
@@ -1,0 +1,11 @@
+#include "Define.h"
+#include "Timer.h"
+
+
+Timer::Timer() { 
+	resetTime();
+}
+
+int Timer::getSec() const {
+	return m_time / FPS_N;
+}

--- a/Timer.h
+++ b/Timer.h
@@ -16,6 +16,8 @@ public:
 
 	inline void setTime(int time) { m_time = time; }
 
+	inline void advanceTime() { m_time++; }
+
 	inline void resetTime() { m_time = START_TIME; }
 
 	// •b”‚Å•Ô‚·

--- a/Timer.h
+++ b/Timer.h
@@ -1,0 +1,25 @@
+#ifndef TIMER_H_INCLUDED
+#define TIMER_H_INCLUDED
+
+class Timer {
+private:
+
+	const int START_TIME = 0;
+
+	int m_time;
+
+public:
+
+	Timer();
+
+	inline int getTime() const { return m_time; }
+
+	inline void setTime(int time) { m_time = time; }
+
+	inline void resetTime() { m_time = START_TIME; }
+
+	// ïbêîÇ≈ï‘Ç∑
+	int getSec() const;
+};
+
+#endif

--- a/Title.cpp
+++ b/Title.cpp
@@ -58,7 +58,7 @@ SelectSaveData::SelectSaveData() {
 		}
 	}
 
-	// チャプター名を取得
+	// ループ名を取得
 	for (int i = 0; i < maxLoop; i++) {
 		//string s = getChapterName(i + 1);
 		//m_chapterNames.push_back(s);
@@ -164,7 +164,7 @@ const char* SelectSaveData::useDirName() {
 	return m_gameData[m_useSaveDataIndex]->getSaveFilePath();
 }
 
-// 始めるチャプター
+// 始めるループ
 int SelectSaveData::startLoop() {
 	if (m_useSaveDataIndex == NOT_DECIDE_DATA || m_startLoop[m_useSaveDataIndex] == nullptr) { return -1; }
 	int loop = m_startLoop[m_useSaveDataIndex]->getNowValue();

--- a/Title.h
+++ b/Title.h
@@ -43,8 +43,8 @@ private:
 	// 使用するセーブデータのインデックス
 	int m_useSaveDataIndex;
 
-	// 開始するチャプター番号
-	ControlBar* m_startStoryNum[GAME_DATA_SUM];
+	// 開始するループ番号
+	ControlBar* m_startLoop[GAME_DATA_SUM];
 
 	// 背景
 	TitleBackGround* m_haikei;
@@ -63,8 +63,8 @@ public:
 	// セーブデータが1つでも存在するか
 	bool saveDataExist();
 
-	// 最大のStoryNum
-	int getLatestStoryNum();
+	// 最大のLoop
+	int getLatestLoop();
 
 	// セーブデータ選択画面の処理
 	bool play(int handX, int handY);
@@ -75,8 +75,8 @@ public:
 	// 使用するセーブデータのディレクトリ名
 	const char* useDirName();
 
-	// 始めるチャプター 指定がないなら-1
-	int startStoryNum();
+	// 始めるループ 指定がないなら-1
+	int startLoop();
 
 	// 全セーブデータ共通のデータをセーブ(タイトル画面のオプション用)
 	void saveCommon(int soundVolume);
@@ -147,9 +147,9 @@ public:
 		return m_selectSaveData->useDirName();
 	}
 
-	// 始めるチャプター番号 指定がないなら-1
-	inline int startStoryNum() {
-		return m_selectSaveData->startStoryNum();
+	// 始めるループ番号 指定がないなら-1
+	inline int startLoop() {
+		return m_selectSaveData->startLoop();
 	}
 
 };

--- a/World.cpp
+++ b/World.cpp
@@ -841,6 +841,12 @@ CharacterController* World::createControllerWithData(const Character* character,
 	return createController(data->controllerName(), brain, action);
 }
 
+void World::playBGM() {
+	if (!m_soundPlayer_p->checkBGMplay()) {
+		m_soundPlayer_p->playBGM();
+	}
+}
+
 /*
 *  í‚í‚¹‚é
 */
@@ -848,9 +854,7 @@ void World::battle() {
 
 	m_dispHpInfoFlag = true;
 
-	if (!m_soundPlayer_p->checkBGMplay()) {
-		m_soundPlayer_p->playBGM();
-	}
+	playBGM();
 	
 	// ‰æ–ÊˆÃ“]ˆ—
 	if (dealBrightValue()) { return; }

--- a/World.h
+++ b/World.h
@@ -327,6 +327,9 @@ public:
 	// 仲間をプレイヤーの位置へ移動
 	void setPlayerFollowerPoint();
 
+	// BGMを流す
+	void playBGM();
+
 	// キャラに戦わせる
 	void battle();
 

--- a/WorldDrawer.h
+++ b/WorldDrawer.h
@@ -88,8 +88,11 @@ public:
 
 	~WorldDrawer();
 
+	// ゲッタ
+	inline const World* getWorld() const { return m_world; }
+
 	// セッタ
-	void setWorld(World* world) { m_world = world; }
+	inline void setWorld(World* world) { m_world = world; }
 
 	// 描画する
 	void draw(bool drawSkillBar);


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#226 の対応。詳細はissueから確認

# やったこと
- 依存イベントのクリア条件：前ループでクリアしている・今ループでクリアすればいいの2種類用意
  - 全ループクリア条件：2周かけてやる想定のイベントを1周でこなされるとシナリオに矛盾が生じるため必要

# やらないこと
- 特定のイベントを「クリアしていない」ことが開始条件のイベントの発火機能
- 同じループで先にクリアが必要なイベント（前のループでクリア済みなら未クリアに修正する）の機能
- 時間を３倍速で進める機能

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [x] デバッグモードで確認

# 懸念点
記入欄
