### PR TITLE
キャラがやられた時に画面がフリーズする機能を追加

### DIFF
--- a/Camera.cpp
+++ b/Camera.cpp
@@ -2,12 +2,15 @@
 #include "Define.h"
 #include "DxLib.h"
 
+#include <cmath>
+
 
 Camera::Camera() :
 	Camera(0, 0, 1.0, 1)
 {
 
 }
+
 
 Camera::Camera(int x, int y, double ex, int speed) {
 	m_x = x;
@@ -24,6 +27,7 @@ Camera::Camera(int x, int y, double ex, int speed) {
 	m_zoomOutMode = false;
 }
 
+
 Camera::Camera(const Camera* original) {
 	m_x = original->getX();
 	m_y = original->getY();
@@ -38,6 +42,7 @@ Camera::Camera(const Camera* original) {
 	m_shakingTime = original->getShakingTime();
 	m_zoomOutMode = original->getZoomOutMode();
 }
+
 
 // カメラの移動 目標地点が近いほど鈍感になる
 void Camera::move() {
@@ -57,6 +62,7 @@ void Camera::move() {
 	}
 }
 
+
 // カメラで座標と拡大率を調整する
 void Camera::setCamera(int* x, int* y, double* ex) const {
 	// カメラからのずれを計算
@@ -75,6 +81,7 @@ void Camera::setCamera(int* x, int* y, double* ex) const {
 	*ex *= m_ex;
 }
 
+
 void Camera::getMouse(int* x, int* y) const {
 	GetMousePoint(x, y);
 
@@ -87,11 +94,13 @@ void Camera::getMouse(int* x, int* y) const {
 	*y = m_y + dy;
 }
 
+
 // カメラを揺らす
 void Camera::shakingStart(int width, int time) {
 	m_shakingWidth = width;
 	m_shakingTime = time;
 }
+
 
 // カメラを揺らす
 void Camera::shaking() {
@@ -99,4 +108,12 @@ void Camera::shaking() {
 	m_x += GetRand(m_shakingWidth * 2) - m_shakingWidth;
 	m_y += GetRand(m_shakingWidth * 2) - m_shakingWidth;
 	m_shakingTime--;
+}
+
+
+// 目標地点までの距離を計算
+int Camera::calcGoalDistance() {
+	int dx = m_gx - m_x;
+	int dy = m_gy - m_y;
+	return sqrt(dx * dx + dy * dy);
 }

--- a/Camera.cpp
+++ b/Camera.cpp
@@ -63,6 +63,23 @@ void Camera::move() {
 }
 
 
+// X, Y方向に同じ感度で移動する
+void Camera::moveNormal() {
+	if (m_x < m_gx) {
+		m_x += (m_gx - m_x) / 8 + 1;
+	}
+	if (m_x > m_gx) {
+		m_x -= (m_x - m_gx) / 8 + 1;
+	}
+	if (m_y < m_gy) {
+		m_y += (m_gy - m_y) / 8 + 1;
+	}
+	if (m_y > m_gy) {
+		m_y -= (m_y - m_gy) / 8 + 1;
+	}
+}
+
+
 // カメラで座標と拡大率を調整する
 void Camera::setCamera(int* x, int* y, double* ex) const {
 	// カメラからのずれを計算

--- a/Camera.h
+++ b/Camera.h
@@ -75,6 +75,9 @@ public:
 
 	// カメラを揺らす
 	void shaking();
+
+	// 目標地点までの距離を計算
+	int calcGoalDistance();
 };
 
 

--- a/Camera.h
+++ b/Camera.h
@@ -64,6 +64,9 @@ public:
 	// カメラの動き
 	void move();
 
+	// X, Y方向に同じ感度で移動する
+	void moveNormal();
+
 	// カメラの座標を考慮した描画位置の補正
 	void setCamera(int* x, int* y, double* ex) const;
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -667,7 +667,9 @@ bool Game::play() {
 	// セーブ完了通知の処理
 	m_gameData->setNoticeSaveDone(max(0, m_gameData->getNoticeSaveDone() - 1));
 
-	m_soundPlayer->play();
+	if (m_world->getWorldFreezeTime() == 0) {
+		m_soundPlayer->play();
+	}
 
 	// テストは以降を実行しない
 	if (TEST_MODE) { return false; }
@@ -772,7 +774,8 @@ bool Game::skillUsable() {
 				m_world->getBrightValue() == 255 &&
 				m_world->getControlCharacterName() == "ハート" &&
 				m_world->getConversation() == nullptr &&
-				m_world->getObjectConversation() == nullptr)
+				m_world->getObjectConversation() == nullptr &&
+				m_world->getWorldFreezeTime() == 0)
 			{
 				// ハート自身がスキル発動可能な状態か
 				Character* character = m_world->getCharacterWithName("ハート");

--- a/Game.cpp
+++ b/Game.cpp
@@ -631,7 +631,9 @@ bool Game::play() {
 	// スキル発動中で、操作記録中
 	if (m_skill != nullptr && !m_skill->finishRecordFlag()) {
 		m_skill->battle();
-		m_skill->play();
+		if (m_world->getWorldFreezeTime() == 0) {
+			m_skill->play();
+		}
 	}
 	// ストーリー進行
 	else if (m_story->play(WORLD_LIFESPAN, MAX_VERSION)) {
@@ -655,7 +657,7 @@ bool Game::play() {
 		m_gameData->save();
 	}
 	else if (m_skill != nullptr) { // スキル発動中で、最後のループ中
-		if (m_skill->play()) {
+		if (m_world->getWorldFreezeTime() == 0 && m_skill->play()) {
 			endSkill();
 		}
 	}

--- a/World.cpp
+++ b/World.cpp
@@ -1268,7 +1268,7 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 						}
 					}
 				}
-				if (character->haveDeadGraph() || character->getBossFlag() || character->getId() == m_playerId) {
+				if (!m_duplicationFlag && (true || character->haveDeadGraph() || character->getBossFlag() || character->getId() == m_playerId)) {
 					// ƒtƒŠ[ƒY‚³‚¹‚é
 					m_worldFreezeTime = 30;
 					m_camera->setGPoint(character->getCenterX(), character->getCenterY());

--- a/World.cpp
+++ b/World.cpp
@@ -864,7 +864,7 @@ void World::battle() {
 			m_worldFreezeTime--;
 		}
 		else {
-			m_camera->move();
+			m_camera->moveNormal();
 		}
 		return;
 	}
@@ -1268,7 +1268,7 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 						}
 					}
 				}
-				if (true) {
+				if (character->haveDeadGraph() || character->getBossFlag() || character->getId() == m_playerId) {
 					// ƒtƒŠ[ƒY‚³‚¹‚é
 					m_worldFreezeTime = 30;
 					m_camera->setGPoint(character->getCenterX(), character->getCenterY());

--- a/World.h
+++ b/World.h
@@ -58,6 +58,9 @@ public:
 class World {
 private:
 
+	// 世界をフリーズする時間
+	int m_worldFreezeTime;
+
 	// (Drawer用) ＨＰなどの情報を表示するか
 	bool m_dispHpInfoFlag;
 
@@ -189,6 +192,7 @@ public:
 	void debug(int x, int y, int color) const;
 
 	// ゲッタ
+	inline int getWorldFreezeTime() const { return m_worldFreezeTime; }
 	inline bool getDispHpInfoFlag() const { return m_dispHpInfoFlag; }
 	inline int getFocusId() const { return m_focusId; }
 	inline int getPlayerId() const { return m_playerId; }


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
キャラがやられた時にフリーズする機能を追加。

仕様
- フリーズする条件
  - Dead画像がある or ボス or 操作中のキャラ
- スキルとの関係
  - 操作記録フェーズではフリーズしない。
  - 最後の周ではフリーズする。フリーズ中は複製のハートの操作再現も進行しない。
- カメラ移動
  - フリーズと同時にやられたキャラへカメラが向かう。
  - カメラの向かう速度はX, Y方向で同じ感度。
  - カメラが到着してから30F後にフリーズ処理終了する。
- 効果音
  - フリーズ処理が終了してから攻撃を食らった効果音などが鳴る。
- ゲームオーバー時
  - フリーズ処理が終了してからゲームオーバー処理に入る。

# やったこと
記入欄

# やらないこと
将来的にはcsvファイルでキャラごとにフリーズするかどうかを設定できるようにする？

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [ ] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
