### PR TITLE
レトロ風のフィルタ対象を変更

### DIFF
--- a/GameDrawer.cpp
+++ b/GameDrawer.cpp
@@ -132,6 +132,8 @@ void GameDrawer::draw(int screen) {
 		DrawRotaGraph(leftX + (time * wide / lifespan), y + height / 2, ex, 0.0, m_needleHandle, TRUE);
 	}
 
+	filterRetroDisp(screen);
+
 	if (m_game->quickModeNow()) {
 		m_quickModeCnt++;
 		double angle = PI / 180 * m_quickModeCnt;
@@ -168,9 +170,11 @@ void GameDrawer::draw(int screen) {
 	else{
 		SetMouseDispFlag(MOUSE_DISP);//マウス表示
 	}
+}
 
 
-	// ここから画面の加工を行う
+// レトロゲーム風の画面加工を行う
+void GameDrawer::filterRetroDisp(int screen) {
 	int fixThin = THIN * m_exX;
 	SetDrawScreen(m_tmpScreenR);
 	SetDrawBright(255, 0, 0);

--- a/GameDrawer.h
+++ b/GameDrawer.h
@@ -56,6 +56,10 @@ public:
 	~GameDrawer();
 
 	void draw(int screen);
+
+private:
+	// ƒŒƒgƒƒQ[ƒ€•—‚Ì‰æ–Ê‰ÁH‚ğs‚¤
+	void filterRetroDisp(int screen);
 };
 
 

--- a/WorldDrawer.cpp
+++ b/WorldDrawer.cpp
@@ -278,5 +278,4 @@ void WorldDrawer::drawBattleField(const Camera* camera, int bright, bool drawSki
 		oss << "‚oF" << money;
 		DrawStringToHandle((int)(1650 * m_exX), (int)(20 * m_exY), oss.str().c_str(), BLACK, m_font);
 	}
-
 }


### PR DESCRIPTION
<!-- プルリクエストのテンプレート -->

# 概要
セーブ完了通知や一時停止画面にはレトロ風のフィルタをしない。

# やったこと
記入欄

# やらないこと
記入欄

# できるようになること(ユーザ目線)
記入欄

# できなくなること(ユーザ目線)
記入欄

# 動作確認
- [x] テストプレイで確認
- [x] スキル発動時にエラーがないか確認
- [ ] デバッグモードで確認

# 懸念点
記入欄
