### PR TITLE
経過時間の表示を画像に修正

### DIFF
--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -27,6 +27,11 @@ GameDrawer::GameDrawer(const Game* game) {
 	m_skillInfoHandle = LoadGraph("picture/battleMaterial/skillInfo.png");
 	m_skillInfoBackHandle = LoadGraph("picture/battleMaterial/skillInfoBack.png");
 
+	m_timeBarNoonHandle = LoadGraph("picture/battleMaterial/timeBarNoon.png");
+	m_timeBarEveningHandle = LoadGraph("picture/battleMaterial/timeBarEvening.png");
+	m_timeBarNightHandle = LoadGraph("picture/battleMaterial/timeBarNight.png");
+	m_needleHandle = LoadGraph("picture/battleMaterial/needle.png");
+
 	m_gameoverHandle = LoadGraph("picture/system/gameover.png");
 
 	m_quickModeHandle = LoadGraph("picture/battleMaterial/quickMode.png");
@@ -47,6 +52,10 @@ GameDrawer::~GameDrawer() {
 	DeleteFontToHandle(m_quickModeFontHandle);
 	DeleteGraph(m_skillInfoHandle);
 	DeleteGraph(m_skillInfoBackHandle);
+	DeleteGraph(m_timeBarNoonHandle);
+	DeleteGraph(m_timeBarEveningHandle);
+	DeleteGraph(m_timeBarNightHandle);
+	DeleteGraph(m_needleHandle);
 	DeleteGraph(m_gameoverHandle);
 	DeleteGraph(m_quickModeHandle);
 	DeleteGraph(m_noticeSaveDataHandle);
@@ -96,14 +105,21 @@ void GameDrawer::draw() {
 	}
 	// Œo‰ßŽžŠÔ TODO: ‰æ‘œ‚É‚·‚é
 	else if (m_worldDrawer->getWorld()->getBrightValue() == 255 && !m_game->getStory()->eventNow()) {
+		int date = m_game->getStory()->getDate();
+		int barHandle = m_timeBarNoonHandle;
+		if (date == 1) { barHandle = m_timeBarEveningHandle; }
+		else if (date == 2) { barHandle = m_timeBarNightHandle; }
+		int x = (int)(1350 * m_exX);
+		int y = (int)(40 * m_exY);
+		double ex = 0.08 * min(m_exX, m_exY);
+		DrawRotaGraph(x, y, ex, 0.0, barHandle, TRUE);
+
 		int time = m_game->getStory()->getTimer()->getTime();
 		int lifespan = m_game->WORLD_LIFESPAN;
-		int wide = GAME_WIDE / 4;
-		int barWide = (int)(10 * m_exX);
-		int leftX = (int)(850 * m_exX);
-		DrawBox(leftX, (int)(50 * m_exY), leftX + wide, (int)(80 * m_exY), BLACK, TRUE);
-		int p = leftX + (time * wide / lifespan);
-		DrawBox(p - barWide, (int)(20 * m_exY), p + barWide, (int)(110 * m_exY), WHITE, TRUE);
+		int wide = (int)(390 * m_exX);
+		int height = (int)(50 * m_exY);
+		int leftX = (int)(1185 * m_exX);
+		DrawRotaGraph(leftX + (time * wide / lifespan), y + height / 2, ex, 0.0, m_needleHandle, TRUE);
 	}
 
 	if (m_game->quickModeNow()) {

--- a/GameDrawer.h
+++ b/GameDrawer.h
@@ -22,6 +22,12 @@ private:
 	int m_skillInfoHandle;
 	int m_skillInfoBackHandle;
 
+	// 時間
+	int m_timeBarNoonHandle;
+	int m_timeBarEveningHandle;
+	int m_timeBarNightHandle;
+	int m_needleHandle;
+
 	// ゲームオーバーの画像
 	int m_gameoverHandle;
 

--- a/Object.cpp
+++ b/Object.cpp
@@ -737,7 +737,6 @@ Item* BulletObject::createAttackEnergy() {
 	m_energyCnt++;
 	if (m_energyEraseTime > 0 && m_energyCnt % 15 == 0) {
 		EnergyItem* energyItem = new EnergyItem("energy", (m_x1 + m_x2) / 2, (m_y1 + m_y2) / 2, m_damage, m_energyEraseTime);
-		m_energyEraseTime = 0; // ヒットストップなどが起きてもエネルギー放出は一度だけ
 		return energyItem;
 	}
 	return nullptr;

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -243,7 +243,7 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 		// ƒn[ƒg‚Ìî•ñ
 		if (player != -1) {
 			const int x = 30;
-			const int y = 30;
+			const int y = 10;
 			const int wide = 700;
 			const int height = 70;
 			const Character* playerCharacter = actions[player]->getCharacter();


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
タイトルの通り。

スクリーンショット：
- version1, 2

<img width="2869" height="1649" alt="スクリーンショット 2025-09-07 164207" src="https://github.com/user-attachments/assets/ed8cad30-aa4b-4c08-84d8-bdb034844bb0" />

- version3, 4
<img width="2862" height="1648" alt="スクリーンショット 2025-09-07 164227" src="https://github.com/user-attachments/assets/b55cdb6c-9ada-491f-b4f4-d1187c49f6b1" />

- version5, 6
<img width="2866" height="1654" alt="スクリーンショット 2025-09-07 164257" src="https://github.com/user-attachments/assets/ec48c566-3372-46dd-93be-269d822ec3bf" />

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
