### PR TITLE
斬撃の二重ヒット防止を修正

### DIFF
--- a/CharacterController.cpp
+++ b/CharacterController.cpp
@@ -50,7 +50,6 @@ CharacterController::CharacterController(Brain* brain, CharacterAction* characte
 
 	m_duplicationFlag = false;
 
-	m_damagedObjectId = -1;
 }
 
 CharacterController::CharacterController() :
@@ -259,6 +258,18 @@ void CharacterController::stopCharacter(int cnt) {
 	m_characterAction->stopCharacter(cnt);
 }
 
+bool CharacterController::checkAndPushDamagedObjectId(int id) {
+	for (unsigned i = 0; i < m_damagedObjectIds.size(); i++) {
+		if (m_damagedObjectIds[i] == id) {
+			return true;
+		}
+	}
+	m_damagedObjectIds.push_back(id);
+	// 増加し続けるのを防ぐため古いIDは不要とみなし掃除する
+	if (m_damagedObjectIds.size() > 10) { m_damagedObjectIds.erase(m_damagedObjectIds.begin(), m_damagedObjectIds.begin() + 4); }
+	return false;
+}
+
 
 /*
 * キャラコントロール マウスを使う可能性もあるのでCameraが必要
@@ -282,7 +293,7 @@ CharacterController* NormalController::createCopy(std::vector<Character*> charac
 	res->setSlashRecorder(m_slashRecorder);
 	res->setBulletRecorder(m_bulletRecorder);
 	res->setDamageRecorder(m_damageRecorder);
-	res->setDamagedObjectId(m_damagedObjectId);
+	res->setDamagedObjectIds(m_damagedObjectIds);
 	return res;
 }
 

--- a/CharacterController.h
+++ b/CharacterController.h
@@ -40,7 +40,7 @@ protected:
 	ControllerRecorder* m_damageRecorder;
 
 	// 操作対象に攻撃を与えたObjectのID(2重で攻撃を与えない用)
-	int m_damagedObjectId;
+	std::vector<int> m_damagedObjectIds;
 
 public:
 	static const char* CONTROLLER_NAME;
@@ -65,7 +65,6 @@ public:
 	inline const ControllerRecorder* getSlashRecorder() const { return m_slashRecorder; }
 	inline const ControllerRecorder* getBulletRecorder() const { return m_bulletRecorder; }
 	inline const ControllerRecorder* getDamageRecorder() const { return m_damageRecorder; }
-	inline const int getDamagedObjectId() const { return m_damagedObjectId; }
 
 	// セッタ
 	void setAction(CharacterAction* action);
@@ -78,7 +77,7 @@ public:
 	void setDamageRecorder(ControllerRecorder* recorder);
 	void setTarget(Character* character);
 	void setDuplicationFlag(bool flag) { m_duplicationFlag = flag; }
-	void setDamagedObjectId(int damagedObjectId) { m_damagedObjectId = damagedObjectId; }
+	inline void setDamagedObjectIds(std::vector<int>& list) { for (unsigned int i = 0; i < list.size(); i++) { m_damagedObjectIds.push_back(list[i]); } }
 
 	// レコーダを初期化
 	void initRecorder();
@@ -149,6 +148,9 @@ public:
 
 	// キャラをストップ
 	void stopCharacter(int cnt);
+
+	// 攻撃を受けたことがあるIDかチェックし、ないならpushしてfalseを返す
+	bool checkAndPushDamagedObjectId(int id);
 };
 
 

--- a/Debug.cpp
+++ b/Debug.cpp
@@ -72,7 +72,7 @@ void Story::debug(int x, int y, int color) {
 // CharacterControllerクラスのデバッグ
 void CharacterController::debugController(int x, int y, int color) const {
 	DrawFormatString(x, y, color, "**CharacterController**");
-	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "slashOrder=%d, slashCnt=%d, bulletOrder=%d, bulletCnt=%d", m_brain->slashOrder(), m_characterAction->getSlashCnt(), m_brain->bulletOrder(), m_characterAction->getBulletCnt());
+	DrawFormatString(x, y + DRAW_FORMAT_STRING_SIZE, color, "slashOrder=%d, slashCnt=%d, bulletOrder=%d, bulletCnt=%d, damagedObjectIds=%d", m_brain->slashOrder(), m_characterAction->getSlashCnt(), m_brain->bulletOrder(), m_characterAction->getBulletCnt(), m_damagedObjectIds.size());
 	m_brain->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 2, color);
 	m_characterAction->debug(x + DRAW_FORMAT_STRING_SIZE, y + DRAW_FORMAT_STRING_SIZE * 4, color);
 }


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
#247 が不十分だったので修正。

直近１回の受けた攻撃IDだけではだめだった。

攻撃IDをvectorで複数保持するように修正。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [ ] スキル発動時にエラーがないか確認
- [x] デバッグモードで確認

# 懸念点
記入欄
