### PR TITLE
アイテムの床・壁との当たり判定を修正

### DIFF
--- a/Object.cpp
+++ b/Object.cpp
@@ -81,8 +81,9 @@ bool Object::decreaseHp(int damageValue, int id) {
 
 // 単純に四角の落下物と衝突しているか
 bool Object::atariDropBox(int x1, int y1, int x2, int y2, int& vx, int& vy) {
-	// 上から衝突してきた
-	if (x2 + vx >= m_x1 && x1 + vx <= m_x2 && y2 < m_y1 && y2 + vy >= m_y1) {
+	// 上から衝突してきた (座標がint型で+-1の誤差があるためそれは許容する)
+	if (x2 + vx >= m_x1 && x1 + vx <= m_x2 && y2 - 1 <= m_y1 && y2 + 1 + vy >= m_y1) {
+		vx = 0; vy = 0;
 		return true;
 	}
 	// 左右からの衝突
@@ -96,12 +97,15 @@ bool Object::atariDropBox(int x1, int y1, int x2, int y2, int& vx, int& vy) {
 	}
 	// 下からの衝突
 	if (y1 > y2 && y1 + vy <= y2 && x2 > m_x1 && x1 < m_x2) {
-		vy = 0;
+		vy = 1;
 		return false;
 	}
 	// 埋まっている
 	if (x2 > m_x1 && x1 < m_x2 && y2 > m_y1 && y1 < m_y2) {
-		vx = 0; vy = 0;
+		if ((y1 + y2) < (m_y1 + m_y2)) { vy = -1; }
+		else { vy = 1; }
+		if ((x1 + x2) < (m_x1 + m_x2)) { vx = -1; }
+		else { vx = 1; }
 		return false;
 	}
 	return false;
@@ -490,9 +494,9 @@ bool TriangleObject::atari(CharacterController* characterController) {
 // 単純に四角の落下物と衝突しているか
 bool TriangleObject::atariDropBox(int x1, int y1, int x2, int y2, int& vx, int& vy) {
 	int y = getY((x1 + x2) / 2);
-	// 上から衝突してきた
-	if (x2 + vx >= m_x1 && x1 + vx <= m_x2 && y2 < y && y2 + vy >= y) {
-		return true;
+	// 上から衝突してきた (座標がint型で+-1の誤差があるためそれは許容する)
+	if (x2 + vx >= m_x1 && x1 + vx <= m_x2 && y2 - 1 <= y && y2 + 1 + vy >= y) {
+		vx = 0; vy = 0;
 	}
 	// 左右からの衝突
 	if (x2 <= m_x1 && x2 + vx >= m_x1 && y2 > y && y1 < m_y2) {
@@ -505,12 +509,15 @@ bool TriangleObject::atariDropBox(int x1, int y1, int x2, int y2, int& vx, int& 
 	}
 	// 下からの衝突
 	if (y1 > y2 && y1 + vy <= y2 && x2 > m_x1 && x1 < m_x2) {
-		vy = 0;
+		vy = 1;
 		return false;
 	}
 	// 埋まっている
 	if (x2 > m_x1 && x1 < m_x2 && y2 > y && y1 < m_y2) {
-		vx = 0; vy = 0;
+		if ((y1 + y2) < (m_y1 + m_y2)) { vy = -1; }
+		else { vy = 1; }
+		if ((x1 + x2) < (m_x1 + m_x2)) { vx = -1; }
+		else { vx = 1; }
 		return false;
 	}
 	return false;

--- a/World.cpp
+++ b/World.cpp
@@ -1121,19 +1121,20 @@ void World::controlItem() {
 		}
 		// ‰Šú‰»
 		m_itemVector[i]->init();
+		int vx = m_itemVector[i]->getVx();
+		int vy = m_itemVector[i]->getVy();
 		// •Ç°‚Æ‚Ì“–‚½‚è”»’è
 		for (unsigned int j = 0; j < m_stageObjects.size(); j++) {
 			int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
 			m_itemVector[i]->getPoint(&x1, &y1, &x2, &y2);
-			int vx = m_itemVector[i]->getVx();
-			int vy = m_itemVector[i]->getVy();
 			if (m_stageObjects[j]->atariDropBox(x1, y1, x2, y2, vx, vy)) {
 				m_itemVector[i]->setGrand(true);
 				m_itemVector[i]->setY(m_stageObjects[j]->getY(m_itemVector[i]->getX()));
+				break;
 			}
-			m_itemVector[i]->setVx(vx);
-			m_itemVector[i]->setVy(vy);
 		}
+		m_itemVector[i]->setVx(vx);
+		m_itemVector[i]->setVy(vy);
 		// ƒLƒƒƒ‰‚Æ‚Ì“–‚½‚è”»’è
 		if (targetCharacter != nullptr && m_itemVector[i]->atariCharacter(targetCharacter)) {
 			m_soundPlayer_p->pushSoundQueue(m_itemVector[i]->getSound());


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
現状天井にくっつく＆壁際で出現したアイテムが壁に埋まる

対処法：オブジェクトに埋まったアイテムはぬるっと外に移動する

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
