### PR TITLE
時間のスピードアップモードを追加

### DIFF
--- a/Define.h
+++ b/Define.h
@@ -11,6 +11,9 @@ static int MOUSE_DISP = TRUE;
 // FPS
 #define FPS_N 60
 
+// ‰~Žü—¦
+#define PI 3.14
+
 //‰æ–Ê‚Ì‘å‚«‚³
 #define GAME_WIDE_MAX 3840
 #define GAME_HEIGHT_MAX 2160
@@ -45,5 +48,6 @@ const int BLUE = GetColor(0, 0, 255);
 const int LIGHT_BLUE = GetColor(100, 100, 255);
 const int ORANGE = GetColor(255, 165, 0);
 const int DARK_ORANGE = GetColor(80, 50, 0);
+const int YELLOW = GetColor(255, 255, 0);
 
 #endif

--- a/Game.h
+++ b/Game.h
@@ -374,6 +374,11 @@ private:
 	// 一時停止画面
 	BattleOption* m_battleOption;
 
+	// 時間の進む速度
+	int m_timeSpeed;
+	const int DEFAULT_TIME_SPEED = 1;
+	const int QUICK_TIME_SPEED = 10;
+
 	// 一時停止画面音
 	int m_pauseSound;
 
@@ -407,6 +412,8 @@ public:
 
 	// スキル発動できるところまでストーリーが進んでいるか
 	bool afterSkillUsableLoop() const;
+
+	bool quickModeNow() const { return !(m_timeSpeed == DEFAULT_TIME_SPEED); }
 
 private:
 

