### PR TITLE
スピードアップモード時に世界がアップデート・ループしないバグ修正

### DIFF
--- a/Story.h
+++ b/Story.h
@@ -102,6 +102,11 @@ public:
 
 	// 前のセーブポイントへ戻ったことを教えてもらう
 	void doneBackPrevSave();
+
+private:
+	int calcVersion(int time, int worldLifespan, int maxVersion);
+	int calcDate(int time, int worldLifespan);
+
 };
 
 

--- a/World.cpp
+++ b/World.cpp
@@ -213,7 +213,7 @@ World::World(int fromAreaNum, int toAreaNum, SoundPlayer* soundPlayer) :
 
 	m_camera->setEx(m_cameraMaxEx);
 
-	m_characterDeadGraph = new GraphHandles("picture/effect/dead", 5, 1.0, 0, true);
+	m_characterDeadGraph = new GraphHandles("picture/effect/dead", 6, 1.0, 0, true);
 	m_characterDamageGraph = new GraphHandles("picture/effect/damage", 1, 0.2, 0, true);
 	m_bombGraph = new GraphHandles("picture/effect/bomb", 9, 1.0, 0, true);
 	m_characterDeadSound = LoadSoundMem("sound/battle/dead.wav");
@@ -1281,14 +1281,6 @@ void World::atariCharacterAndObject(CharacterController* controller, vector<Obje
 					m_camera->setGPoint(character->getCenterX(), character->getCenterY());
 				}
 			}
-		}
-		// deleteFlag‚ªtrue‚È‚çíœ‚·‚é
-		if (objects[i]->getDeleteFlag()) {
-			delete objects[i];
-			// ––”ö‚ğíœ‚·‚é•û‚ª‘¬‚¢
-			objects[i] = objects.back();
-			objects.pop_back();
-			i--;
 		}
 	}
 }


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
スピードアップモード時はtimeが+10ずつされていく。

世界のアップデート条件は「time==特定の値」なので、スピードアップモード時にこの条件をすり抜ける。

条件を修正する。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