--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -22,11 +22,15 @@ GameDrawer::GameDrawer(const Game* game) {
 	m_worldDrawer = new WorldDrawer(nullptr);
 
 	m_skillHandle = CreateFontToHandle(nullptr, (int)(SKILL_SIZE * m_exX), 10);
+	m_quickModeFontHandle = CreateFontToHandle(nullptr, (int)(QUICK_SIZE * m_exX), 5);
 
 	m_skillInfoHandle = LoadGraph("picture/battleMaterial/skillInfo.png");
 	m_skillInfoBackHandle = LoadGraph("picture/battleMaterial/skillInfoBack.png");
 
 	m_gameoverHandle = LoadGraph("picture/system/gameover.png");
+
+	m_quickModeHandle = LoadGraph("picture/battleMaterial/quickMode.png");
+	m_quickModeCnt = 0;
 
 	m_noticeSaveDataHandle = LoadGraph("picture/system/noticeSaveDone.png");
 	m_noticeEx = 0.7;
@@ -40,9 +44,11 @@ GameDrawer::GameDrawer(const Game* game) {
 GameDrawer::~GameDrawer() {
 	delete m_worldDrawer;
 	DeleteFontToHandle(m_skillHandle);
+	DeleteFontToHandle(m_quickModeFontHandle);
 	DeleteGraph(m_skillInfoHandle);
 	DeleteGraph(m_skillInfoBackHandle);
 	DeleteGraph(m_gameoverHandle);
+	DeleteGraph(m_quickModeHandle);
 	DeleteGraph(m_noticeSaveDataHandle);
 }
 
@@ -98,6 +104,16 @@ void GameDrawer::draw() {
 		DrawBox(leftX, (int)(50 * m_exY), leftX + wide, (int)(80 * m_exY), BLACK, TRUE);
 		int p = leftX + (time * wide / lifespan);
 		DrawBox(p - barWide, (int)(20 * m_exY), p + barWide, (int)(110 * m_exY), WHITE, TRUE);
+	}
+
+	if (m_game->quickModeNow()) {
+		m_quickModeCnt++;
+		double angle = PI / 180 * m_quickModeCnt;
+		DrawRotaGraph(GAME_WIDE / 2, GAME_HEIGHT / 2, min(m_exX, m_exY) * 0.2, angle, m_quickModeHandle, TRUE);
+		DrawStringToHandle((int)(20 * m_exX), GAME_HEIGHT - (int)(70 * m_exY), "Ｑキーでスピードアップを解除", YELLOW, m_quickModeFontHandle);
+	}
+	else {
+		m_quickModeCnt = 0;
 	}
 
 	// セーブ完了通知

--- a/GameDrawer.h
+++ b/GameDrawer.h
@@ -25,6 +25,12 @@ private:
 	// ゲームオーバーの画像
 	int m_gameoverHandle;
 
+	// スピードアップモード
+	int m_quickModeHandle;
+	const int QUICK_SIZE = 50;
+	int m_quickModeFontHandle;
+	int m_quickModeCnt = 0;
+
 	// セーブ完了通知の画像
 	int m_noticeSaveDataHandle;
 	int m_noticeX, m_noticeY;

--- a/PausePage.cpp
+++ b/PausePage.cpp
@@ -230,11 +230,19 @@ BattleOption::BattleOption(SoundPlayer* soundPlayer):
 	m_titleButton = new Button("Back to the title", x, y, wide, height, WHITE, RED, m_font, BLACK);
 	m_titleFlag = false;
 
+	x = (int)(QUICK_X1 * m_exX);
+	y = (int)(QUICK_Y1 * m_exY);
+	wide = (int)((QUICK_X2 - QUICK_X1) * m_exX);
+	height = (int)((QUICK_Y2 - QUICK_Y1) * m_exY);
+	m_quickButton = new Button("ŠÔ‚ğ‚P‚O”{‘¬‚É‚·‚é", x, y, wide, height, WHITE, RED, m_font, BLACK);
+	m_quickFlag = false;
+
 	m_tutorialDisp = new TutorialDisp(m_font, m_fontSize, m_exX, m_exY);
 	m_tutorialDisp->setPoint(GAME_WIDE / 2 - (int)(100 * m_exX), (int)(50 * m_exY), GAME_WIDE - (int)(50 * m_exX), GAME_HEIGHT - (int)(50 * m_exY));
 }
 BattleOption::~BattleOption() {
 	delete m_titleButton;
+	delete m_quickButton;
 	DeleteGraph(m_backgroundGraph);
 	DeleteFontToHandle(m_font);
 	delete m_tutorialDisp;
@@ -247,6 +255,9 @@ void BattleOption::play() {
 	if (leftClick() == 1) {
 		if (m_titleButton->overlap(m_handX, m_handY)) {
 			m_titleFlag = true;
+		}
+		if (m_quickButton->overlap(m_handX, m_handY)) {
+			m_quickFlag = true;
 		}
 	}
 
@@ -261,6 +272,8 @@ void BattleOption::draw() const {
 	GamePause::draw();
 
 	m_titleButton->draw(m_handX, m_handY);
+
+	m_quickButton->draw(m_handX, m_handY);
 
 	m_tutorialDisp->draw();
 

--- a/PausePage.h
+++ b/PausePage.h
@@ -180,15 +180,21 @@ private:
 	// 1080を基準としたGAME_HEIGHTの倍率
 	double m_exY;
 
-	// ボタンの座標
+	// タイトルへ戻るボタン
 	const int TITLE_X1 = 100;
 	const int TITLE_Y1 = 800;
 	const int TITLE_X2 = 600;
 	const int TITLE_Y2 = 1000;
-
-	// タイトルへ戻るボタン
 	Button* m_titleButton;
 	bool m_titleFlag;
+
+	// 時間を高速で進める機能
+	const int QUICK_X1 = 70;
+	const int QUICK_Y1 = 150;
+	const int QUICK_X2 = 600;
+	const int QUICK_Y2 = 250;
+	Button* m_quickButton;
+	bool m_quickFlag;
 
 	// 操作説明
 	TutorialDisp* m_tutorialDisp;
@@ -202,7 +208,11 @@ public:
 	void draw() const;
 
 	// ゲッタ
-	bool getTitleFlag() { return m_titleFlag; }
+	inline bool getTitleFlag() { return m_titleFlag; }
+	inline bool getQuickFlag() { return m_quickFlag; }
+
+	// セッタ
+	inline bool setQuickFlag(bool quickFlag) { m_quickFlag = quickFlag; }
 };
 
 

--- a/Story.cpp
+++ b/Story.cpp
@@ -137,7 +137,7 @@ void Story::loadVersionCsvData(const char* fileName, World* world, SoundPlayer* 
 	}
 }
 
-bool Story::play(int worldLifespan, int maxVersion) {
+bool Story::play(int worldLifespan, int maxVersion, int timeSpeed) {
 	m_initDark = false;
 	if (m_nowEvent == nullptr) {
 		if (m_timer->getTime() == worldLifespan) {
@@ -146,7 +146,7 @@ bool Story::play(int worldLifespan, int maxVersion) {
 			m_worldEndFlag = true;
 			m_loop++;
 		}
-		m_timer->advanceTime();
+		m_timer->advanceTime(timeSpeed);
 		m_world_p->battle();
 		checkFire();
 		if (m_timer->getTime() % (worldLifespan / maxVersion) == 0) {

--- a/Story.h
+++ b/Story.h
@@ -68,7 +68,7 @@ public:
 
 	void debug(int x, int y, int color);
 
-	bool play(int worldLifespan, int maxVersion);
+	bool play(int worldLifespan, int maxVersion, int timeSpeed);
 
 	// イベントの発火確認
 	void checkFire();

--- a/Timer.h
+++ b/Timer.h
@@ -16,7 +16,7 @@ public:
 
 	inline void setTime(int time) { m_time = time; }
 
-	inline void advanceTime() { m_time++; }
+	inline void advanceTime(int speed) { m_time += speed; }
 
 	inline void resetTime() { m_time = START_TIME; }
 


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
一時停止画面から時間のスピードアップモードをＯＮにできる。

ＯＮにすると10倍速で時間が進む。

仕様
- Qキーを押すと解除される。
- スキル発動すると解除される。
- イベントが始まると解除される。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [ ] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
